### PR TITLE
feat(chunker): add C# language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Two skills are also available: `/lumen:doctor` (health check) and
   via Merkle tree diffing
 - **Incremental updates** — re-indexes only what changed; large codebases
   re-index in seconds after the first run
-- **14 language families** — Go, Python, TypeScript, JavaScript, Rust, Ruby,
-  Java, PHP, C/C++, Markdown, YAML, JSON, TOML, Go module
+- **15 language families** — Go, Python, TypeScript, JavaScript, Rust, Ruby,
+  Java, PHP, C/C++, C#, Markdown, YAML, JSON, TOML, Go module
 - **Zero cloud** — embeddings stay on your machine; no data leaves your network
 - **Ollama and LM Studio** — works with either local embedding backend
 
@@ -107,7 +107,7 @@ reproduce instructions.
 
 ## Supported Languages
 
-Supports **14 language families** with semantic chunking:
+Supports **15 language families** with semantic chunking:
 
 | Language | Parser | Extensions | Status |
 | ---------------- | ----------- | ----------------------------------------- |-------------------------------------|
@@ -119,6 +119,7 @@ Supports **14 language families** with semantic chunking:
 | Ruby | tree-sitter | `.rb` | Supported |
 | Java | tree-sitter | `.java` | Supported |
 | PHP | tree-sitter | `.php` | Supported |
+| C# | tree-sitter | `.cs` | Supported |
 | C / C++ | tree-sitter | `.c`, `.h`, `.cpp`, `.cc`, `.cxx`, `.hpp` | Supported |
 | Markdown / MDX | tree-sitter | `.md`, `.mdx` | Supported |
 | YAML | tree-sitter | `.yaml`, `.yml` | Supported |

--- a/internal/chunker/languages.go
+++ b/internal/chunker/languages.go
@@ -17,6 +17,7 @@ package chunker
 import (
 	sitter_c "github.com/smacker/go-tree-sitter/c"
 	sitter_cpp "github.com/smacker/go-tree-sitter/cpp"
+	sitter_cs "github.com/smacker/go-tree-sitter/csharp"
 	sitter_java "github.com/smacker/go-tree-sitter/java"
 	sitter_js "github.com/smacker/go-tree-sitter/javascript"
 	sitter_php "github.com/smacker/go-tree-sitter/php"
@@ -39,6 +40,7 @@ var supportedExtensions = []string{
 	".c", ".h",
 	".cpp", ".cc", ".cxx", ".hpp",
 	".php",
+	".cs",
 	".md", ".mdx",
 	".yaml", ".yml", ".json", ".toml",
 	".mod",
@@ -156,6 +158,23 @@ func DefaultLanguages(maxChunkTokens int) map[string]Chunker {
 		},
 	})
 
+	cs := mustTreeSitterChunker(LanguageDef{
+		Language: sitter_cs.GetLanguage(),
+		Queries: []QueryDef{
+			{Pattern: `(method_declaration name: (identifier) @name) @decl`, Kind: "method"},
+			{Pattern: `(class_declaration name: (identifier) @name) @decl`, Kind: "type"},
+			{Pattern: `(interface_declaration name: (identifier) @name) @decl`, Kind: "interface"},
+			{Pattern: `(struct_declaration name: (identifier) @name) @decl`, Kind: "type"},
+			{Pattern: `(enum_declaration name: (identifier) @name) @decl`, Kind: "type"},
+			{Pattern: `(property_declaration name: (identifier) @name) @decl`, Kind: "method"},
+			{Pattern: `(constructor_declaration name: (identifier) @name) @decl`, Kind: "function"},
+			{Pattern: `(destructor_declaration name: (identifier) @name) @decl`, Kind: "function"},
+			{Pattern: `(delegate_declaration name: (identifier) @name) @decl`, Kind: "type"},
+			{Pattern: `(record_declaration name: (identifier) @name) @decl`, Kind: "type"},
+			{Pattern: `(event_field_declaration (variable_declaration (variable_declarator (identifier) @name))) @decl`, Kind: "var"},
+		},
+	})
+
 	goChunker := NewGoAST()
 
 	md := NewMarkdownChunker()
@@ -180,6 +199,7 @@ func DefaultLanguages(maxChunkTokens int) map[string]Chunker {
 		".cxx":  cpp,
 		".hpp":  cpp,
 		".php":  php,
+		".cs":   cs,
 		".md":   md,
 		".mdx":  md,
 		".yaml": structured,

--- a/internal/chunker/treesitter_test.go
+++ b/internal/chunker/treesitter_test.go
@@ -509,6 +509,86 @@ func TestTreeSitterChunker_CPP(t *testing.T) {
 	check("add", "function")
 }
 
+var sampleCSharp = []byte(`using System;
+
+namespace MyApp
+{
+    public delegate void StatusChanged(string status);
+
+    public enum Direction { North, South, East, West }
+
+    public interface IShape
+    {
+        double Area();
+    }
+
+    public record Point(double X, double Y);
+
+    public struct Vector2
+    {
+        public double X;
+        public double Y;
+    }
+
+    public class Calculator : IShape
+    {
+        private int _value;
+
+        public event StatusChanged OnStatusChanged;
+
+        public int Value { get => _value; set => _value = value; }
+
+        public Calculator(int initial) { _value = initial; }
+
+        ~Calculator() { }
+
+        public int Add(int a, int b) => a + b;
+
+        public double Area() => _value;
+    }
+}
+`)
+
+func TestTreeSitterChunker_CSharp(t *testing.T) {
+	langs := chunker.DefaultLanguages(512)
+	c, ok := langs[".cs"]
+	if !ok {
+		t.Fatal("DefaultLanguages() missing .cs")
+	}
+
+	chunks, err := c.Chunk("sample.cs", sampleCSharp)
+	if err != nil {
+		t.Fatalf("Chunk: %v", err)
+	}
+
+	bySymbolKind := make(map[string]map[string]bool)
+	for _, ch := range chunks {
+		if bySymbolKind[ch.Symbol] == nil {
+			bySymbolKind[ch.Symbol] = make(map[string]bool)
+		}
+		bySymbolKind[ch.Symbol][ch.Kind] = true
+	}
+
+	check := func(symbol, kind string) {
+		t.Helper()
+		kinds, ok := bySymbolKind[symbol]
+		if !ok || !kinds[kind] {
+			t.Errorf("missing chunk %q/%q (got: %v)", symbol, kind, symbolNames(chunks))
+		}
+	}
+
+	check("Calculator", "type")     // class_declaration
+	check("IShape", "interface")    // interface_declaration
+	check("Vector2", "type")        // struct_declaration
+	check("Direction", "type")      // enum_declaration
+	check("Point", "type")          // record_declaration
+	check("StatusChanged", "type")  // delegate_declaration
+	check("Add", "method")          // method_declaration
+	check("Value", "method")        // property_declaration
+	check("Calculator", "function") // constructor_declaration
+	check("OnStatusChanged", "var")  // event_field_declaration
+}
+
 func symbolNames(chunks []chunker.Chunk) []string {
 	names := make([]string, len(chunks))
 	for i, c := range chunks {
@@ -563,6 +643,7 @@ func TestDefaultLanguages_AllExtensionsPresent(t *testing.T) {
 		".cxx":  []byte("void foo() {}"),
 		".hpp":  []byte("void foo() {}"),
 		".php":  []byte("<?php\nfunction foo() {}"),
+		".cs":   []byte("class Foo {}"),
 		".md":   []byte("# Foo\nSome content."),
 		".mdx":  []byte("# Foo\nSome content."),
 		".yaml": []byte("foo: bar\n"),


### PR DESCRIPTION
## Summary

- Add tree-sitter chunker for `.cs` files with 11 query patterns covering: classes, interfaces, structs, enums, records, delegates, methods, properties, constructors, destructors, and event fields
- Add `.cs` to `supportedExtensions` and register in `DefaultLanguages`
- Update README to reflect 15 supported language families and add C# row to the languages table

## Test plan

- [x] `CGO_ENABLED=1 go test ./internal/chunker/...` — all pass
- [x] `CGO_ENABLED=1 go test ./...` — full suite passes
- [x] `golangci-lint run` — zero issues
- [x] `make build` — cross-platform binaries build successfully
- [x] `TestTreeSitterChunker_CSharp` validates chunking of classes, interfaces, structs, enums, records, delegates, methods, properties, constructors, and events
- [x] `TestDefaultLanguages_AllExtensionsPresent` updated with `.cs` trivial source

🤖 Generated with [Claude Code](https://claude.com/claude-code)