### PR TITLE
feat: distribute lumen binary via npm optional dependencies

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Publish
         run: bash scripts/npm-publish.sh "${{ needs.release-please.outputs.tag_name }}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AENEASR }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,3 +42,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+  publish-npm:
+    name: Publish npm packages
+    runs-on: ubuntu-latest
+    needs: [release-please, release]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish
+        run: bash scripts/npm-publish.sh "${{ needs.release-please.outputs.tag_name }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ dist/
 lumen
 
 bench-swe/bench-swe
-bench-swe/overview.txt
+bench-swe/overview.txt.claude/worktrees/

--- a/npm/lumen.js
+++ b/npm/lumen.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+function getBinary() {
+  const platform = os.platform(); // 'darwin', 'linux', 'win32'
+  const arch = os.arch();         // 'arm64', 'x64'
+  const ext = platform === 'win32' ? '.exe' : '';
+  const suffix = `${platform}-${arch}`;
+
+  try {
+    const pkgJson = require.resolve(`@ory/lumen-${suffix}/package.json`);
+    return path.join(path.dirname(pkgJson), 'bin', `lumen${ext}`);
+  } catch {
+    // platform package not installed
+  }
+
+  process.stderr.write(
+    `@ory/lumen: no binary found for ${platform}/${arch}.\n` +
+    `Platform package @ory/lumen-${platform}-${arch} is not installed.\n` +
+    `Please report this at https://github.com/ory/lumen/issues\n`
+  );
+  process.exit(1);
+}
+
+const bin = getBinary();
+try {
+  execFileSync(bin, process.argv.slice(2), { stdio: 'inherit' });
+} catch (e) {
+  process.exit(e.status ?? 1);
+}

--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Publishes @ory/lumen and platform-specific npm packages.
+# Downloads binaries from the GitHub release, verifies checksums, and wraps them in npm packages.
+#
+# Usage: npm-publish.sh <tag>  (e.g. v0.0.12)
+# Requires: NODE_AUTH_TOKEN env var set to an npm automation token with publish access.
+set -euo pipefail
+
+TAG="${1:?Usage: npm-publish.sh <tag> [--dry-run]}"
+DRY_RUN=""
+[ "${2:-}" = "--dry-run" ] && DRY_RUN="--dry-run"
+VERSION="${TAG#v}"
+REPO="ory/lumen"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# goreleaser_os goreleaser_arch npm_package npm_os npm_cpu binary_ext
+PLATFORMS=(
+  "darwin  amd64 darwin-x64   darwin x64  "
+  "darwin  arm64 darwin-arm64 darwin arm64 "
+  "linux   amd64 linux-x64    linux  x64  "
+  "linux   arm64 linux-arm64  linux  arm64 "
+  "windows amd64 win32-x64    win32  x64  .exe"
+)
+
+# NODE_AUTH_TOKEN is set by actions/setup-node and consumed by npm automatically.
+# For local use outside CI, set it explicitly: NODE_AUTH_TOKEN=<token> ./scripts/npm-publish.sh <tag>
+[ -z "${DRY_RUN}" ] && : "${NODE_AUTH_TOKEN:?NODE_AUTH_TOKEN must be set}"
+
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+# Download checksums file for verification
+CHECKSUMS_FILE="${TMP_DIR}/checksums.txt"
+echo "Downloading checksums..."
+curl -sfL "${BASE_URL}/checksums.txt" -o "${CHECKSUMS_FILE}"
+
+# Publish platform packages first
+for row in "${PLATFORMS[@]}"; do
+  read -r GO_OS GO_ARCH NPM_PKG NPM_OS NPM_CPU EXT <<< "$row"
+
+  ASSET="lumen-${VERSION}-${GO_OS}-${GO_ARCH}${EXT}"
+  PKG_DIR="${TMP_DIR}/@ory/lumen-${NPM_PKG}"
+  mkdir -p "${PKG_DIR}/bin"
+
+  echo "Downloading ${ASSET}..."
+  curl -sfL "${BASE_URL}/${ASSET}" -o "${PKG_DIR}/bin/lumen${EXT}"
+
+  # Verify checksum
+  EXPECTED="$(grep " ${ASSET}$" "${CHECKSUMS_FILE}" | awk '{print $1}')"
+  ACTUAL="$(sha256sum "${PKG_DIR}/bin/lumen${EXT}" | awk '{print $1}')"
+  if [ "${EXPECTED}" != "${ACTUAL}" ]; then
+    echo "Checksum mismatch for ${ASSET}: expected ${EXPECTED}, got ${ACTUAL}" >&2
+    exit 1
+  fi
+
+  chmod +x "${PKG_DIR}/bin/lumen${EXT}"
+
+  cat > "${PKG_DIR}/package.json" << PKGJSON
+{
+  "name": "@ory/lumen-${NPM_PKG}",
+  "version": "${VERSION}",
+  "description": "Platform binary for @ory/lumen (${NPM_PKG})",
+  "repository": { "type": "git", "url": "git+https://github.com/ory/lumen.git" },
+  "license": "Apache-2.0",
+  "os": ["${NPM_OS}"],
+  "cpu": ["${NPM_CPU}"],
+  "files": ["bin/"]
+}
+PKGJSON
+
+  (cd "${PKG_DIR}" && npm publish --access public ${DRY_RUN})
+  echo "Published @ory/lumen-${NPM_PKG}@${VERSION}"
+done
+
+# Build and publish wrapper package
+WRAPPER_DIR="${TMP_DIR}/@ory/lumen"
+mkdir -p "${WRAPPER_DIR}/bin"
+
+cp "${REPO_ROOT}/npm/lumen.js" "${WRAPPER_DIR}/bin/lumen.js"
+chmod +x "${WRAPPER_DIR}/bin/lumen.js"
+# Copy only the files needed at runtime (not publish tooling)
+mkdir -p "${WRAPPER_DIR}/scripts"
+cp "${REPO_ROOT}/scripts/run.sh" "${WRAPPER_DIR}/scripts/run.sh"
+[ -f "${REPO_ROOT}/scripts/run.bat" ] && cp "${REPO_ROOT}/scripts/run.bat" "${WRAPPER_DIR}/scripts/run.bat"
+cp -r "${REPO_ROOT}/.claude-plugin" "${WRAPPER_DIR}/"
+cp -r "${REPO_ROOT}/hooks" "${WRAPPER_DIR}/"
+cp -r "${REPO_ROOT}/skills" "${WRAPPER_DIR}/"
+[ -f "${REPO_ROOT}/LICENSE" ] && cp "${REPO_ROOT}/LICENSE" "${WRAPPER_DIR}/"
+
+cat > "${WRAPPER_DIR}/package.json" << WRAPPERJSON
+{
+  "name": "@ory/lumen",
+  "version": "${VERSION}",
+  "description": "Precise local semantic code search via MCP. Indexes your codebase with Go AST parsing, embeds with Ollama or LM Studio, and exposes vector search to Claude — no cloud, no npm.",
+  "repository": { "type": "git", "url": "git+https://github.com/ory/lumen.git" },
+  "license": "Apache-2.0",
+  "keywords": ["semantic-search", "code-index", "mcp", "embeddings", "ollama"],
+  "bin": {
+    "lumen": "./bin/lumen.js"
+  },
+  "files": [
+    "bin/",
+    "scripts/",
+    ".claude-plugin/",
+    "hooks/",
+    "skills/"
+  ],
+  "optionalDependencies": {
+    "@ory/lumen-darwin-arm64": "${VERSION}",
+    "@ory/lumen-darwin-x64": "${VERSION}",
+    "@ory/lumen-linux-arm64": "${VERSION}",
+    "@ory/lumen-linux-x64": "${VERSION}",
+    "@ory/lumen-win32-x64": "${VERSION}"
+  }
+}
+WRAPPERJSON
+
+(cd "${WRAPPER_DIR}" && npm publish --access public ${DRY_RUN})
+echo "Published @ory/lumen@${VERSION}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,6 +13,10 @@ case "$ARCH" in
   aarch64) ARCH="arm64" ;;
 esac
 
+# npm naming differs from Go: amd64→x64, windows→win32
+case "$ARCH" in amd64) NPM_ARCH="x64" ;; *) NPM_ARCH="$ARCH" ;; esac
+case "$OS" in windows) NPM_OS="win32" ;; *) NPM_OS="$OS" ;; esac
+
 # Environment defaults
 export LUMEN_BACKEND="${LUMEN_BACKEND:-ollama}"
 export LUMEN_EMBED_MODEL="${LUMEN_EMBED_MODEL:-ordis/jina-embeddings-v2-base-code}"
@@ -21,7 +25,8 @@ export LUMEN_EMBED_MODEL="${LUMEN_EMBED_MODEL:-ordis/jina-embeddings-v2-base-cod
 BINARY=""
 for candidate in \
   "${PLUGIN_ROOT}/bin/lumen" \
-  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"; do
+  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}" \
+  "${PLUGIN_ROOT}/../lumen-${NPM_OS}-${NPM_ARCH}/bin/lumen"; do
   if [ -x "$candidate" ]; then
     BINARY="$candidate"
     break


### PR DESCRIPTION
## Summary

- **Root cause**: On first launch after a marketplace upgrade, `run.sh` downloaded the binary at MCP startup time, but the MCP connection timed out after 94ms before the download completed
- **Fix**: Distribute the binary via npm `optionalDependencies` so it arrives at install time, not startup time — the same pattern used by esbuild, Biome, etc.

## Changes

- **`scripts/npm-publish.sh`**: Downloads release binaries from GitHub, verifies sha256 checksums against goreleaser's `checksums.txt`, and publishes `@ory/lumen-<platform>` packages + the `@ory/lumen` wrapper with `optionalDependencies`
- **`npm/lumen.js`**: JS shim used as the wrapper's `bin` entry — resolves the installed platform package and execs the binary
- **`scripts/run.sh`**: Probes the npm sibling package path (`../lumen-<os>-<arch>/bin/lumen`) before falling back to download, so npm-installed plugins find the binary with no network call at startup
- **`.github/workflows/release-please.yml`**: Adds `publish-npm` job that runs after goreleaser on `ubuntu-latest` using `NODE_AUTH_TOKEN` from `NPM_TOKEN` secret

## Test plan

- [x] Dry-run verified against v0.0.13: all 5 platform packages + wrapper published cleanly with correct contents and checksums
- [ ] Add `NPM_TOKEN` secret to the `ory/lumen` repo (requires org admin)
- [ ] Verify next release publishes `@ory/lumen@<version>` to npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)