### PR TITLE
chore(release): sync marketplace versions via release-please extra-files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Ory Lumen — local semantic code search for AI coding agents",
-    "version": "0.2.0"
+    "version": "0.0.3"
   },
   "plugins": [
     {
       "name": "lumen",
       "source": "./",
       "description": "Precise local semantic code search via MCP. Indexes your codebase with Go AST parsing, embeds with Ollama or LM Studio, and exposes vector search to Claude through an MCP server — no cloud, no npm.",
-      "version": "0.2.0",
+      "version": "0.0.3",
       "author": {
         "name": "Aeneas Rekkas",
         "url": "https://github.com/ory"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,19 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "json-path": "$.metadata.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "json-path": "$.plugins[0].version"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Configures release-please `extra-files` to update both `$.metadata.version` and `$.plugins[0].version` in `.claude-plugin/marketplace.json` as part of each release PR
- Syncs `marketplace.json` versions from `0.2.0` → `0.0.3` to match the current `.release-please-manifest.json` baseline

## How it works

Going forward, when release-please opens a release PR it will bump `version.txt`, `CHANGELOG.md`, **and** both version fields in `marketplace.json` in the same commit. The tag is cut after that PR merges, so goreleaser always sees consistent versions — no post-release commits or jq hooks needed.

## Test plan

- [ ] Verify next release-please PR includes version bumps in `.claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)