### PR TITLE
fix: update guidance for reindexing the Lumen index

### DIFF
--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -11,5 +11,9 @@ Run a health check on the Lumen semantic search setup for the current project.
    - Embedding service: status, backend, host, model
    - Index: total files, indexed files, chunks, stale or fresh, last indexed
      time
+   - If the index is empty or has never been indexed, tell the user to run
+     `/lumen:reindex` to build the index
+   - If the index is stale (out of date), tell the user to run
+     `/lumen:reindex` to update it
    - If any issues found, suggest remediation (e.g. "reinstall the lumen
      plugin")


### PR DESCRIPTION
## Problem                                                                                      
                                                                                           
Initial run of `/lumen:doctor` skill provides inconsistent diagnostics.

**Version 1**      
<img width="749" height="776" alt="Screenshot 2026-03-06 at 9 15 18 AM" src="https://github.com/user-attachments/assets/8472578a-c1a9-4d92-b8de-c701e47467e0" />

**Version 2**                                                                                              
<img width="2268" height="1198" alt="Screenshot 2026-03-06 at 10 55 53 AM" src="https://github.com/user-attachments/assets/db7dd370-7830-43a2-8911-914987d1e4ff" />

## Fix
  - Added guidance to suggest `/lumen:reindex `when the index is empty or never been built
  - Added guidance to suggest `/lumen:reindex `when the index is stale

<img width="790" height="637" alt="Screenshot 2026-03-06 at 11 36 12 AM" src="https://github.com/user-attachments/assets/8c1111e5-76d9-4d93-9694-b1250f0879cc" />

### Test: 
1. run `claude --plugin-dir $(pwd)` when in lumen directory
2. run `/lumen:doctor`
