### PR TITLE
feat: add cwd parameter for reliable index root detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ format:
 
 plugin-dev: build-local
 	@echo "Run: claude --plugin-dir ."
+
+vhs:
+	export CLAUDE_PLUGIN_ROOT=$(pwd) && cd testdata/fixtures/go && vhs ../../../docs/demo/demo.tape

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -83,6 +83,7 @@ func generateHookContent(mcpName string) string {
 	toolRef := "`mcp__" + mcpName + "__semantic_search`"
 	return "<EXTREMELY_IMPORTANT>\n" +
 		"# Lumen Semantic Search\n\n" +
+		"ALWAYS pass your current working directory as the `cwd` parameter when calling " + toolRef + ".\n\n" +
 		"ALWAYS use " + toolRef + " as the FIRST tool for code discovery.\n\n" +
 		"Before using Grep, Glob, Find, or Read for any search, stop and ask:\n" +
 		"\"Do I already know the exact literal string I'm searching for?\"\n" +

--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ory/lumen/internal/config"
 	"github.com/ory/lumen/internal/embedder"
 	"github.com/ory/lumen/internal/index"
+	"github.com/ory/lumen/internal/merkle"
 	"github.com/ory/lumen/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +51,8 @@ var stdioCmd = &cobra.Command{
 // SemanticSearchInput defines the parameters for the semantic_search tool.
 type SemanticSearchInput struct {
 	Query        string   `json:"query" jsonschema:"Natural language search query"`
-	Path         string   `json:"path" jsonschema:"Absolute path to the project root"`
+	Path         string   `json:"path" jsonschema:"Absolute path to search in. Defaults to cwd. When a subdirectory of cwd, results are filtered to that subtree."`
+	Cwd          string   `json:"cwd,omitempty" jsonschema:"The current working directory / project root. Used as index root when provided."`
 	Limit        int      `json:"limit,omitempty" jsonschema:"Max results to return, default 20"`
 	MinScore     *float64 `json:"min_score,omitempty" jsonschema:"Minimum score threshold (-1 to 1). Results below this score are excluded. Default 0.5. Use -1 to return all results."`
 	ForceReindex bool     `json:"force_reindex,omitempty" jsonschema:"Force full re-index before searching"`
@@ -78,7 +80,8 @@ type SemanticSearchOutput struct {
 
 // IndexStatusInput defines the parameters for the index_status tool.
 type IndexStatusInput struct {
-	Path string `json:"path" jsonschema:"Absolute path to the project root"`
+	Path string `json:"path" jsonschema:"Absolute path to the project root. Defaults to cwd."`
+	Cwd  string `json:"cwd,omitempty" jsonschema:"The current working directory / project root. Used as index root when provided."`
 }
 
 // IndexStatusOutput is the structured output of the index_status tool.
@@ -106,11 +109,20 @@ type HealthCheckOutput struct {
 
 // --- indexerCache ---
 
+// cacheEntry holds an indexer together with the effective root directory it
+// was created for. When a subdirectory is aliased to a parent index, both
+// the parent path and the subdirectory path map to the same cacheEntry, but
+// effectiveRoot always points at the parent.
+type cacheEntry struct {
+	idx           *index.Indexer
+	effectiveRoot string
+}
+
 // indexerCache manages one *index.Indexer per project path, creating them
 // lazily with a shared embedder.
 type indexerCache struct {
 	mu       sync.RWMutex
-	cache    map[string]*index.Indexer
+	cache    map[string]cacheEntry
 	embedder embedder.Embedder
 	model    string
 	cfg      config.Config
@@ -119,14 +131,20 @@ type indexerCache struct {
 // findEffectiveRoot walks up the directory tree from path's parent to find an
 // existing parent index (either in cache or on disk). Returns path unchanged
 // if no parent index is found. Must be called under ic.mu write lock.
+//
+// A candidate parent is skipped when the relative path from that parent to
+// path passes through a directory in merkle.SkipDirs (e.g. "testdata"). Such
+// a parent index would never contain path's files, so it is not useful.
 func (ic *indexerCache) findEffectiveRoot(path string) string {
 	candidate := filepath.Dir(path)
 	for {
-		if _, ok := ic.cache[candidate]; ok {
-			return candidate
-		}
-		if _, err := os.Stat(config.DBPathForProject(candidate, ic.model)); err == nil {
-			return candidate
+		if !pathCrossesSkipDir(candidate, path) {
+			if _, ok := ic.cache[candidate]; ok {
+				return candidate
+			}
+			if _, err := os.Stat(config.DBPathForProject(candidate, ic.model)); err == nil {
+				return candidate
+			}
 		}
 		parent := filepath.Dir(candidate)
 		if parent == candidate {
@@ -137,16 +155,36 @@ func (ic *indexerCache) findEffectiveRoot(path string) string {
 	return path
 }
 
+// pathCrossesSkipDir reports whether the relative path from root to sub passes
+// through any directory whose base name is in merkle.SkipDirs.
+func pathCrossesSkipDir(root, sub string) bool {
+	rel, err := filepath.Rel(root, sub)
+	if err != nil {
+		return false
+	}
+	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
+		if merkle.SkipDirs[part] {
+			return true
+		}
+	}
+	return false
+}
+
 // getOrCreate returns an existing Indexer for the given project path (or a
 // parent index if one exists), along with the effective root directory used by
 // the indexer. Creates a new indexer if none exists.
-func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, string, error) {
+//
+// When preferredRoot is non-empty it is used as the effective root directly,
+// bypassing the findEffectiveRoot walk. This lets callers pass the known
+// project root (e.g. cwd from Claude) so that sub-directory paths index the
+// whole project.
+func (ic *indexerCache) getOrCreate(projectPath string, preferredRoot string) (*index.Indexer, string, error) {
 	// Fast path: read lock for already-cached indexers.
 	ic.mu.RLock()
 	if ic.cache != nil {
-		if idx, ok := ic.cache[projectPath]; ok {
+		if entry, ok := ic.cache[projectPath]; ok {
 			ic.mu.RUnlock()
-			return idx, projectPath, nil
+			return entry.idx, entry.effectiveRoot, nil
 		}
 	}
 	ic.mu.RUnlock()
@@ -156,21 +194,26 @@ func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, string,
 	defer ic.mu.Unlock()
 
 	if ic.cache == nil {
-		ic.cache = make(map[string]*index.Indexer)
+		ic.cache = make(map[string]cacheEntry)
 	}
 	// Double-check: another goroutine may have created it while we waited.
-	if idx, ok := ic.cache[projectPath]; ok {
-		return idx, projectPath, nil
+	if entry, ok := ic.cache[projectPath]; ok {
+		return entry.idx, entry.effectiveRoot, nil
 	}
 
-	// Walk up to find an existing parent index.
-	effectiveRoot := ic.findEffectiveRoot(projectPath)
+	// Determine the effective root: prefer explicit root, then walk up.
+	var effectiveRoot string
+	if preferredRoot != "" {
+		effectiveRoot = filepath.Clean(preferredRoot)
+	} else {
+		effectiveRoot = ic.findEffectiveRoot(projectPath)
+	}
 
 	// If a parent index is already cached, alias and return.
 	if effectiveRoot != projectPath {
-		if idx, ok := ic.cache[effectiveRoot]; ok {
-			ic.cache[projectPath] = idx
-			return idx, effectiveRoot, nil
+		if entry, ok := ic.cache[effectiveRoot]; ok {
+			ic.cache[projectPath] = cacheEntry{idx: entry.idx, effectiveRoot: effectiveRoot}
+			return entry.idx, effectiveRoot, nil
 		}
 	}
 
@@ -184,9 +227,9 @@ func (ic *indexerCache) getOrCreate(projectPath string) (*index.Indexer, string,
 		return nil, "", fmt.Errorf("create indexer: %w", err)
 	}
 
-	ic.cache[effectiveRoot] = idx
+	ic.cache[effectiveRoot] = cacheEntry{idx: idx, effectiveRoot: effectiveRoot}
 	if effectiveRoot != projectPath {
-		ic.cache[projectPath] = idx
+		ic.cache[projectPath] = cacheEntry{idx: idx, effectiveRoot: effectiveRoot}
 	}
 	return idx, effectiveRoot, nil
 }
@@ -199,7 +242,7 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 		return nil, nil, err
 	}
 
-	idx, effectiveRoot, err := ic.getOrCreate(input.Path)
+	idx, effectiveRoot, err := ic.getOrCreate(input.Path, input.Cwd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get indexer: %w", err)
 	}
@@ -262,9 +305,27 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 }
 
 func validateSearchInput(input *SemanticSearchInput) error {
-	if input.Path == "" {
-		return fmt.Errorf("path is required")
+	if input.Cwd != "" {
+		input.Cwd = filepath.Clean(input.Cwd)
+		if !filepath.IsAbs(input.Cwd) {
+			return fmt.Errorf("cwd must be an absolute path")
+		}
 	}
+
+	if input.Path == "" && input.Cwd != "" {
+		input.Path = input.Cwd
+	}
+	if input.Path == "" {
+		return fmt.Errorf("path is required (or provide cwd)")
+	}
+
+	if input.Cwd != "" && input.Path != input.Cwd {
+		rel, err := filepath.Rel(input.Cwd, input.Path)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return fmt.Errorf("path must be equal to or under cwd")
+		}
+	}
+
 	if input.Query == "" {
 		return fmt.Errorf("query is required")
 	}
@@ -336,11 +397,14 @@ func computeMaxDistance(minScore *float64) float64 {
 // handleIndexStatus is the tool handler for the index_status tool.
 // Uses Out=any so the SDK does not set StructuredContent.
 func (ic *indexerCache) handleIndexStatus(_ context.Context, _ *mcp.CallToolRequest, input IndexStatusInput) (*mcp.CallToolResult, any, error) {
+	if input.Path == "" && input.Cwd != "" {
+		input.Path = input.Cwd
+	}
 	if input.Path == "" {
-		return nil, nil, fmt.Errorf("path is required")
+		return nil, nil, fmt.Errorf("path is required (or provide cwd)")
 	}
 
-	idx, effectiveRoot, err := ic.getOrCreate(input.Path)
+	idx, effectiveRoot, err := ic.getOrCreate(input.Path, input.Cwd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get indexer: %w", err)
 	}

--- a/cmd/stdio_test.go
+++ b/cmd/stdio_test.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/ory/lumen/internal/config"
-	"github.com/ory/lumen/internal/index"
 )
 
 // stubEmbedder satisfies embedder.Embedder for tests.
@@ -50,7 +50,7 @@ func TestIndexerCache_ConcurrentReads(_ *testing.T) {
 		wg.Go(func() {
 			// Path doesn't exist on disk — getOrCreate will error, that's fine.
 			// We're testing there's no data race on the cache map/mutex.
-			_, _, _ = ic.getOrCreate("/nonexistent/path/for/race/test")
+			_, _, _ = ic.getOrCreate("/nonexistent/path/for/race/test", "")
 		})
 	}
 	wg.Wait()
@@ -61,7 +61,7 @@ func TestIndexerCache_FindEffectiveRoot(t *testing.T) {
 
 	t.Run("returns path when no parent exists", func(t *testing.T) {
 		ic := &indexerCache{
-			cache: make(map[string]*index.Indexer),
+			cache: make(map[string]cacheEntry),
 			model: model,
 		}
 		root := ic.findEffectiveRoot("/project/src/pkg")
@@ -71,9 +71,8 @@ func TestIndexerCache_FindEffectiveRoot(t *testing.T) {
 	})
 
 	t.Run("returns cached parent", func(t *testing.T) {
-		// A nil *Indexer value still satisfies the map presence check.
 		ic := &indexerCache{
-			cache: map[string]*index.Indexer{"/project": nil},
+			cache: map[string]cacheEntry{"/project": {idx: nil, effectiveRoot: "/project"}},
 			model: model,
 		}
 		root := ic.findEffectiveRoot("/project/src/pkg")
@@ -96,12 +95,37 @@ func TestIndexerCache_FindEffectiveRoot(t *testing.T) {
 		}
 
 		ic := &indexerCache{
-			cache: make(map[string]*index.Indexer),
+			cache: make(map[string]cacheEntry),
 			model: model,
 		}
 		root := ic.findEffectiveRoot("/project/src/pkg")
 		if root != "/project" {
 			t.Fatalf("expected /project (db on disk), got %s", root)
+		}
+	})
+
+	t.Run("ignores parent when path crosses a SkipDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Simulate a parent index at /project.
+		parentDBPath := config.DBPathForProject("/project", model)
+		if err := os.MkdirAll(filepath.Dir(parentDBPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(parentDBPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		ic := &indexerCache{
+			cache: make(map[string]cacheEntry),
+			model: model,
+		}
+		// "testdata" is in merkle.SkipDirs — the parent index would never
+		// contain these files, so findEffectiveRoot must return the path itself.
+		root := ic.findEffectiveRoot("/project/testdata/fixtures/go")
+		if root != "/project/testdata/fixtures/go" {
+			t.Fatalf("expected original path (skip dir in route), got %s", root)
 		}
 	})
 }
@@ -122,7 +146,7 @@ func TestIndexerCache_GetOrCreate_ReusesParentIndex(t *testing.T) {
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	parentIdx, parentRoot, err := ic.getOrCreate(parentDir)
+	parentIdx, parentRoot, err := ic.getOrCreate(parentDir, "")
 	if err != nil {
 		t.Fatalf("getOrCreate(parent): %v", err)
 	}
@@ -132,7 +156,7 @@ func TestIndexerCache_GetOrCreate_ReusesParentIndex(t *testing.T) {
 
 	// Second call: request a subdirectory — should reuse the parent indexer.
 	subDir := filepath.Join(parentDir, "src")
-	subIdx, subRoot, err := ic.getOrCreate(subDir)
+	subIdx, subRoot, err := ic.getOrCreate(subDir, "")
 	if err != nil {
 		t.Fatalf("getOrCreate(subdir): %v", err)
 	}
@@ -148,11 +172,161 @@ func TestIndexerCache_GetOrCreate_ReusesParentIndex(t *testing.T) {
 	cachedParent := ic.cache[parentDir]
 	cachedSub := ic.cache[subDir]
 	ic.mu.RUnlock()
-	if cachedParent != parentIdx {
+	if cachedParent.idx != parentIdx {
 		t.Fatal("parent key not in cache")
 	}
-	if cachedSub != parentIdx {
+	if cachedSub.idx != parentIdx {
 		t.Fatal("subdir key not aliased to parent indexer in cache")
+	}
+
+	// Third call: same subDir again — hits fast path; must still return parent root.
+	subIdx2, subRoot2, err := ic.getOrCreate(subDir, "")
+	if err != nil {
+		t.Fatalf("getOrCreate(subdir fast path): %v", err)
+	}
+	if subRoot2 != parentDir {
+		t.Fatalf("fast-path: expected effectiveRoot=%s, got %s", parentDir, subRoot2)
+	}
+	if subIdx2 != parentIdx {
+		t.Fatal("fast-path: expected same indexer instance")
+	}
+}
+
+func TestIndexerCache_GetOrCreate_FastPathEffectiveRoot(t *testing.T) {
+	// Regression: the fast path (second call to same path) must return the
+	// correct effectiveRoot (the parent), not the requested subdirectory path.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	const model = "stub"
+	ic := &indexerCache{
+		embedder: &stubEmbedder{},
+		model:    model,
+		cfg:      config.Config{MaxChunkTokens: 512},
+	}
+
+	parentDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subDir := filepath.Join(parentDir, "api")
+
+	// Prime the parent index.
+	if _, _, err := ic.getOrCreate(parentDir, ""); err != nil {
+		t.Fatalf("getOrCreate(parent): %v", err)
+	}
+
+	// First subDir call — slow path, caches alias.
+	if _, _, err := ic.getOrCreate(subDir, ""); err != nil {
+		t.Fatalf("getOrCreate(subdir slow path): %v", err)
+	}
+
+	// Second subDir call — hits the fast path.
+	_, root, err := ic.getOrCreate(subDir, "")
+	if err != nil {
+		t.Fatalf("getOrCreate(subdir fast path): %v", err)
+	}
+	if root != parentDir {
+		t.Fatalf("fast path returned wrong effectiveRoot: got %s, want %s", root, parentDir)
+	}
+}
+
+func TestIndexerCache_GetOrCreate_PreferredRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	ic := &indexerCache{
+		embedder: &stubEmbedder{},
+		model:    "stub",
+		cfg:      config.Config{MaxChunkTokens: 512},
+	}
+
+	parentDir := filepath.Join(tmpDir, "project")
+	subDir := filepath.Join(parentDir, "src")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call with subDir as projectPath but parentDir as preferredRoot.
+	idx, root, err := ic.getOrCreate(subDir, parentDir)
+	if err != nil {
+		t.Fatalf("getOrCreate with preferredRoot: %v", err)
+	}
+	if root != parentDir {
+		t.Fatalf("expected effectiveRoot=%s, got %s", parentDir, root)
+	}
+
+	// Both subDir and parentDir should be cached.
+	ic.mu.RLock()
+	parentEntry := ic.cache[parentDir]
+	subEntry := ic.cache[subDir]
+	ic.mu.RUnlock()
+	if parentEntry.idx != idx {
+		t.Fatal("parent key not in cache")
+	}
+	if subEntry.idx != idx {
+		t.Fatal("subdir key not aliased to parent indexer")
+	}
+}
+
+func TestValidateSearchInput_CwdPathInteraction(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   SemanticSearchInput
+		wantErr string
+		wantPath string
+	}{
+		{
+			name:     "cwd only — path defaults to cwd",
+			input:    SemanticSearchInput{Cwd: "/project", Query: "test"},
+			wantPath: "/project",
+		},
+		{
+			name:     "path only — works as before",
+			input:    SemanticSearchInput{Path: "/project/src", Query: "test"},
+			wantPath: "/project/src",
+		},
+		{
+			name:     "both valid — path under cwd",
+			input:    SemanticSearchInput{Cwd: "/project", Path: "/project/src", Query: "test"},
+			wantPath: "/project/src",
+		},
+		{
+			name:    "both invalid — path outside cwd",
+			input:   SemanticSearchInput{Cwd: "/project", Path: "/other", Query: "test"},
+			wantErr: "path must be equal to or under cwd",
+		},
+		{
+			name:    "neither provided",
+			input:   SemanticSearchInput{Query: "test"},
+			wantErr: "path is required (or provide cwd)",
+		},
+		{
+			name:    "cwd is relative",
+			input:   SemanticSearchInput{Cwd: "relative/path", Query: "test"},
+			wantErr: "cwd must be an absolute path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.input
+			err := validateSearchInput(&input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if input.Path != tt.wantPath {
+				t.Fatalf("expected path=%s, got %s", tt.wantPath, input.Path)
+			}
+		})
 	}
 }
 

--- a/docs/demo/demo.tape
+++ b/docs/demo/demo.tape
@@ -1,19 +1,19 @@
-Output docs/demo/demo.gif
+Output ../../../docs/demo/demo.gif
 
 Set FontSize 13
 Set Width 1200
 Set Height 700
 Set Theme "Dracula"
 Set PlaybackSpeed 1.0
-Set TypingSpeed 50ms
+Set TypingSpeed 10ms
 
 # Prerequisite (run once before recording to pre-index):
 #   ./bin/lumen index testdata/fixtures/go
 
-Type "claude"
+Type "claude --dangerously-skip-permissions"
 Enter
-Sleep 5s
+Sleep 2s
 
-Type "Explain to me how Observe records a histogram value"
+Type "How does TSDB compaction work end-to-end? Explain the Compactor interface, LeveledCompactor, and how the DB triggers compaction. Show relevant types, interfaces, and key method signatures."
 Enter
-Sleep 30s
+Sleep 20s

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1039,3 +1039,96 @@ func TestE2E_ErrorHandling(t *testing.T) {
 		t.Errorf("expected 0 results for empty project, got %d", len(out.Results))
 	}
 }
+
+func TestE2E_SubdirFastPathNoDoubleIndex(t *testing.T) {
+	// Regression: when a subdirectory search hits the fast path (second call),
+	// the correct effectiveRoot must be used — not the subdirectory path.
+	// A wrong effectiveRoot causes spurious re-indexing and broken snippets.
+	session := startServer(t)
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "api")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Root-level file.
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(`package main
+
+// Run starts the server.
+func Run() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Subdirectory file — target for subdir searches below.
+	if err := os.WriteFile(filepath.Join(subDir, "handler.go"), []byte(`package api
+
+import "net/http"
+
+// HandleHealth returns a health check response.
+func HandleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call 1: search the ROOT — triggers indexing, effectiveRoot = tmpDir.
+	out1 := callSearch(t, session, map[string]any{
+		"query": "server",
+		"path":  tmpDir,
+	})
+	if !out1.Reindexed {
+		t.Error("call 1 (root): expected Reindexed=true")
+	}
+
+	// Call 2: search a SUBDIRECTORY for the first time — slow path, aliases
+	// tmpDir/api → effectiveRoot = tmpDir in cache.
+	out2 := callSearch(t, session, map[string]any{
+		"query":     "HTTP handler health check",
+		"path":      subDir,
+		"min_score": -1,
+	})
+	if out2.Reindexed {
+		t.Error("call 2 (first subdir search): expected Reindexed=false (parent already indexed)")
+	}
+
+	// Call 3: search the SAME subdirectory again — hits the fast path.
+	// Before the fix: fast path returned subDir as effectiveRoot → EnsureFresh
+	// built a Merkle tree for subDir alone (different hash), triggering a
+	// spurious re-index. extractSnippets also used the wrong root path.
+	out3 := callSearch(t, session, map[string]any{
+		"query":     "HTTP handler health check",
+		"path":      subDir,
+		"min_score": -1,
+	})
+	if out3.Reindexed {
+		t.Error("call 3 (fast-path subdir): expected Reindexed=false — double index detected!")
+	}
+
+	if len(out3.Results) == 0 {
+		t.Fatal("call 3: expected at least one result")
+	}
+	found := findResult(out3.Results, "HandleHealth")
+	if found == nil {
+		t.Fatalf("call 3: expected HandleHealth in results, got: %v", resultSymbols(out3.Results))
+	}
+	// Snippet content must be non-empty — proves extractSnippets used the right root.
+	if found.Content == "" {
+		t.Error("call 3: HandleHealth result has no snippet content — wrong effectiveRoot in extractSnippets")
+	}
+
+	// Call 4: same subdirectory with min_score=0.3 filter.
+	out4 := callSearch(t, session, map[string]any{
+		"query":     "HTTP handler health check",
+		"path":      subDir,
+		"min_score": 0.3,
+	})
+	if out4.Reindexed {
+		t.Error("call 4 (min_score filter): unexpected re-index")
+	}
+	if found.Score > 0.3 && findResult(out4.Results, "HandleHealth") == nil {
+		t.Errorf("call 4: HandleHealth (score=%.2f) should pass min_score=0.3 filter", found.Score)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds optional `cwd` parameter to `semantic_search` and `index_status` MCP tools so Claude can pass its working directory as the authoritative index root
- When `cwd` is provided, `getOrCreate` uses it directly as the effective root, bypassing `findEffectiveRoot` — this prevents sub-directory paths from creating partial indexes
- Adds `pathCrossesSkipDir` check to `findEffectiveRoot` so parent indexes that would never contain a path's files (e.g. paths through `testdata/`) are skipped
- Updates SessionStart hook to instruct Claude to always pass `cwd`

## Test plan
- [x] `go test ./...` — all existing + new tests pass
- [x] `golangci-lint run` — zero issues
- [ ] Manual: run `claude --plugin-dir .`, call `semantic_search` with `cwd` set to project root and `path` set to a subdirectory — should index full project and filter results

🤖 Generated with [Claude Code](https://claude.com/claude-code)