### PR TITLE
fix(scripts): pin binary download to manifest version

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -24,35 +24,23 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 if not exist "%BINARY%" (
   set "REPO=ory/lumen"
 
-  if not defined LUMEN_VERSION (
-    for /f "tokens=*" %%i in ('curl -sfL "https://api.github.com/repos/!REPO!/releases/latest" ^| findstr "tag_name"') do (
-      for /f "tokens=2 delims=:" %%j in ("%%i") do (
-        set "VERSION=%%~j"
-        set "VERSION=!VERSION: =!"
-        set "VERSION=!VERSION:,=!"
-        set "VERSION=!VERSION:"=!"
-      )
-    )
-  ) else (
-    set "VERSION=%LUMEN_VERSION%"
+  :: Always use the version pinned in the manifest — keeps plugin and binary in sync
+  set "MANIFEST=%PLUGIN_ROOT%\.release-please-manifest.json"
+  if not exist "!MANIFEST!" (
+    echo Error: .release-please-manifest.json not found in %PLUGIN_ROOT% >&2
+    exit /b 1
   )
-
-  if "!VERSION!"=="" (
-    set "MANIFEST=%PLUGIN_ROOT%\.release-please-manifest.json"
-    if exist "!MANIFEST!" (
-      for /f "tokens=*" %%i in ('findstr /r "\"[.]\"" "!MANIFEST!"') do (
-        for /f "tokens=2 delims=:" %%j in ("%%i") do (
-          set "VERSION=v%%~j"
-          set "VERSION=!VERSION: =!"
-          set "VERSION=!VERSION:,=!"
-          set "VERSION=!VERSION:"=!"
-        )
-      )
+  for /f "tokens=*" %%i in ('findstr /r "\"[.]\"" "!MANIFEST!"') do (
+    for /f "tokens=2 delims=:" %%j in ("%%i") do (
+      set "VERSION=v%%~j"
+      set "VERSION=!VERSION: =!"
+      set "VERSION=!VERSION:,=!"
+      set "VERSION=!VERSION:"=!"
     )
   )
 
   if "!VERSION!"=="" (
-    echo Error: could not determine latest lumen version >&2
+    echo Error: could not read version from !MANIFEST! >&2
     exit /b 1
   )
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -31,23 +31,17 @@ done
 # Download on first run if no binary found
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
-  VERSION="${LUMEN_VERSION:-latest}"
   REPO="ory/lumen"
 
-  if [ "$VERSION" = "latest" ]; then
-    # Try manifest first (always available, no rate limits)
-    MANIFEST="${PLUGIN_ROOT}/.release-please-manifest.json"
-    if [ -f "$MANIFEST" ]; then
-      VERSION="v$(grep '"[.]"' "$MANIFEST" | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
-    fi
-    # Fall back to GitHub API if manifest didn't give us a version
-    if [ -z "$VERSION" ]; then
-      VERSION="$(curl -sfL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/' || true)"
-    fi
+  # Always use the version pinned in the manifest — keeps plugin and binary in sync
+  MANIFEST="${PLUGIN_ROOT}/.release-please-manifest.json"
+  if [ ! -f "$MANIFEST" ]; then
+    echo "Error: .release-please-manifest.json not found in ${PLUGIN_ROOT}" >&2
+    exit 1
   fi
-
-  if [ -z "$VERSION" ]; then
-    echo "Error: could not determine latest lumen version" >&2
+  VERSION="v$(grep '"[.]"' "$MANIFEST" | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+  if [ -z "$VERSION" ] || [ "$VERSION" = "v" ]; then
+    echo "Error: could not read version from ${MANIFEST}" >&2
     exit 1
   fi
 

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -144,10 +144,7 @@ printf '{\n  ".": "1.2.3"\n}\n' > "$MANIFEST"
 
 resolved_version_from_manifest() {
   local manifest="$1"
-  local ver=""
-  if [ -f "$manifest" ]; then
-    ver="v$(grep '"[.]"' "$manifest" | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
-  fi
+  local ver="v$(grep '"[.]"' "$manifest" | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
   echo "$ver"
 }
 
@@ -155,9 +152,9 @@ assert_eq "manifest version resolution" \
   "v1.2.3" \
   "$(resolved_version_from_manifest "$MANIFEST")"
 
-assert_eq "missing manifest returns empty" \
-  "" \
-  "$(resolved_version_from_manifest "/nonexistent/.release-please-manifest.json")"
+assert_eq "pre-release version preserved" \
+  "v0.0.1-alpha.4" \
+  "$(printf '{\n  ".": "0.0.1-alpha.4"\n}\n' | grep '"[.]"' | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/v\1/')"
 
 echo ""
 echo "=== summary ==="


### PR DESCRIPTION
## Summary

- Remove GitHub API `releases/latest` call and `LUMEN_VERSION` env override from `run.sh` and `run.bat`
- Binary version is now always read from `.release-please-manifest.json`, making plugin version X deterministically download binary version X
- Hard error if manifest is missing or unparseable, rather than silently falling back to an unknown version

## Test plan

- [ ] `bash scripts/test_run.sh` passes (all 16 tests green)
- [ ] Install plugin fresh on macOS/Linux — verify it downloads the manifest-pinned version without hitting GitHub API
- [ ] Install plugin fresh on Windows — same check for `run.bat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)