### PR TITLE
fix(scripts): correct jsonpath field name in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,12 +10,12 @@
         {
           "type": "json",
           "path": ".claude-plugin/marketplace.json",
-          "json-path": "$.metadata.version"
+          "jsonpath": "$.metadata.version"
         },
         {
           "type": "json",
           "path": ".claude-plugin/marketplace.json",
-          "json-path": "$.plugins[0].version"
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Rename `json-path` → `jsonpath` in both `extra-files` entries of `release-please-config.json`
- Fixes `release-please failed: You must supply a "path" property when providing an object argument to JSONPath.evaluate()` error in the Release Please GitHub Actions workflow

## Test plan

- [ ] Push to `main` and verify the Release Please workflow completes without the JSONPath error
- [ ] Confirm the next release-please PR includes `marketplace.json` version bumps for both `$.metadata.version` and `$.plugins[0].version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)