### PR TITLE
feat(index): worktree-aware index seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Two skills are also available: `/lumen:doctor` (health check) and
   re-index in seconds after the first run
 - **11 language families** — Go, Python, TypeScript, JavaScript, Rust, Ruby,
   Java, PHP, C/C++, C#
+- **Git worktree support** — worktrees share index data automatically; a new
+  worktree seeds from a sibling's index and only re-indexes changed files,
+  turning minutes of embedding into seconds
 - **Zero cloud** — embeddings stay on your machine; no data leaves your network
 - **Ollama and LM Studio** — works with either local embedding backend
 
@@ -242,6 +245,12 @@ needed.
 
 You can safely delete the entire `lumen` directory to clear all indexes, or use
 `lumen purge` to do it automatically.
+
+**Git worktrees** are detected automatically. When you create a new worktree
+(`git worktree add` or `claude --worktree`), Lumen finds a sibling worktree's
+existing index and copies it as a seed. The Merkle tree diff then re-indexes
+only the files that actually differ — typically a handful of files instead of
+the entire codebase. No configuration needed; it just works.
 
 ## CLI Reference
 

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -107,6 +107,9 @@ func generateSessionContext(mcpName, cwd string) string {
 
 	dbPath := config.DBPathForProject(cwd, cfg.Model)
 	if _, err := os.Stat(dbPath); err != nil {
+		if donorPath := config.FindDonorIndex(cwd, cfg.Model); donorPath != "" {
+			return directive + " Sibling worktree index found — fast incremental re-index on first search."
+		}
 		return directive + " No index yet — auto-created on first call."
 	}
 

--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -222,6 +222,15 @@ func (ic *indexerCache) getOrCreate(projectPath string, preferredRoot string) (*
 		return nil, "", fmt.Errorf("create db directory: %w", err)
 	}
 
+	// Seed from sibling worktree if this is a new index.
+	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
+		if donorPath := config.FindDonorIndex(effectiveRoot, ic.model); donorPath != "" {
+			if _, seedErr := index.SeedFromDonor(donorPath, dbPath); seedErr != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "lumen: seed from worktree failed: %v\n", seedErr)
+			}
+		}
+	}
+
 	idx, err := index.NewIndexer(dbPath, ic.embedder, ic.cfg.MaxChunkTokens)
 	if err != nil {
 		return nil, "", fmt.Errorf("create indexer: %w", err)

--- a/internal/config/seed.go
+++ b/internal/config/seed.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/ory/lumen/internal/git"
+)
+
+// FindDonorIndex searches sibling git worktrees for an existing lumen index
+// DB that uses the same model and IndexVersion. Returns the DB path of the
+// most recently modified candidate, or "" if no suitable donor exists.
+func FindDonorIndex(projectPath, model string) string {
+	return FindDonorIndexBase(XDGDataDir(), projectPath, model)
+}
+
+// FindDonorIndexBase is like FindDonorIndex but accepts an explicit data
+// directory, making it safe for testing without side effects.
+func FindDonorIndexBase(dataDir, projectPath, model string) string {
+	worktrees, err := git.ListWorktrees(projectPath)
+	if err != nil || len(worktrees) < 2 {
+		return ""
+	}
+
+	// Resolve symlinks so comparisons work on macOS (/var → /private/var).
+	resolvedSelf := projectPath
+	if r, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolvedSelf = r
+	}
+
+	type candidate struct {
+		path    string
+		modTime int64
+	}
+	var candidates []candidate
+
+	for _, wt := range worktrees {
+		if wt == resolvedSelf {
+			continue
+		}
+		dbPath := DBPathForProjectBase(dataDir, wt, model)
+		info, err := os.Stat(dbPath)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{path: dbPath, modTime: info.ModTime().UnixNano()})
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	// Pick the most recently modified index.
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		if a.modTime > b.modTime {
+			return -1
+		}
+		if a.modTime < b.modTime {
+			return 1
+		}
+		return 0
+	})
+
+	return candidates[0].path
+}

--- a/internal/config/seed_test.go
+++ b/internal/config/seed_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindDonorIndex_NoSiblings(t *testing.T) {
+	dir := t.TempDir()
+	result := FindDonorIndexBase(dir, "/some/path", "model")
+	if result != "" {
+		t.Fatalf("expected empty string, got %q", result)
+	}
+}
+
+func TestFindDonorIndex_WithSibling(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Create a git repo with a worktree.
+	main := t.TempDir()
+	gitRun(t, main, "git", "init")
+	gitRun(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	gitRun(t, main, "git", "worktree", "add", wt)
+
+	// Resolve symlinks so DB path matches what ListWorktrees returns.
+	mainResolved, err := filepath.EvalSymlinks(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake donor index for the main worktree using resolved path.
+	dataDir := t.TempDir()
+	donorDB := DBPathForProjectBase(dataDir, mainResolved, "test-model")
+	if err := os.MkdirAll(filepath.Dir(donorDB), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(donorDB, []byte("fake-db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// From the worktree, we should find the main's index.
+	result := FindDonorIndexBase(dataDir, wt, "test-model")
+	if result != donorDB {
+		t.Fatalf("expected %q, got %q", donorDB, result)
+	}
+}
+
+func TestFindDonorIndex_WrongModel(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	main := t.TempDir()
+	gitRun(t, main, "git", "init")
+	gitRun(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	gitRun(t, main, "git", "worktree", "add", wt)
+
+	// Resolve symlinks for DB path consistency.
+	mainResolved, err := filepath.EvalSymlinks(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create index for different model.
+	dataDir := t.TempDir()
+	donorDB := DBPathForProjectBase(dataDir, mainResolved, "model-a")
+	if err := os.MkdirAll(filepath.Dir(donorDB), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(donorDB, []byte("fake-db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Looking for model-b should not find model-a's index.
+	result := FindDonorIndexBase(dataDir, wt, "model-b")
+	if result != "" {
+		t.Fatalf("expected empty string for wrong model, got %q", result)
+	}
+}
+
+func gitRun(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package git provides utilities for detecting git worktrees and finding
+// sibling worktree paths.
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// IsWorktree reports whether projectPath is a git worktree (as opposed to
+// the main working tree). A worktree has a .git file pointing at the shared
+// .git directory, whereas the main repo has a .git directory.
+func IsWorktree(projectPath string) bool {
+	info, err := os.Lstat(filepath.Join(projectPath, ".git"))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// CommonDir returns the shared .git directory for the repository containing
+// projectPath, by running "git rev-parse --git-common-dir". Returns an error
+// if git is not available or projectPath is not inside a git repository.
+func CommonDir(projectPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
+	cmd.Dir = projectPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	dir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(projectPath, dir)
+	}
+	dir = filepath.Clean(dir)
+	// Resolve symlinks so paths are comparable across macOS
+	// /var → /private/var symlink boundaries.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	return dir, nil
+}
+
+// ListWorktrees returns the absolute paths of all worktrees (including the
+// main working tree) for the repository containing projectPath. Returns nil
+// if git is not available or projectPath is not inside a git repository.
+func ListWorktrees(projectPath string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
+	cmd.Dir = projectPath
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			// Resolve symlinks so paths are comparable across macOS
+			// /var → /private/var symlink boundaries.
+			if resolved, err := filepath.EvalSymlinks(path); err == nil {
+				path = resolved
+			}
+			paths = append(paths, path)
+		}
+	}
+	return paths, nil
+}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsWorktree_GitDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if IsWorktree(dir) {
+		t.Fatal("expected false for .git directory")
+	}
+}
+
+func TestIsWorktree_GitFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /some/path\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !IsWorktree(dir) {
+		t.Fatal("expected true for .git file")
+	}
+}
+
+func TestIsWorktree_NoGit(t *testing.T) {
+	dir := t.TempDir()
+	if IsWorktree(dir) {
+		t.Fatal("expected false when .git does not exist")
+	}
+}
+
+func TestListWorktrees(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Create a real git repo.
+	main := t.TempDir()
+	run(t, main, "git", "init")
+	run(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	// Add a worktree.
+	wt := filepath.Join(t.TempDir(), "wt")
+	run(t, main, "git", "worktree", "add", wt)
+
+	// Resolve symlinks for comparison (macOS /var → /private/var).
+	wtResolved, err := filepath.EvalSymlinks(wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := ListWorktrees(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) < 2 {
+		t.Fatalf("expected ≥2 worktrees, got %d: %v", len(paths), paths)
+	}
+
+	found := false
+	for _, p := range paths {
+		if p == wtResolved {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected worktree %q in list %v", wtResolved, paths)
+	}
+}
+
+func TestCommonDir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	main := t.TempDir()
+	run(t, main, "git", "init")
+	run(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	run(t, main, "git", "worktree", "add", wt)
+
+	commonFromMain, err := CommonDir(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commonFromWT, err := CommonDir(wt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if commonFromMain != commonFromWT {
+		t.Fatalf("expected same common dir, got %q and %q", commonFromMain, commonFromWT)
+	}
+}
+
+func TestListWorktrees_NotARepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	dir := t.TempDir()
+	paths, err := ListWorktrees(dir)
+	if err == nil {
+		t.Fatalf("expected error, got paths: %v", paths)
+	}
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+	}
+}

--- a/internal/index/seed.go
+++ b/internal/index/seed.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	_ "github.com/mattn/go-sqlite3" // register sqlite3 driver for WAL checkpoint
+)
+
+// SeedFromDonor copies the donor SQLite database to dstPath if dstPath does
+// not already exist. It checkpoints the WAL first to ensure a self-contained
+// copy, then performs an atomic copy (write to temp file + rename).
+//
+// Returns (true, nil) if seeded successfully, (false, nil) if dstPath already
+// exists, or (false, error) on failure.
+func SeedFromDonor(donorPath, dstPath string) (bool, error) {
+	if _, err := os.Stat(dstPath); err == nil {
+		return false, nil
+	}
+
+	// Checkpoint the WAL so the main DB file is self-contained.
+	db, err := sql.Open("sqlite3", donorPath+"?mode=ro")
+	if err != nil {
+		return false, fmt.Errorf("open donor: %w", err)
+	}
+	_, _ = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	_ = db.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return false, fmt.Errorf("create dst directory: %w", err)
+	}
+
+	// Atomic copy: write to temp file then rename.
+	tmp := dstPath + ".seed-tmp"
+	if err := copyFile(donorPath, tmp); err != nil {
+		_ = os.Remove(tmp)
+		return false, fmt.Errorf("copy donor: %w", err)
+	}
+
+	if err := os.Rename(tmp, dstPath); err != nil {
+		_ = os.Remove(tmp)
+		return false, fmt.Errorf("rename seed: %w", err)
+	}
+
+	return true, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/internal/index/seed_test.go
+++ b/internal/index/seed_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSeedFromDonor_CopiesDB(t *testing.T) {
+	// Create a real SQLite DB with indexed data.
+	projectDir := t.TempDir()
+	writeGoFile(t, projectDir, "main.go", `package main
+
+func Hello() {}
+`)
+
+	donorPath := filepath.Join(t.TempDir(), "donor.db")
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(donorPath, emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), projectDir, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed to a new path.
+	dstPath := filepath.Join(t.TempDir(), "sub", "seeded.db")
+	seeded, err := SeedFromDonor(donorPath, dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seeded {
+		t.Fatal("expected seeded=true")
+	}
+
+	// Verify the seeded DB works.
+	idx2, err := NewIndexer(dstPath, emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx2.Close() }()
+
+	status, err := idx2.Status(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.IndexedFiles == 0 {
+		t.Fatal("expected seeded DB to have indexed files")
+	}
+}
+
+func TestSeedFromDonor_DstExists(t *testing.T) {
+	donorPath := filepath.Join(t.TempDir(), "donor.db")
+	if err := os.WriteFile(donorPath, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dstPath := filepath.Join(t.TempDir(), "existing.db")
+	if err := os.WriteFile(dstPath, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	seeded, err := SeedFromDonor(donorPath, dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seeded {
+		t.Fatal("expected seeded=false when dst exists")
+	}
+
+	// Verify original content preserved.
+	content, _ := os.ReadFile(dstPath)
+	if string(content) != "existing" {
+		t.Fatalf("expected dst unchanged, got %q", content)
+	}
+}
+
+func TestSeedFromDonor_IncrementalUpdate(t *testing.T) {
+	// Create donor with one file.
+	projectDir := t.TempDir()
+	writeGoFile(t, projectDir, "main.go", `package main
+
+func Hello() {}
+`)
+
+	donorPath := filepath.Join(t.TempDir(), "donor.db")
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(donorPath, emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), projectDir, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+	callsAfterDonor := emb.callCount
+
+	// Seed to new path.
+	dstPath := filepath.Join(t.TempDir(), "seeded.db")
+	if _, err := SeedFromDonor(donorPath, dstPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open seeded DB and add a new file to the project.
+	writeGoFile(t, projectDir, "extra.go", `package main
+
+func Extra() {}
+`)
+
+	idx2, err := NewIndexer(dstPath, emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx2.Close() }()
+
+	// EnsureFresh should do an incremental update (not full re-index).
+	reindexed, stats, err := idx2.EnsureFresh(context.Background(), projectDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reindexed {
+		t.Fatal("expected reindexed=true after adding a file")
+	}
+	// Only the new file should be indexed, not the original.
+	if stats.IndexedFiles != 1 {
+		t.Fatalf("expected 1 file indexed incrementally, got %d", stats.IndexedFiles)
+	}
+	if emb.callCount == callsAfterDonor {
+		t.Fatal("expected embed calls for the new file")
+	}
+}


### PR DESCRIPTION
## Summary

- **Git worktree support**: When `git worktree add` or `claude --worktree` creates a new worktree, Lumen detects sibling worktree indexes and copies the most recent one as a seed before running the normal Merkle tree diff
- **Incremental instead of full re-index**: Worktrees typically share 95%+ of files, so seeding turns minutes of embedding into seconds of incremental update
- **Zero configuration**: Detection, seeding, and incremental update are fully automatic

### New packages
| Package | Purpose |
|---------|---------|
| `internal/git` | Worktree detection: `IsWorktree`, `CommonDir`, `ListWorktrees` |
| `internal/config` | `FindDonorIndex` searches siblings for existing indexes |
| `internal/index` | `SeedFromDonor` does atomic SQLite copy with WAL checkpoint |

### Integration points
- `cmd/stdio.go`: Seeds before `NewIndexer` in `getOrCreate()` — runs only when DB doesn't exist yet
- `cmd/hook.go`: Reports sibling availability in SessionStart context so the user knows fast re-index is available
- `README.md`: Documents git worktree support in "What you get" and "Database location"

### Edge cases handled
- git not installed → gracefully skipped
- Concurrent writes to donor → WAL checkpoint + file copy is safe
- Stale donor → Merkle diff catches all differences
- macOS `/var` → `/private/var` symlinks → resolved via `EvalSymlinks`

## Test plan

- [x] `internal/git`: IsWorktree with .git dir vs file, ListWorktrees with real repo, CommonDir, not-a-repo graceful failure
- [x] `internal/config`: FindDonorIndex with no siblings, with sibling, wrong model mismatch
- [x] `internal/index`: SeedFromDonor copies DB, skips when dst exists, incremental update after seed works correctly
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)