### PR TITLE
refactor(plugin): inline mcpServers config and remove .mcp.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,11 @@
     "embeddings",
     "ollama",
     "rag"
-  ]
+  ],
+  "mcpServers": {
+    "lumen": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh",
+      "args": ["stdio"]
+    }
+  }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "lumen": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh",
-      "args": ["stdio"]
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- Moves MCP server configuration from `.mcp.json` inline into `.claude-plugin/plugin.json`
- Removes `.mcp.json` to prevent Claude Code from auto-loading it as a project-level MCP config when developing the plugin

## Why

When working on the plugin codebase in Claude Code, the project-level `.mcp.json` was auto-loaded, causing the `${CLAUDE_PLUGIN_ROOT}` variable to remain unresolved (only substituted in plugin context). Moving the config inline in `plugin.json` eliminates the conflict — the MCP server only loads when the plugin is installed and enabled.

## Test plan

- [ ] Verify `claude --plugin-dir .` still loads the MCP server correctly
- [ ] Verify opening the repo in Claude Code no longer triggers MCP server auto-load

🤖 Generated with [Claude Code](https://claude.com/claude-code)