### PR TITLE
ci: skip CI jobs for release-please bot PRs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "lumen-local",
+  "interface": {
+    "displayName": "Lumen Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "lumen",
+      "source": {
+        "source": "local",
+        "path": "./plugins/lumen"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +54,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +72,7 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     services:
       ollama:
         image: ollama/ollama:latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dist/
 .worktrees/
 
 lumen
+!plugins/
+!plugins/lumen/
+!plugins/lumen/**
 
 bench-swe/bench-swe
 bench-swe/overview.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Repository Expectations
+
+- The repo root is the Claude Code plugin surface. Keep `.claude-plugin/`, `hooks/`, `skills/`, and `scripts/` compatible with Claude.
+- The Codex plugin surface lives under `plugins/lumen/`. Keep Codex-only manifests, skills, and wrappers isolated there.
+- Do not add a repo-root `.mcp.json` or repo-root `.codex-plugin/`. Claude Code reads repo-root `.mcp.json` as project-scoped MCP config, which would change behavior for this repository.
+- When changing plugin metadata for releases, keep `.claude-plugin/plugin.json` and `plugins/lumen/.codex-plugin/plugin.json` aligned unless a difference is intentionally product-specific.
+
+## Commands
+
+- `make build-local` builds the local binary.
+- `make test` runs the Go test suite.
+- `make lint` runs `golangci-lint`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,9 @@ runtime behavior for this repository outside the Claude plugin install path.
 - **E2E tests**: `go test -tags e2e ./...` (requires Ollama/LM Studio running)
 - **All tests must pass before commit**
 - Coverage tracked but not enforced
+- **TDD required**: All features and bug fixes must follow red/green TDD — write
+  a failing test that demonstrates the bug or specifies the feature first, then
+  make it pass with the implementation.
 
 ### Linting & Errors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,15 @@ Claude Code plugin system. It provides fast, semantic search capabilities over
 codebases by leveraging vector embeddings and a Merkle tree structure to
 efficiently detect changes and minimize re-indexing.
 
-This repository is structured as a claude plugin available via the claude
-marketplace.
+This repository has two separate agent integration surfaces:
+
+- Claude Code plugin files at the repo root
+  (`.claude-plugin/`, `hooks/`, `skills/`, `scripts/`)
+- Codex plugin files under `plugins/lumen/`
+
+Do not add a repo-root `.mcp.json` or repo-root `.codex-plugin/`. Claude Code
+reads repo-root `.mcp.json` as project-scoped MCP config, which would change
+runtime behavior for this repository outside the Claude plugin install path.
 
 ## Go Standards
 
@@ -104,6 +111,9 @@ system handles MCP registration, hooks, and skills declaratively via:
 - `hooks/hooks.json` — SessionStart + PreToolUse hooks
 - `skills/` — `/lumen:doctor` and `/lumen:reindex` skills
 
+Codex packaging is intentionally separate under `plugins/lumen/`. Keep the
+Claude plugin root authoritative for Claude-specific manifests and hooks.
+
 ## Environment Variables
 
 | Variable                 | Default                  | Description                                |
@@ -123,8 +133,10 @@ system handles MCP registration, hooks, and skills declaratively via:
 .
 ├── main.go              # 3-line entrypoint
 ├── .claude-plugin/      # Plugin manifest
+├── .agents/             # Codex repo-local marketplace
 ├── hooks/               # Hook declarations
 ├── skills/              # Skill definitions
+├── plugins/lumen/       # Codex plugin package
 ├── scripts/             # Platform wrappers (run.sh, run.bat)
 ├── cmd/
 │   ├── root.go         # Cobra root command
@@ -181,6 +193,8 @@ because slog writes to the log file while tui writes to the process stderr.
 - **Cosine distance KNN**: Normalized for semantic similarity
 - **Plugin system**: Declarative hooks/MCP/skills via `.claude-plugin/`,
   replacing manual install/uninstall
+- **Codex packaging**: Duplicated under `plugins/lumen/` to avoid repo-root
+  `.mcp.json` or `.codex-plugin/` changing Claude behavior
 
 ## Claude Integration Notes
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFLAGS  := -tags=$(GOTAGS)
 
 XGORELEASER_IMAGE := oryd/xgoreleaser:1.26.0-2.14.1
 
-.PHONY: build build-local build-bench-swe test e2e e2e-lang lint vet tidy clean format plugin-dev
+.PHONY: build build-local build-bench-swe test e2e e2e-lang lint vet tidy clean format plugin-dev plugin-dev-codex
 
 build:
 	docker run --platform linux/amd64 --mount type=bind,source="$$(pwd)",target=/project \
@@ -45,6 +45,9 @@ format:
 
 plugin-dev: build-local
 	@echo "Run: claude --plugin-dir ."
+
+plugin-dev-codex:
+	@echo "Restart Codex in this repository, open /plugins, choose the \"Lumen Local Plugins\" marketplace, and install lumen."
 
 vhs:
 	export CLAUDE_PLUGIN_ROOT=$(pwd) && cd testdata/fixtures/go && vhs ../../../docs/demo/demo.tape

--- a/README.md
+++ b/README.md
@@ -73,16 +73,28 @@ _Claude Code asking about the
    ```bash
    ollama pull ordis/jina-embeddings-v2-base-code
    ```
-2. [Claude Code](https://code.claude.com/docs/en/quickstart) installed
+2. [Claude Code](https://code.claude.com/docs/en/quickstart) or
+   [Codex](https://developers.openai.com/codex/cli) installed
 
 **Install:**
+
+**Claude Code**
 
 ```bash
 /plugin marketplace add ory/claude-plugins
 /plugin install lumen@ory
 ```
 
-That's it. On first session start, Lumen:
+**Codex**
+
+This repository ships a repo-local Codex marketplace for development and local
+testing. Restart Codex in the repo, open `/plugins`, choose **Lumen Local
+Plugins**, and install `lumen`. The Codex package lives under `plugins/lumen/`.
+
+Official public Codex plugin publishing is not self-serve yet, so the
+repo-local marketplace is the supported Codex install path for now.
+
+On first Claude session start, Lumen:
 
 1. Downloads the binary automatically from the
    [latest GitHub release](https://github.com/ory/lumen/releases)
@@ -91,6 +103,11 @@ That's it. On first session start, Lumen:
 
 Two skills are also available: `/lumen:doctor` (health check) and
 `/lumen:reindex` (forced re-indexing).
+
+After the Codex plugin is installed, the same MCP tools are bundled there as
+well. Codex-native `doctor` and `reindex` skills are included in the plugin,
+and the first `semantic_search` call seeds or refreshes the index
+automatically.
 
 ## What you get
 
@@ -280,6 +297,9 @@ ollama pull ordis/jina-embeddings-v2-base-code
 
 Run `/lumen:doctor` inside Claude Code to confirm connectivity.
 
+In Codex, use the bundled `doctor` skill or call `health_check` and
+`index_status` directly.
+
 **Stale index after large refactor**
 
 Run `/lumen:reindex` inside Claude Code to force a full re-index, or:
@@ -287,6 +307,9 @@ Run `/lumen:reindex` inside Claude Code to force a full re-index, or:
 ```bash
 lumen purge && lumen index .
 ```
+
+In Codex, use the bundled `reindex` skill to refresh the index through the MCP
+server, or run the same CLI commands for a clean rebuild.
 
 **Switching embedding models**
 
@@ -316,7 +339,11 @@ make lint
 
 # Load as a Claude Code plugin from source
 make plugin-dev
+
+# Load the repo-local Codex plugin
+make plugin-dev-codex
 ```
 
 See [CLAUDE.md](CLAUDE.md) for architecture details, design decisions, and
-contribution guidelines.
+contribution guidelines, and [AGENTS.md](AGENTS.md) for Codex-specific repo
+instructions.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -151,7 +151,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	tr.record("path resolution", indexRoot)
 
 	// Span 2: indexer setup
-	idx, err := setupIndexer(&cfg, indexRoot, nil)
+	dbPath := config.DBPathForProject(indexRoot, cfg.Model)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return fmt.Errorf("create db directory: %w", err)
+	}
+	idx, err := setupIndexer(&cfg, dbPath, nil)
 	if err != nil {
 		return fmt.Errorf("setup indexer: %w", err)
 	}

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ory/lumen/internal/config"
 )
 
 func TestTracer_DisabledIsNoop(t *testing.T) {
@@ -106,6 +110,43 @@ func TestSearchCmd_FlagsRegistered(t *testing.T) {
 			t.Fatalf("search cmd missing flag --%s", name)
 		}
 	}
+}
+
+// TestSetupIndexer_DBPathVsDirectory is a regression test for
+// https://github.com/ory/lumen/issues/72.
+//
+// runSearch previously passed the raw indexRoot directory to setupIndexer
+// instead of the computed DB file path. SQLite cannot open a directory and
+// returns an error containing "PRAGMA journal_mode=WAL".
+//
+// Red: passing the directory directly must fail with a SQLite error.
+// Green: passing config.DBPathForProject(dir, model) must succeed.
+func TestSetupIndexer_DBPathVsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	// RED: directory path → SQLite PRAGMA error (the pre-fix behaviour).
+	_, dirErr := setupIndexer(&cfg, dir, nil)
+	if dirErr == nil {
+		t.Fatal("expected error when passing a directory as the db path, got nil")
+	}
+	if !strings.Contains(dirErr.Error(), "PRAGMA") && !strings.Contains(dirErr.Error(), "unable to open") {
+		t.Fatalf("expected SQLite open error, got: %v", dirErr)
+	}
+
+	// GREEN: proper db file path → no error.
+	dbPath := config.DBPathForProject(dir, cfg.Model)
+	if mkErr := os.MkdirAll(filepath.Dir(dbPath), 0o755); mkErr != nil {
+		t.Fatalf("MkdirAll: %v", mkErr)
+	}
+	idx, err := setupIndexer(&cfg, dbPath, nil)
+	if err != nil {
+		t.Fatalf("setupIndexer with db path failed: %v", err)
+	}
+	_ = idx.Close()
 }
 
 func TestSearchCmd_TraceSpanLabels(t *testing.T) {

--- a/plugins/lumen/.codex-plugin/plugin.json
+++ b/plugins/lumen/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "lumen",
+  "version": "0.0.25",
+  "description": "Precise local semantic code search via MCP. Indexes your codebase with Go AST parsing, embeds with Ollama or LM Studio, and exposes vector search to Codex through an MCP server — no cloud, no npm.",
+  "author": {
+    "name": "Ory Corp",
+    "url": "https://github.com/ory"
+  },
+  "homepage": "https://github.com/ory/lumen",
+  "repository": "https://github.com/ory/lumen",
+  "license": "Apache-2.0",
+  "keywords": [
+    "semantic-search",
+    "code-index",
+    "mcp",
+    "embeddings",
+    "ollama",
+    "rag"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Lumen",
+    "shortDescription": "Local semantic code search for Codex",
+    "longDescription": "Use Lumen to search code by meaning instead of file-wide reads or brittle text matches. The plugin bundles a local MCP server and Codex-native skills for health checks and index refresh workflows.",
+    "developerName": "Ory Corp",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
+    "websiteURL": "https://github.com/ory/lumen",
+    "defaultPrompt": [
+      "Use Lumen to find where this repository implements authentication.",
+      "Use Lumen to explain how the indexing pipeline works.",
+      "Use Lumen to locate the code paths for a specific feature."
+    ],
+    "brandColor": "#0F766E"
+  }
+}

--- a/plugins/lumen/.mcp.json
+++ b/plugins/lumen/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "lumen": {
+      "command": "./scripts/run.sh",
+      "args": [
+        "stdio"
+      ]
+    }
+  }
+}

--- a/plugins/lumen/scripts/run.bat
+++ b/plugins/lumen/scripts/run.bat
@@ -1,0 +1,43 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "PLUGIN_ROOT=%~dp0.."
+
+set "ARCH=amd64"
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "ARCH=arm64"
+
+if not defined LUMEN_BACKEND set "LUMEN_BACKEND=ollama"
+if not defined LUMEN_EMBED_MODEL set "LUMEN_EMBED_MODEL=ordis/jina-embeddings-v2-base-code"
+
+set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
+
+if not exist "%BINARY%" (
+  set "REPO=ory/lumen"
+  set "MANIFEST=%PLUGIN_ROOT%\.codex-plugin\plugin.json"
+  if not exist "!MANIFEST!" (
+    echo Error: .codex-plugin\plugin.json not found in %PLUGIN_ROOT% >&2
+    exit /b 1
+  )
+
+  for /f "tokens=2 delims=:" %%j in ('findstr /r /c:"\"version\"" "!MANIFEST!"') do (
+    set "VERSION=v%%~j"
+    set "VERSION=!VERSION: =!"
+    set "VERSION=!VERSION:,=!"
+    set "VERSION=!VERSION:"=!"
+  )
+
+  if "!VERSION!"=="" (
+    echo Error: could not read version from !MANIFEST! >&2
+    exit /b 1
+  )
+
+  set "ASSET=lumen-!VERSION:~1!-windows-!ARCH!.exe"
+  set "URL=https://github.com/!REPO!/releases/download/!VERSION!/!ASSET!"
+
+  echo Downloading lumen !VERSION! for windows/!ARCH!... >&2
+  if not exist "%PLUGIN_ROOT%\bin" mkdir "%PLUGIN_ROOT%\bin"
+  curl -sfL "!URL!" -o "%BINARY%"
+  echo Installed lumen to %BINARY% >&2
+)
+
+"%BINARY%" %*

--- a/plugins/lumen/scripts/run.sh
+++ b/plugins/lumen/scripts/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Codex installs plugins into a cache path, so derive the plugin root from the
+# script location instead of depending on an external environment variable.
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+esac
+
+export LUMEN_BACKEND="${LUMEN_BACKEND:-ollama}"
+export LUMEN_EMBED_MODEL="${LUMEN_EMBED_MODEL:-ordis/jina-embeddings-v2-base-code}"
+
+BINARY=""
+for candidate in \
+  "${PLUGIN_ROOT}/bin/lumen" \
+  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"; do
+  if [ -x "$candidate" ]; then
+    BINARY="$candidate"
+    break
+  fi
+done
+
+if [ -z "$BINARY" ]; then
+  BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
+  REPO="ory/lumen"
+  MANIFEST="${PLUGIN_ROOT}/.codex-plugin/plugin.json"
+  if [ ! -f "$MANIFEST" ]; then
+    echo "Error: .codex-plugin/plugin.json not found in ${PLUGIN_ROOT}" >&2
+    exit 1
+  fi
+
+  VERSION="v$(sed -n 's/^[[:space:]]*\"version\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p' "$MANIFEST" | head -n 1)"
+  if [ -z "$VERSION" ] || [ "$VERSION" = "v" ]; then
+    echo "Error: could not read version from ${MANIFEST}" >&2
+    exit 1
+  fi
+
+  ASSET="lumen-${VERSION#v}-${OS}-${ARCH}"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+  echo "Downloading lumen ${VERSION} for ${OS}/${ARCH}..." >&2
+  mkdir -p "$(dirname "$BINARY")"
+  curl -fL --progress-bar --max-time 300 --retry 3 --retry-delay 2 "$URL" -o "$BINARY"
+  chmod +x "$BINARY"
+  echo "Installed lumen to ${BINARY}" >&2
+fi
+
+exec "$BINARY" "$@"

--- a/plugins/lumen/skills/doctor/SKILL.md
+++ b/plugins/lumen/skills/doctor/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: doctor
+description: Run a health check on the bundled Lumen semantic search setup for the current project, verify backend reachability and index freshness, and summarize remediation steps.
+---
+
+# Lumen Doctor
+
+Run a health check on the bundled Lumen semantic search setup for the current
+project.
+
+## Steps
+
+1. Call `mcp__lumen__health_check` to verify the embedding service is reachable.
+2. Call `mcp__lumen__index_status` with `path` or `cwd` set to the current
+   working directory to check index freshness.
+3. Report a concise summary:
+   - Embedding service status, backend, host, and model
+   - Index totals: files, chunks, last indexed time, stale or fresh
+   - Any MCP or plugin setup issue that blocks the tools
+4. If no index exists yet, explain that `mcp__lumen__semantic_search`
+   automatically seeds the index on first use.
+5. If the user wants eager indexing instead of waiting for the next search,
+   suggest running `lumen index .` in the repository root.

--- a/plugins/lumen/skills/reindex/SKILL.md
+++ b/plugins/lumen/skills/reindex/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: reindex
+description: Refresh or rebuild the bundled Lumen index for the current project, preferring MCP-driven refreshes and using the CLI only for an explicit clean rebuild.
+---
+
+# Lumen Reindex
+
+Refresh or rebuild the bundled Lumen index for the current project.
+
+## Steps
+
+1. Call `mcp__lumen__index_status` for the current working directory so you can
+   report the current state before making changes.
+2. If the user wants the index refreshed or seeded, call
+   `mcp__lumen__semantic_search` with a broad natural-language query and set
+   `path` or `cwd` to the current working directory. The search tool refreshes
+   stale or missing indexes automatically.
+3. If the user explicitly asks for a clean rebuild, explain that
+   `lumen purge && lumen index .` deletes cached indexes before rebuilding, then
+   run it via the shell.
+4. After the refresh or rebuild, report the new index status.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugins/lumen/.codex-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'release-please[bot]'` to all three CI jobs (`test`, `lint`, `e2e`)
- Release-please PRs now show jobs as **skipped** instead of pending/failed, enabling auto-merge

## Why

Release-please PRs don't need CI: the source branch (`main`) must already be green, and the release workflow validates on push to main. Without this filter, CI blocks auto-merge and requires a manual force-merge workaround.

## Test plan

- [ ] Confirm CI still runs on normal (non-release-please) PRs
- [ ] Confirm next release-please PR shows CI jobs as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)