### PR TITLE
fix(scripts): point to ory/lumen and download raw binaries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
     "name": "Aeneas Rekkas",
     "url": "https://github.com/aeneasr"
   },
-  "homepage": "https://github.com/aeneasr/lumen",
-  "repository": "https://github.com/aeneasr/lumen",
+  "homepage": "https://github.com/ory/lumen",
+  "repository": "https://github.com/ory/lumen",
   "license": "Apache-2.0",
   "keywords": ["semantic-search", "code-index", "mcp", "embeddings", "ollama", "rag"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Script tests
+        run: bash scripts/test_run.sh
+
       - name: Vet
         run: go vet -tags=fts5 ./...
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,11 +73,7 @@ builds:
 archives:
   - id: default
     formats:
-      - tar.gz
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
+      - binary
     name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -22,7 +22,7 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
-  set "REPO=aeneasr/lumen"
+  set "REPO=ory/lumen"
 
   if not defined LUMEN_VERSION (
     for /f "tokens=*" %%i in ('curl -sfL "https://api.github.com/repos/!REPO!/releases/latest" ^| findstr "tag_name"') do (
@@ -42,19 +42,13 @@ if not exist "%BINARY%" (
     exit /b 1
   )
 
-  set "ASSET=lumen-!VERSION:~1!-windows-!ARCH!.zip"
+  set "ASSET=lumen-!VERSION:~1!-windows-!ARCH!.exe"
   set "URL=https://github.com/!REPO!/releases/download/!VERSION!/!ASSET!"
 
   echo Downloading lumen !VERSION! for windows/!ARCH!... >&2
   if not exist "%PLUGIN_ROOT%\bin" mkdir "%PLUGIN_ROOT%\bin"
 
-  set "TMP=%TEMP%\lumen-download"
-  mkdir "!TMP!" 2>nul
-
-  curl -sfL "!URL!" -o "!TMP!\archive.zip"
-  tar -xf "!TMP!\archive.zip" -C "!TMP!"
-  move "!TMP!\lumen.exe" "%BINARY%" >nul
-  rmdir /s /q "!TMP!"
+  curl -sfL "!URL!" -o "%BINARY%"
 
   echo Installed lumen to %BINARY% >&2
 )

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -33,7 +33,7 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
   VERSION="${LUMEN_VERSION:-latest}"
-  REPO="aeneasr/lumen"
+  REPO="ory/lumen"
 
   if [ "$VERSION" = "latest" ]; then
     VERSION="$(curl -sfL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
@@ -44,17 +44,13 @@ if [ -z "$BINARY" ]; then
     exit 1
   fi
 
-  ASSET="lumen-${VERSION#v}-${OS}-${ARCH}.tar.gz"
+  ASSET="lumen-${VERSION#v}-${OS}-${ARCH}"
   URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
 
   echo "Downloading lumen ${VERSION} for ${OS}/${ARCH}..." >&2
   mkdir -p "$(dirname "$BINARY")"
-  TMP="$(mktemp -d)"
-  trap 'rm -rf "$TMP"' EXIT
 
-  curl -sfL "$URL" -o "${TMP}/archive.tar.gz"
-  tar -xzf "${TMP}/archive.tar.gz" -C "$TMP"
-  mv "${TMP}/lumen" "$BINARY"
+  curl -sfL "$URL" -o "$BINARY"
   chmod +x "$BINARY"
   echo "Installed lumen to ${BINARY}" >&2
 fi

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Tests for run.sh URL construction and OS/arch detection logic.
+# Runs entirely offline — no real HTTP calls are made.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+ok() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "        expected: $2"
+  echo "        got:      $3"
+  FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" got="$3"
+  if [ "$expected" = "$got" ]; then
+    ok "$desc"
+  else
+    fail "$desc" "$expected" "$got"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# asset_name <version_tag> <os> <arch>
+# Mirrors the logic in run.sh: strip leading 'v', build asset filename.
+# ---------------------------------------------------------------------------
+asset_name() {
+  local version="$1" os="$2" arch="$3"
+  local ver_no_v="${version#v}"
+  case "$os" in
+    windows) echo "lumen-${ver_no_v}-${os}-${arch}.zip" ;;
+    *)       echo "lumen-${ver_no_v}-${os}-${arch}.tar.gz" ;;
+  esac
+}
+
+# download_url <repo> <version_tag> <os> <arch>
+download_url() {
+  local repo="$1" version="$2" os="$3" arch="$4"
+  local asset
+  asset="$(asset_name "$version" "$os" "$arch")"
+  echo "https://github.com/${repo}/releases/download/${version}/${asset}"
+}
+
+# ---------------------------------------------------------------------------
+# arch normalisation (mirrors run.sh case statement)
+# ---------------------------------------------------------------------------
+normalise_arch() {
+  case "$1" in
+    x86_64)  echo "amd64" ;;
+    aarch64) echo "arm64" ;;
+    *)       echo "$1" ;;
+  esac
+}
+
+echo "=== asset name tests ==="
+assert_eq "macOS arm64 asset" \
+  "lumen-0.0.1-alpha.4-darwin-arm64.tar.gz" \
+  "$(asset_name "v0.0.1-alpha.4" "darwin" "arm64")"
+
+assert_eq "macOS amd64 asset" \
+  "lumen-0.0.1-alpha.4-darwin-amd64.tar.gz" \
+  "$(asset_name "v0.0.1-alpha.4" "darwin" "amd64")"
+
+assert_eq "Linux amd64 asset" \
+  "lumen-0.0.1-alpha.4-linux-amd64.tar.gz" \
+  "$(asset_name "v0.0.1-alpha.4" "linux" "amd64")"
+
+assert_eq "Linux arm64 asset" \
+  "lumen-0.0.1-alpha.4-linux-arm64.tar.gz" \
+  "$(asset_name "v0.0.1-alpha.4" "linux" "arm64")"
+
+assert_eq "Windows amd64 asset (zip)" \
+  "lumen-0.0.1-alpha.4-windows-amd64.zip" \
+  "$(asset_name "v0.0.1-alpha.4" "windows" "amd64")"
+
+echo ""
+echo "=== download URL tests ==="
+REPO="ory/lumen"
+VERSION="v0.0.1-alpha.4"
+
+assert_eq "macOS arm64 URL" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-darwin-arm64.tar.gz" \
+  "$(download_url "$REPO" "$VERSION" "darwin" "arm64")"
+
+assert_eq "Linux amd64 URL" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-linux-amd64.tar.gz" \
+  "$(download_url "$REPO" "$VERSION" "linux" "amd64")"
+
+assert_eq "Windows amd64 URL" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-windows-amd64.zip" \
+  "$(download_url "$REPO" "$VERSION" "windows" "amd64")"
+
+echo ""
+echo "=== arch normalisation tests ==="
+assert_eq "x86_64 → amd64"  "amd64" "$(normalise_arch "x86_64")"
+assert_eq "aarch64 → arm64" "arm64" "$(normalise_arch "aarch64")"
+assert_eq "arm64 passthrough" "arm64" "$(normalise_arch "arm64")"
+assert_eq "amd64 passthrough" "amd64" "$(normalise_arch "amd64")"
+
+echo ""
+echo "=== binary candidate priority tests ==="
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "$BIN_DIR"
+
+# Simulate: only downloaded binary present → should pick lumen-os-arch
+touch "${BIN_DIR}/lumen-linux-amd64"
+chmod +x "${BIN_DIR}/lumen-linux-amd64"
+
+FOUND=""
+for candidate in "${BIN_DIR}/lumen" "${BIN_DIR}/lumen-linux-amd64"; do
+  if [ -x "$candidate" ]; then FOUND="$candidate"; break; fi
+done
+assert_eq "picks lumen-linux-amd64 when lumen absent" \
+  "${BIN_DIR}/lumen-linux-amd64" "$FOUND"
+
+# Simulate: both present → local dev build wins
+touch "${BIN_DIR}/lumen"
+chmod +x "${BIN_DIR}/lumen"
+
+FOUND=""
+for candidate in "${BIN_DIR}/lumen" "${BIN_DIR}/lumen-linux-amd64"; do
+  if [ -x "$candidate" ]; then FOUND="$candidate"; break; fi
+done
+assert_eq "prefers bin/lumen (dev build) over downloaded binary" \
+  "${BIN_DIR}/lumen" "$FOUND"
+
+echo ""
+echo "=== summary ==="
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -35,8 +35,8 @@ asset_name() {
   local version="$1" os="$2" arch="$3"
   local ver_no_v="${version#v}"
   case "$os" in
-    windows) echo "lumen-${ver_no_v}-${os}-${arch}.zip" ;;
-    *)       echo "lumen-${ver_no_v}-${os}-${arch}.tar.gz" ;;
+    windows) echo "lumen-${ver_no_v}-${os}-${arch}.exe" ;;
+    *)       echo "lumen-${ver_no_v}-${os}-${arch}" ;;
   esac
 }
 
@@ -61,23 +61,23 @@ normalise_arch() {
 
 echo "=== asset name tests ==="
 assert_eq "macOS arm64 asset" \
-  "lumen-0.0.1-alpha.4-darwin-arm64.tar.gz" \
+  "lumen-0.0.1-alpha.4-darwin-arm64" \
   "$(asset_name "v0.0.1-alpha.4" "darwin" "arm64")"
 
 assert_eq "macOS amd64 asset" \
-  "lumen-0.0.1-alpha.4-darwin-amd64.tar.gz" \
+  "lumen-0.0.1-alpha.4-darwin-amd64" \
   "$(asset_name "v0.0.1-alpha.4" "darwin" "amd64")"
 
 assert_eq "Linux amd64 asset" \
-  "lumen-0.0.1-alpha.4-linux-amd64.tar.gz" \
+  "lumen-0.0.1-alpha.4-linux-amd64" \
   "$(asset_name "v0.0.1-alpha.4" "linux" "amd64")"
 
 assert_eq "Linux arm64 asset" \
-  "lumen-0.0.1-alpha.4-linux-arm64.tar.gz" \
+  "lumen-0.0.1-alpha.4-linux-arm64" \
   "$(asset_name "v0.0.1-alpha.4" "linux" "arm64")"
 
-assert_eq "Windows amd64 asset (zip)" \
-  "lumen-0.0.1-alpha.4-windows-amd64.zip" \
+assert_eq "Windows amd64 asset (.exe)" \
+  "lumen-0.0.1-alpha.4-windows-amd64.exe" \
   "$(asset_name "v0.0.1-alpha.4" "windows" "amd64")"
 
 echo ""
@@ -86,15 +86,15 @@ REPO="ory/lumen"
 VERSION="v0.0.1-alpha.4"
 
 assert_eq "macOS arm64 URL" \
-  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-darwin-arm64.tar.gz" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-darwin-arm64" \
   "$(download_url "$REPO" "$VERSION" "darwin" "arm64")"
 
 assert_eq "Linux amd64 URL" \
-  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-linux-amd64.tar.gz" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-linux-amd64" \
   "$(download_url "$REPO" "$VERSION" "linux" "amd64")"
 
 assert_eq "Windows amd64 URL" \
-  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-windows-amd64.zip" \
+  "https://github.com/ory/lumen/releases/download/v0.0.1-alpha.4/lumen-0.0.1-alpha.4-windows-amd64.exe" \
   "$(download_url "$REPO" "$VERSION" "windows" "amd64")"
 
 echo ""


### PR DESCRIPTION
## Summary

- Update repo references from `aeneasr/lumen` to `ory/lumen` in run scripts and `plugin.json`
- Switch goreleaser to `binary` format — uploads raw binaries instead of `.tar.gz`/`.zip` archives
- Simplify `run.sh` and `run.bat` to `curl` the binary directly, removing the `tar` extraction step and temp dir handling

## Test plan

- [ ] `bash scripts/test_run.sh` passes
- [ ] Smoke test: delete `bin/lumen*`, run `scripts/run.sh --version` — downloads from `ory/lumen` and executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)