### PR TITLE
fix: reuse parent index for subdirectory searches

### DIFF
--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -116,15 +116,37 @@ type indexerCache struct {
 	cfg      config.Config
 }
 
-// getOrCreate returns an existing Indexer for the given project path, or
-// creates a new one backed by a SQLite database in the XDG data directory.
-func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, error) {
+// findEffectiveRoot walks up the directory tree from path's parent to find an
+// existing parent index (either in cache or on disk). Returns path unchanged
+// if no parent index is found. Must be called under ic.mu write lock.
+func (ic *indexerCache) findEffectiveRoot(path string) string {
+	candidate := filepath.Dir(path)
+	for {
+		if _, ok := ic.cache[candidate]; ok {
+			return candidate
+		}
+		if _, err := os.Stat(config.DBPathForProject(candidate, ic.model)); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			break
+		}
+		candidate = parent
+	}
+	return path
+}
+
+// getOrCreate returns an existing Indexer for the given project path (or a
+// parent index if one exists), along with the effective root directory used by
+// the indexer. Creates a new indexer if none exists.
+func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, string, error) {
 	// Fast path: read lock for already-cached indexers.
 	ic.mu.RLock()
 	if ic.cache != nil {
 		if idx, ok := ic.cache[projectPath]; ok {
 			ic.mu.RUnlock()
-			return idx, nil
+			return idx, projectPath, nil
 		}
 	}
 	ic.mu.RUnlock()
@@ -138,21 +160,35 @@ func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, error) 
 	}
 	// Double-check: another goroutine may have created it while we waited.
 	if idx, ok := ic.cache[projectPath]; ok {
-		return idx, nil
+		return idx, projectPath, nil
 	}
 
-	dbPath := config.DBPathForProject(projectPath, ic.model)
+	// Walk up to find an existing parent index.
+	effectiveRoot := ic.findEffectiveRoot(projectPath)
+
+	// If a parent index is already cached, alias and return.
+	if effectiveRoot != projectPath {
+		if idx, ok := ic.cache[effectiveRoot]; ok {
+			ic.cache[projectPath] = idx
+			return idx, effectiveRoot, nil
+		}
+	}
+
+	dbPath := config.DBPathForProject(effectiveRoot, ic.model)
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create db directory: %w", err)
+		return nil, "", fmt.Errorf("create db directory: %w", err)
 	}
 
 	idx, err := index.NewIndexer(dbPath, ic.embedder, ic.cfg.MaxChunkTokens)
 	if err != nil {
-		return nil, fmt.Errorf("create indexer: %w", err)
+		return nil, "", fmt.Errorf("create indexer: %w", err)
 	}
 
-	ic.cache[projectPath] = idx
-	return idx, nil
+	ic.cache[effectiveRoot] = idx
+	if effectiveRoot != projectPath {
+		ic.cache[projectPath] = idx
+	}
+	return idx, effectiveRoot, nil
 }
 
 // handleSemanticSearch is the tool handler for the semantic_search tool.
@@ -163,14 +199,14 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 		return nil, nil, err
 	}
 
-	idx, err := ic.getOrCreate(input.Path)
+	idx, effectiveRoot, err := ic.getOrCreate(input.Path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get indexer: %w", err)
 	}
 
 	progress := buildProgressFunc(ctx, req)
 
-	out, err := ic.ensureIndexed(ctx, idx, input, progress)
+	out, err := ic.ensureIndexed(ctx, idx, input, effectiveRoot, progress)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,7 +218,15 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 
 	maxDistance := computeMaxDistance(input.MinScore)
 
-	results, err := idx.Search(ctx, input.Path, queryVec, input.Limit, maxDistance)
+	// When searching a subdirectory, filter results to that prefix only.
+	var pathPrefix string
+	if input.Path != effectiveRoot {
+		if rel, relErr := filepath.Rel(effectiveRoot, input.Path); relErr == nil && rel != "." {
+			pathPrefix = rel
+		}
+	}
+
+	results, err := idx.Search(ctx, effectiveRoot, queryVec, input.Limit, maxDistance, pathPrefix)
 	if err != nil {
 		return nil, nil, fmt.Errorf("search: %w", err)
 	}
@@ -190,7 +234,7 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 	out.Results = make([]SearchResultItem, len(results))
 	var snippets []string
 	if !input.Summary {
-		snippets = extractSnippets(input.Path, results)
+		snippets = extractSnippets(effectiveRoot, results)
 	}
 	for i, r := range results {
 		var content string
@@ -245,10 +289,10 @@ func buildProgressFunc(ctx context.Context, req *mcp.CallToolRequest) index.Prog
 	}
 }
 
-func (ic *indexerCache) ensureIndexed(ctx context.Context, idx *index.Indexer, input SemanticSearchInput, progress index.ProgressFunc) (SemanticSearchOutput, error) {
+func (ic *indexerCache) ensureIndexed(ctx context.Context, idx *index.Indexer, input SemanticSearchInput, projectDir string, progress index.ProgressFunc) (SemanticSearchOutput, error) {
 	out := SemanticSearchOutput{}
 	if input.ForceReindex {
-		stats, err := idx.Index(ctx, input.Path, true, progress)
+		stats, err := idx.Index(ctx, projectDir, true, progress)
 		if err != nil {
 			return out, fmt.Errorf("force reindex: %w", err)
 		}
@@ -257,7 +301,7 @@ func (ic *indexerCache) ensureIndexed(ctx context.Context, idx *index.Indexer, i
 		return out, nil
 	}
 
-	reindexed, stats, err := idx.EnsureFresh(ctx, input.Path, progress)
+	reindexed, stats, err := idx.EnsureFresh(ctx, projectDir, progress)
 	if err != nil {
 		return out, fmt.Errorf("ensure fresh: %w", err)
 	}
@@ -296,12 +340,12 @@ func (ic *indexerCache) handleIndexStatus(_ context.Context, _ *mcp.CallToolRequ
 		return nil, nil, fmt.Errorf("path is required")
 	}
 
-	idx, err := ic.getOrCreate(input.Path)
+	idx, effectiveRoot, err := ic.getOrCreate(input.Path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get indexer: %w", err)
 	}
 
-	info, err := idx.Status(input.Path)
+	info, err := idx.Status(effectiveRoot)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get status: %w", err)
 	}
@@ -315,7 +359,7 @@ func (ic *indexerCache) handleIndexStatus(_ context.Context, _ *mcp.CallToolRequ
 		EmbeddingModel: info.EmbeddingModel,
 	}
 
-	fresh, err := idx.IsFresh(input.Path)
+	fresh, err := idx.IsFresh(effectiveRoot)
 	if err != nil {
 		return nil, nil, fmt.Errorf("check freshness: %w", err)
 	}

--- a/cmd/stdio_test.go
+++ b/cmd/stdio_test.go
@@ -16,10 +16,13 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/aeneasr/lumen/internal/config"
+	"github.com/aeneasr/lumen/internal/index"
 )
 
 // stubEmbedder satisfies embedder.Embedder for tests.
@@ -47,10 +50,110 @@ func TestIndexerCache_ConcurrentReads(_ *testing.T) {
 		wg.Go(func() {
 			// Path doesn't exist on disk — getOrCreate will error, that's fine.
 			// We're testing there's no data race on the cache map/mutex.
-			_, _ = ic.getOrCreate("/nonexistent/path/for/race/test")
+			_, _, _ = ic.getOrCreate("/nonexistent/path/for/race/test")
 		})
 	}
 	wg.Wait()
+}
+
+func TestIndexerCache_FindEffectiveRoot(t *testing.T) {
+	const model = "test-model"
+
+	t.Run("returns path when no parent exists", func(t *testing.T) {
+		ic := &indexerCache{
+			cache: make(map[string]*index.Indexer),
+			model: model,
+		}
+		root := ic.findEffectiveRoot("/project/src/pkg")
+		if root != "/project/src/pkg" {
+			t.Fatalf("expected original path, got %s", root)
+		}
+	})
+
+	t.Run("returns cached parent", func(t *testing.T) {
+		// A nil *Indexer value still satisfies the map presence check.
+		ic := &indexerCache{
+			cache: map[string]*index.Indexer{"/project": nil},
+			model: model,
+		}
+		root := ic.findEffectiveRoot("/project/src/pkg")
+		if root != "/project" {
+			t.Fatalf("expected /project (cached parent), got %s", root)
+		}
+	})
+
+	t.Run("returns parent with existing db on disk", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Create the DB file that would exist for /project with our model.
+		parentDBPath := config.DBPathForProject("/project", model)
+		if err := os.MkdirAll(filepath.Dir(parentDBPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(parentDBPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		ic := &indexerCache{
+			cache: make(map[string]*index.Indexer),
+			model: model,
+		}
+		root := ic.findEffectiveRoot("/project/src/pkg")
+		if root != "/project" {
+			t.Fatalf("expected /project (db on disk), got %s", root)
+		}
+	})
+}
+
+func TestIndexerCache_GetOrCreate_ReusesParentIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	const model = "stub"
+	ic := &indexerCache{
+		embedder: &stubEmbedder{},
+		model:    model,
+		cfg:      config.Config{MaxChunkTokens: 512},
+	}
+
+	// First call: index the parent directory — creates an indexer and DB on disk.
+	parentDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parentIdx, parentRoot, err := ic.getOrCreate(parentDir)
+	if err != nil {
+		t.Fatalf("getOrCreate(parent): %v", err)
+	}
+	if parentRoot != parentDir {
+		t.Fatalf("expected effectiveRoot=%s, got %s", parentDir, parentRoot)
+	}
+
+	// Second call: request a subdirectory — should reuse the parent indexer.
+	subDir := filepath.Join(parentDir, "src")
+	subIdx, subRoot, err := ic.getOrCreate(subDir)
+	if err != nil {
+		t.Fatalf("getOrCreate(subdir): %v", err)
+	}
+	if subRoot != parentDir {
+		t.Fatalf("expected effectiveRoot=%s for subdir, got %s", parentDir, subRoot)
+	}
+	if subIdx != parentIdx {
+		t.Fatal("expected subdir to reuse parent indexer, got a different instance")
+	}
+
+	// Both keys should be aliased in the cache.
+	ic.mu.RLock()
+	cachedParent := ic.cache[parentDir]
+	cachedSub := ic.cache[subDir]
+	ic.mu.RUnlock()
+	if cachedParent != parentIdx {
+		t.Fatal("parent key not in cache")
+	}
+	if cachedSub != parentIdx {
+		t.Fatal("subdir key not aliased to parent indexer in cache")
+	}
 }
 
 func TestScoreIsNotDistance(t *testing.T) {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -276,8 +276,9 @@ func (idx *Indexer) IsFresh(projectDir string) (bool, error) {
 
 // Search performs a vector similarity search against the index.
 // If maxDistance > 0, results with distance >= maxDistance are excluded.
-func (idx *Indexer) Search(_ context.Context, _ string, queryVec []float32, limit int, maxDistance float64) ([]store.SearchResult, error) {
-	return idx.store.Search(queryVec, limit, maxDistance)
+// If pathPrefix != "", only chunks under that relative path are returned.
+func (idx *Indexer) Search(_ context.Context, _ string, queryVec []float32, limit int, maxDistance float64, pathPrefix string) ([]store.SearchResult, error) {
+	return idx.store.Search(queryVec, limit, maxDistance, pathPrefix)
 }
 
 // Status returns information about the current index state for a project.

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -88,7 +88,7 @@ func Goodbye(name string) {
 		t.Fatal("expected at least 1 chunk created")
 	}
 
-	results, err := idx.Search(context.Background(), projectDir, []float32{0.1, 0.1, 0.1, 0.1}, 5, 0)
+	results, err := idx.Search(context.Background(), projectDir, []float32{0.1, 0.1, 0.1, 0.1}, 5, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -381,38 +381,44 @@ func (s *Store) DeleteFileChunks(filePath string) error {
 
 // Search performs a KNN vector search and returns the closest chunks.
 // If maxDistance > 0, results with distance >= maxDistance are excluded.
-func (s *Store) Search(queryVec []float32, limit int, maxDistance float64) ([]SearchResult, error) {
+// If pathPrefix != "", only chunks whose file_path equals pathPrefix or
+// starts with pathPrefix+"/" are returned; the KNN candidate count is
+// inflated to compensate for the post-JOIN filter.
+func (s *Store) Search(queryVec []float32, limit int, maxDistance float64, pathPrefix string) ([]SearchResult, error) {
 	blob, err := sqlite_vec.SerializeFloat32(queryVec)
 	if err != nil {
 		return nil, fmt.Errorf("serialize query: %w", err)
 	}
 
-	var query string
-	var args []any
-	if maxDistance > 0 {
-		query = `
-			SELECT c.file_path, c.symbol, c.kind, c.start_line, c.end_line, v.distance
-			FROM vec_chunks v
-			JOIN chunks c ON v.id = c.id
-			WHERE v.embedding MATCH ?
-			AND v.k = ?
-			AND v.distance < ?
-			ORDER BY v.distance
-			LIMIT ?
-		`
-		args = []any{blob, limit, maxDistance, limit}
-	} else {
-		query = `
-			SELECT c.file_path, c.symbol, c.kind, c.start_line, c.end_line, v.distance
-			FROM vec_chunks v
-			JOIN chunks c ON v.id = c.id
-			WHERE v.embedding MATCH ?
-			AND v.k = ?
-			ORDER BY v.distance
-			LIMIT ?
-		`
-		args = []any{blob, limit, limit}
+	// When filtering by path prefix we fetch more KNN candidates so the
+	// post-JOIN filter still returns enough results.
+	knn := limit
+	if pathPrefix != "" {
+		knn = min(limit*3, 300)
 	}
+
+	// Build WHERE clauses dynamically.
+	whereClauses := []string{"v.embedding MATCH ?", "v.k = ?"}
+	args := []any{blob, knn}
+
+	if maxDistance > 0 {
+		whereClauses = append(whereClauses, "v.distance < ?")
+		args = append(args, maxDistance)
+	}
+	if pathPrefix != "" {
+		whereClauses = append(whereClauses, "(c.file_path = ? OR c.file_path LIKE ? || '/%')")
+		args = append(args, pathPrefix, pathPrefix)
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT c.file_path, c.symbol, c.kind, c.start_line, c.end_line, v.distance
+		FROM vec_chunks v
+		JOIN chunks c ON v.id = c.id
+		WHERE %s
+		ORDER BY v.distance
+		LIMIT ?
+	`, strings.Join(whereClauses, "\n\t\tAND "))
 
 	rows, err := s.db.Query(query, args...)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -87,7 +87,7 @@ func TestStore_UpsertAndSearchVectors(t *testing.T) {
 	}
 
 	query := []float32{0.1, 0.2, 0.3, 0.4}
-	results, err := s.Search(query, 2, 0)
+	results, err := s.Search(query, 2, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestStore_DeleteFileChunks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	results, err := s.Search([]float32{0.1, 0.2, 0.3, 0.4}, 10, 0)
+	results, err := s.Search([]float32{0.1, 0.2, 0.3, 0.4}, 10, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,11 +302,107 @@ func TestStore_DimensionMismatchRecreatesTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	results, err := s2.Search([]float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}, 10, 0)
+	results, err := s2.Search([]float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}, 10, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(results) != 1 || results[0].Symbol != "Bar" {
 		t.Fatalf("expected 1 result with symbol Bar, got %v", results)
+	}
+}
+
+func TestStore_SearchWithPathPrefix(t *testing.T) {
+	s, err := New(":memory:", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// Insert files in two different directories.
+	if err := s.UpsertFile("src/main.go", "hash1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertFile("tests/foo_test.go", "hash2"); err != nil {
+		t.Fatal(err)
+	}
+
+	chunks := []chunker.Chunk{
+		{ID: "c1", FilePath: "src/main.go", Symbol: "Main", Kind: "function", StartLine: 1, EndLine: 5},
+		{ID: "c2", FilePath: "tests/foo_test.go", Symbol: "TestFoo", Kind: "function", StartLine: 1, EndLine: 5},
+	}
+	// Use identical vectors so distance doesn't filter anything.
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+	vectors := [][]float32{vec, vec}
+
+	if err := s.InsertChunks(chunks, vectors); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without prefix: both results returned.
+	all, err := s.Search(vec, 10, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 results without prefix, got %d", len(all))
+	}
+
+	// With prefix "src": only src/main.go result.
+	srcResults, err := s.Search(vec, 10, 0, "src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srcResults) != 1 {
+		t.Fatalf("expected 1 result with prefix 'src', got %d", len(srcResults))
+	}
+	if srcResults[0].FilePath != "src/main.go" {
+		t.Fatalf("expected src/main.go, got %s", srcResults[0].FilePath)
+	}
+
+	// With prefix "tests": only tests/foo_test.go result.
+	testResults, err := s.Search(vec, 10, 0, "tests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(testResults) != 1 {
+		t.Fatalf("expected 1 result with prefix 'tests', got %d", len(testResults))
+	}
+	if testResults[0].FilePath != "tests/foo_test.go" {
+		t.Fatalf("expected tests/foo_test.go, got %s", testResults[0].FilePath)
+	}
+}
+
+func TestStore_SearchPathPrefixNoFalsePositives(t *testing.T) {
+	s, err := New(":memory:", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+
+	// "internal/store" and "internal/storefront" share a common prefix string —
+	// the LIKE pattern must not match the latter when filtering by the former.
+	for _, path := range []string{"internal/store/store.go", "internal/storefront/main.go"} {
+		if err := s.UpsertFile(path, "hash"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	chunks := []chunker.Chunk{
+		{ID: "c1", FilePath: "internal/store/store.go", Symbol: "New", Kind: "function", StartLine: 1, EndLine: 5},
+		{ID: "c2", FilePath: "internal/storefront/main.go", Symbol: "Handler", Kind: "function", StartLine: 1, EndLine: 5},
+	}
+	vec := []float32{0.1, 0.2, 0.3, 0.4}
+	if err := s.InsertChunks(chunks, [][]float32{vec, vec}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := s.Search(vec, 10, 0, "internal/store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %v", len(results), results)
+	}
+	if results[0].FilePath != "internal/store/store.go" {
+		t.Fatalf("expected internal/store/store.go, got %s", results[0].FilePath)
 	}
 }


### PR DESCRIPTION
When semantic_search is called with a path that is a subdirectory of an already-indexed parent, lumen now walks up the directory tree to find the parent index (via cache hit or DB file on disk), reuses it, and filters search results to the requested subdirectory prefix via a SQL LIKE condition.

- store.Search: add pathPrefix param; inflates KNN k to min(limit*3,300) when filtering and builds WHERE clauses dynamically
- index.Indexer.Search: thread pathPrefix through to store
- cmd: add findEffectiveRoot walk-up; getOrCreate returns effectiveRoot and aliases both paths in cache; ensureIndexed/handleSemanticSearch/ handleIndexStatus use effectiveRoot for all indexer operations
- Tests: TestStore_SearchWithPathPrefix, TestStore_SearchPathPrefixNoFalsePositives, TestIndexerCache_FindEffectiveRoot, TestIndexerCache_GetOrCreate_ReusesParentIndex