### PR TITLE
fix(index): exclude internal git worktrees from project index

### DIFF
--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -384,6 +384,11 @@ func buildProgressFunc(ctx context.Context, req *mcp.CallToolRequest) index.Prog
 		return nil
 	}
 	return func(current, total int, message string) {
+		if total == 0 {
+			// Skip indeterminate notifications (e.g. "Scanning files...") —
+			// MCP progress requires Total > 0 for meaningful progress tracking.
+			return
+		}
 		_ = req.Session.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
 			ProgressToken: token,
 			Progress:      float64(current),

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1151,3 +1151,228 @@ func HandleHealth(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("call 4: HandleHealth (score=%.2f) should pass min_score=0.3 filter", found.Score)
 	}
 }
+
+// TestE2E_WorktreeIndexesChangedFile verifies that when working inside a git
+// worktree that has a modified file, searching from the worktree path triggers
+// indexing and returns the worktree's version of the file — not the main repo's.
+func TestE2E_WorktreeIndexesChangedFile(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	t.Parallel()
+	session := startServer(t)
+
+	// Set up a main repo with auth.go committed.
+	repoDir := t.TempDir()
+	gitE2ERun(t, repoDir, "init")
+	authPath := filepath.Join(repoDir, "auth.go")
+	if err := os.WriteFile(authPath, []byte(`package main
+
+// ValidateToken checks whether a token is valid.
+func ValidateToken(token string) bool {
+	return token != ""
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitE2ERun(t, repoDir, "add", "auth.go")
+	gitE2ERun(t, repoDir, "commit", "-m", "add auth")
+
+	// Create a worktree INSIDE the repo dir.
+	wtDir := filepath.Join(repoDir, ".worktrees", "feature")
+	gitE2ERun(t, repoDir, "worktree", "add", wtDir)
+
+	// In the worktree, replace ValidateToken with ValidateTokenV2.
+	wtAuthPath := filepath.Join(wtDir, "auth.go")
+	if err := os.WriteFile(wtAuthPath, []byte(`package main
+
+// ValidateTokenV2 checks whether a token is valid using the v2 algorithm.
+func ValidateTokenV2(token string) bool {
+	return len(token) >= 32
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search from the worktree — first call triggers indexing.
+	out1 := callSearch(t, session, map[string]any{
+		"query":     "token validation",
+		"path":      wtDir,
+		"cwd":       wtDir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if !out1.Reindexed {
+		t.Error("expected Reindexed=true on first search in worktree")
+	}
+	if out1.IndexedFiles == 0 {
+		t.Error("expected at least one file indexed in worktree")
+	}
+
+	// The worktree's version of the symbol should appear.
+	v2 := findResult(out1.Results, "ValidateTokenV2")
+	if v2 == nil {
+		t.Fatalf("expected ValidateTokenV2 in worktree search results, got: %v", resultSymbols(out1.Results))
+	}
+
+	// The snippet must reflect the worktree file content (v2 algorithm).
+	if !strings.Contains(v2.Content, "ValidateTokenV2") {
+		t.Errorf("snippet should contain 'ValidateTokenV2', got: %s", v2.Content)
+	}
+	if strings.Contains(v2.Content, "ValidateToken(") {
+		t.Errorf("snippet should not contain old 'ValidateToken(' from main repo, got: %s", v2.Content)
+	}
+
+	// The old symbol (exact name) must not appear — it was replaced in the worktree.
+	for _, r := range out1.Results {
+		if r.Symbol == "ValidateToken" {
+			t.Errorf("ValidateToken (main-repo-only symbol) should not appear in worktree index, but got result: %+v", r)
+		}
+	}
+
+	// Second search — no file changes — must NOT re-index.
+	out2 := callSearch(t, session, map[string]any{
+		"query":     "token validation",
+		"path":      wtDir,
+		"cwd":       wtDir,
+		"min_score": -1,
+	})
+	if out2.Reindexed {
+		t.Error("second search in worktree (no changes): expected Reindexed=false")
+	}
+}
+
+// gitE2ERun runs a git command in dir, failing the test on error.
+func gitE2ERun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+// TestE2E_InternalWorktreeFilesExcludedFromIndex verifies that files inside a
+// git worktree checked out under the project root are not counted or returned
+// by the main-repo index.
+func TestE2E_InternalWorktreeFilesExcludedFromIndex(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	t.Parallel()
+	session := startServer(t)
+
+	// Set up a git repo with one .go file.
+	repoDir := t.TempDir()
+	gitE2ERun(t, repoDir, "init")
+	gitE2ERun(t, repoDir, "commit", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(repoDir, "main.go"), []byte(`package main
+
+// Run starts the application.
+func Run() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a worktree INSIDE the repo dir with different symbols.
+	wtDir := filepath.Join(repoDir, ".worktrees", "feature")
+	gitE2ERun(t, repoDir, "worktree", "add", wtDir)
+	if err := os.WriteFile(filepath.Join(wtDir, "feature.go"), []byte(`package main
+
+// FeatureFlag controls the feature rollout.
+func FeatureFlag() bool { return false }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index the main repo.
+	out1 := callSearch(t, session, map[string]any{
+		"query": "application startup",
+		"path":  repoDir,
+		"cwd":   repoDir,
+	})
+	if !out1.Reindexed {
+		t.Error("expected Reindexed=true on first search")
+	}
+
+	// Only main.go should have been indexed — not the worktree file.
+	if out1.IndexedFiles != 1 {
+		t.Errorf("expected IndexedFiles=1 (main.go only), got %d — worktree files are leaking into the index", out1.IndexedFiles)
+	}
+
+	// A symbol that only exists in the worktree should not be findable.
+	out2 := callSearch(t, session, map[string]any{
+		"query":     "feature flag rollout",
+		"path":      repoDir,
+		"cwd":       repoDir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if findResult(out2.Results, "FeatureFlag") != nil {
+		t.Error("FeatureFlag (worktree-only symbol) should not appear in main repo index")
+	}
+}
+
+// TestE2E_InternalWorktreeSearchNoReindex verifies that searching with a path
+// prefix inside the internal worktree directory does not trigger a re-index.
+func TestE2E_InternalWorktreeSearchNoReindex(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	t.Parallel()
+	session := startServer(t)
+
+	// Set up a git repo with one .go file and an internal worktree.
+	repoDir := t.TempDir()
+	gitE2ERun(t, repoDir, "init")
+	gitE2ERun(t, repoDir, "commit", "--allow-empty", "-m", "init")
+	if err := os.WriteFile(filepath.Join(repoDir, "server.go"), []byte(`package main
+
+// ServeHTTP handles incoming HTTP requests.
+func ServeHTTP() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := filepath.Join(repoDir, ".worktrees", "fix")
+	gitE2ERun(t, repoDir, "worktree", "add", wtDir)
+
+	// Call 1: index the repo.
+	out1 := callSearch(t, session, map[string]any{
+		"query": "HTTP server",
+		"path":  repoDir,
+		"cwd":   repoDir,
+	})
+	if !out1.Reindexed {
+		t.Error("call 1: expected Reindexed=true on first search")
+	}
+
+	// Call 2: search again — no changes, must NOT reindex.
+	out2 := callSearch(t, session, map[string]any{
+		"query": "HTTP server",
+		"path":  repoDir,
+		"cwd":   repoDir,
+	})
+	if out2.Reindexed {
+		t.Error("call 2: expected Reindexed=false (no changes)")
+	}
+
+	// Call 3: search with path pointing INTO the worktree directory.
+	// Should use the parent index (no re-index) and return no results
+	// (worktree files were excluded from the index).
+	out3 := callSearch(t, session, map[string]any{
+		"query":     "anything",
+		"path":      wtDir,
+		"cwd":       repoDir,
+		"min_score": -1,
+	})
+	if out3.Reindexed {
+		t.Error("call 3 (path inside worktree): unexpected re-index triggered")
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -63,6 +63,36 @@ func CommonDir(projectPath string) (string, error) {
 	return dir, nil
 }
 
+// InternalWorktreePaths returns the relative paths (relative to projectPath)
+// of any sibling worktrees that are checked out inside projectPath. These
+// should be excluded from indexing to avoid double-counting their files.
+// Returns nil if git is unavailable, projectPath is not a repo, or no
+// worktrees are nested inside it.
+func InternalWorktreePaths(projectPath string) []string {
+	worktrees, err := ListWorktrees(projectPath)
+	if err != nil {
+		return nil
+	}
+
+	resolvedRoot := projectPath
+	if r, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolvedRoot = r
+	}
+
+	var result []string
+	for _, wt := range worktrees {
+		if wt == resolvedRoot {
+			continue
+		}
+		rel, err := filepath.Rel(resolvedRoot, wt)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		result = append(result, rel)
+	}
+	return result
+}
+
 // ListWorktrees returns the absolute paths of all worktrees (including the
 // main working tree) for the repository containing projectPath. Returns nil
 // if git is not available or projectPath is not inside a git repository.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -113,6 +113,59 @@ func TestCommonDir(t *testing.T) {
 	}
 }
 
+func TestInternalWorktreePaths_InternalWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	main := t.TempDir()
+	run(t, main, "git", "init")
+	run(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	// Create a worktree INSIDE the main repo directory.
+	internalWt := filepath.Join(main, ".worktrees", "feature")
+	run(t, main, "git", "worktree", "add", internalWt)
+
+	paths := InternalWorktreePaths(main)
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 internal worktree path, got %d: %v", len(paths), paths)
+	}
+	want := filepath.Join(".worktrees", "feature")
+	if paths[0] != want {
+		t.Errorf("expected %q, got %q", want, paths[0])
+	}
+}
+
+func TestInternalWorktreePaths_ExternalWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	main := t.TempDir()
+	run(t, main, "git", "init")
+	run(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	// Create a worktree OUTSIDE the main repo directory.
+	externalWt := filepath.Join(t.TempDir(), "feature")
+	run(t, main, "git", "worktree", "add", externalWt)
+
+	paths := InternalWorktreePaths(main)
+	if len(paths) != 0 {
+		t.Errorf("expected 0 internal worktree paths for external worktree, got %v", paths)
+	}
+}
+
+func TestInternalWorktreePaths_NotARepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	paths := InternalWorktreePaths(dir)
+	if len(paths) != 0 {
+		t.Errorf("expected nil for non-repo, got %v", paths)
+	}
+}
+
 func TestListWorktrees_NotARepo(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ory/lumen/internal/chunker"
 	"github.com/ory/lumen/internal/embedder"
+	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/merkle"
 	"github.com/ory/lumen/internal/store"
 )
@@ -84,11 +85,19 @@ func (idx *Indexer) Close() error {
 	return idx.store.Close()
 }
 
+// makeSkip returns a SkipFunc for projectDir that excludes internal worktrees.
+func makeSkip(projectDir string) merkle.SkipFunc {
+	return merkle.MakeSkipWithExtra(projectDir, chunker.SupportedExtensions(), git.InternalWorktreePaths(projectDir))
+}
+
 // Index indexes the project at projectDir. If force is true, all files are
 // re-indexed regardless of whether they have changed.
 func (idx *Indexer) Index(ctx context.Context, projectDir string, force bool, progress ProgressFunc) (Stats, error) {
+	if progress != nil {
+		progress(0, 0, "Scanning files...")
+	}
 	// Build tree outside the lock: it is read-only and can be slow for large projects.
-	curTree, err := merkle.BuildTree(projectDir, merkle.MakeSkip(projectDir, chunker.SupportedExtensions()))
+	curTree, err := merkle.BuildTree(projectDir, makeSkip(projectDir))
 	if err != nil {
 		return Stats{}, fmt.Errorf("build merkle tree: %w", err)
 	}
@@ -112,8 +121,11 @@ func (idx *Indexer) Index(ctx context.Context, projectDir string, force bool, pr
 // EnsureFresh checks if the index is stale and re-indexes if needed.
 // Returns whether a re-index occurred, the stats, and any error.
 func (idx *Indexer) EnsureFresh(ctx context.Context, projectDir string, progress ProgressFunc) (bool, Stats, error) {
+	if progress != nil {
+		progress(0, 0, "Scanning files...")
+	}
 	// Build tree outside the lock: it is read-only and can be slow for large projects.
-	curTree, err := merkle.BuildTree(projectDir, merkle.MakeSkip(projectDir, chunker.SupportedExtensions()))
+	curTree, err := merkle.BuildTree(projectDir, makeSkip(projectDir))
 	if err != nil {
 		return false, Stats{}, fmt.Errorf("build merkle tree: %w", err)
 	}
@@ -271,7 +283,7 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir string, force 
 // the current Merkle tree root hash against the stored one. Returns false if
 // the project has never been indexed (no stored hash).
 func (idx *Indexer) IsFresh(projectDir string) (bool, error) {
-	curTree, err := merkle.BuildTree(projectDir, merkle.MakeSkip(projectDir, chunker.SupportedExtensions()))
+	curTree, err := merkle.BuildTree(projectDir, makeSkip(projectDir))
 	if err != nil {
 		return false, fmt.Errorf("build merkle tree: %w", err)
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -93,9 +93,6 @@ func makeSkip(projectDir string) merkle.SkipFunc {
 // Index indexes the project at projectDir. If force is true, all files are
 // re-indexed regardless of whether they have changed.
 func (idx *Indexer) Index(ctx context.Context, projectDir string, force bool, progress ProgressFunc) (Stats, error) {
-	if progress != nil {
-		progress(0, 0, "Scanning files...")
-	}
 	// Build tree outside the lock: it is read-only and can be slow for large projects.
 	curTree, err := merkle.BuildTree(projectDir, makeSkip(projectDir))
 	if err != nil {
@@ -121,9 +118,6 @@ func (idx *Indexer) Index(ctx context.Context, projectDir string, force bool, pr
 // EnsureFresh checks if the index is stale and re-indexes if needed.
 // Returns whether a re-index occurred, the stats, and any error.
 func (idx *Indexer) EnsureFresh(ctx context.Context, projectDir string, progress ProgressFunc) (bool, Stats, error) {
-	if progress != nil {
-		progress(0, 0, "Scanning files...")
-	}
 	// Build tree outside the lock: it is read-only and can be slow for large projects.
 	curTree, err := merkle.BuildTree(projectDir, makeSkip(projectDir))
 	if err != nil {

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -365,13 +366,17 @@ func checkFirstCall(t *testing.T, first progressCall) {
 	if first.current != 0 {
 		t.Errorf("first call: expected current=0, got %d", first.current)
 	}
-	if first.total != 2 {
-		t.Errorf("first call: expected total=2, got %d", first.total)
+	if !strings.Contains(first.message, "Scanning") {
+		t.Errorf("first call: expected scanning message, got %q", first.message)
 	}
 }
 
 func checkAllCalls(t *testing.T, calls []progressCall) {
 	for i, c := range calls {
+		// Scanning-phase calls report total=0 (unknown at that point).
+		if c.total == 0 {
+			continue
+		}
 		if c.total != 2 {
 			t.Errorf("call[%d]: expected total=2, got %d (message: %s)", i, c.total, c.message)
 		}
@@ -411,6 +416,60 @@ func checkLastCall(t *testing.T, last progressCall) {
 	}
 	if last.current != last.total {
 		t.Errorf("last call: expected current == total, got current=%d total=%d", last.current, last.total)
+	}
+}
+
+func TestIndexer_SkipsInternalWorktrees(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Create a real git repo with one .go file.
+	main := t.TempDir()
+	gitRun(t, main, "git", "init")
+	gitRun(t, main, "git", "commit", "--allow-empty", "-m", "init")
+	writeGoFile(t, main, "main.go", "package main\nfunc Main() {}\n")
+
+	// Add a worktree INSIDE the repo directory with its own .go files.
+	internalWt := filepath.Join(main, ".worktrees", "feature")
+	gitRun(t, main, "git", "worktree", "add", internalWt)
+	writeGoFile(t, internalWt, "feature.go", "package main\nfunc Feature() {}\n")
+	writeGoFile(t, internalWt, "extra.go", "package main\nfunc Extra() {}\n")
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	stats, err := idx.Index(context.Background(), main, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only main.go should be indexed; worktree files must be excluded.
+	if stats.TotalFiles != 1 {
+		t.Errorf("expected TotalFiles=1 (main.go only), got %d", stats.TotalFiles)
+	}
+	if stats.IndexedFiles != 1 {
+		t.Errorf("expected IndexedFiles=1, got %d", stats.IndexedFiles)
+	}
+}
+
+func gitRun(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
 	}
 }
 

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -366,17 +366,13 @@ func checkFirstCall(t *testing.T, first progressCall) {
 	if first.current != 0 {
 		t.Errorf("first call: expected current=0, got %d", first.current)
 	}
-	if !strings.Contains(first.message, "Scanning") {
-		t.Errorf("first call: expected scanning message, got %q", first.message)
+	if !strings.Contains(first.message, "Found") || !strings.Contains(first.message, "files to index") {
+		t.Errorf("first call: expected 'Found ... files to index' message, got %q", first.message)
 	}
 }
 
 func checkAllCalls(t *testing.T, calls []progressCall) {
 	for i, c := range calls {
-		// Scanning-phase calls report total=0 (unknown at that point).
-		if c.total == 0 {
-			continue
-		}
 		if c.total != 2 {
 			t.Errorf("call[%d]: expected total=2, got %d (message: %s)", i, c.total, c.message)
 		}

--- a/internal/merkle/ignore.go
+++ b/internal/merkle/ignore.go
@@ -90,8 +90,9 @@ type dirIgnore struct {
 // IgnoreTree manages hierarchical ignore rules, lazily loading them as
 // filepath.WalkDir traverses directories. It is safe for concurrent use.
 type IgnoreTree struct {
-	rootDir string
-	extSet  map[string]bool
+	rootDir      string
+	extSet       map[string]bool
+	extraSkipDirs map[string]bool // relative paths of directories to always skip
 
 	mu   sync.Mutex
 	dirs map[string]*dirIgnore // keyed by relative dir path ("" = root)
@@ -142,6 +143,9 @@ func (t *IgnoreTree) loadDir(dirRel string) *dirIgnore {
 func (t *IgnoreTree) shouldSkip(relPath string, isDir bool) bool {
 	base := filepath.Base(relPath)
 	if isDir && SkipDirs[base] {
+		return true
+	}
+	if isDir && t.extraSkipDirs[relPath] {
 		return true
 	}
 	if !isDir && SkipFiles[base] {
@@ -244,6 +248,20 @@ func parseLinguistGenerated(path string) *ignore.GitIgnore {
 		return nil
 	}
 	return ignore.CompileIgnoreLines(patterns...)
+}
+
+// MakeSkipWithExtra is like MakeSkip but also skips directories whose relative
+// paths are listed in extraSkipDirs. This is used to exclude git worktrees
+// that are checked out inside the project root directory.
+func MakeSkipWithExtra(rootDir string, exts []string, extraSkipDirs []string) SkipFunc {
+	tree := NewIgnoreTree(rootDir, exts)
+	if len(extraSkipDirs) > 0 {
+		tree.extraSkipDirs = make(map[string]bool, len(extraSkipDirs))
+		for _, p := range extraSkipDirs {
+			tree.extraSkipDirs[filepath.Clean(p)] = true
+		}
+	}
+	return tree.shouldSkip
 }
 
 // MakeSkip returns a SkipFunc that layers six filters:

--- a/internal/merkle/ignore_test.go
+++ b/internal/merkle/ignore_test.go
@@ -349,6 +349,49 @@ func TestParseLinguistGenerated(t *testing.T) {
 	}
 }
 
+func TestMakeSkipWithExtra_SkipsWorktreePaths(t *testing.T) {
+	dir := t.TempDir()
+
+	extraPaths := []string{".worktrees/feature", ".worktrees/bugfix"}
+	skip := MakeSkipWithExtra(dir, []string{".go"}, extraPaths)
+
+	// Extra paths should be skipped as directories
+	if !skip(".worktrees/feature", true) {
+		t.Error("expected .worktrees/feature dir to be skipped")
+	}
+	if !skip(".worktrees/bugfix", true) {
+		t.Error("expected .worktrees/bugfix dir to be skipped")
+	}
+	// Files are not subject to the extra skip (directory pruning handles it)
+	if skip("main.go", false) {
+		t.Error("expected main.go to pass")
+	}
+	// A similarly named dir NOT in the skip list should pass
+	if skip(".worktrees/other", true) {
+		t.Error("expected .worktrees/other to pass (not in extra skip list)")
+	}
+}
+
+func TestBuildTree_SkipsInternalWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main\n")
+	writeFile(t, dir, ".worktrees/feature/main.go", "package main\n")
+	writeFile(t, dir, ".worktrees/feature/util.go", "package util\n")
+
+	skip := MakeSkipWithExtra(dir, []string{".go"}, []string{".worktrees/feature"})
+	tree, err := BuildTree(dir, skip)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tree.Files) != 1 {
+		t.Fatalf("expected 1 file (main.go only), got %d: %v", len(tree.Files), tree.Files)
+	}
+	if _, ok := tree.Files["main.go"]; !ok {
+		t.Error("expected main.go in tree")
+	}
+}
+
 func TestAncestorDirs(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -90,17 +90,21 @@ func (p *Progress) Stop() {
 }
 
 // AsProgressFunc returns a callback compatible with index.ProgressFunc.
-// The progress bar is started on the first call and stopped when
-// current reaches total.
+// Calls with total=0 print an info line; the progress bar is started on
+// the first call with total>0 and stopped when current reaches total.
 func (p *Progress) AsProgressFunc() func(current, total int, message string) {
 	started := false
 	return func(current, total int, message string) {
+		if total == 0 {
+			p.Info(message)
+			return
+		}
 		if !started {
 			p.Start("Indexing", total)
 			started = true
 		}
 		p.Update(current, message)
-		if total > 0 && current >= total {
+		if current >= total {
 			p.Stop()
 			started = false
 		}


### PR DESCRIPTION
## Summary

- Files inside git worktrees checked out under the project root (e.g. `.worktrees/feature`) were being indexed as part of the main repo, inflating file counts and polluting search results with symbols from sibling branches
- Added `git.InternalWorktreePaths` to detect nested worktrees and `merkle.MakeSkipWithExtra` to prune them during the directory walk
- Each worktree continues to get its own independent index (seeded from siblings as before)

## Test Plan

- [x] `TestMakeSkipWithExtra_SkipsWorktreePaths` — skip func excludes extra paths
- [x] `TestBuildTree_SkipsInternalWorktrees` — BuildTree prunes worktree dir
- [x] `TestInternalWorktreePaths_InternalWorktree` — detects worktree nested inside repo
- [x] `TestInternalWorktreePaths_ExternalWorktree` — ignores worktree outside repo
- [x] `TestIndexer_SkipsInternalWorktrees` — full integration with real git repo
- [x] `TestE2E_InternalWorktreeFilesExcludedFromIndex` — main repo index has correct file count, worktree symbols not findable
- [x] `TestE2E_InternalWorktreeSearchNoReindex` — searching with path inside worktree dir doesn't trigger re-index
- [x] `TestE2E_WorktreeIndexesChangedFile` — searching from inside a worktree indexes it, returns worktree's file content (not main repo's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)