### PR TITLE
ci: skip CI jobs for release-please bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +54,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +72,7 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
     services:
       ollama:
         image: ollama/ollama:latest


### PR DESCRIPTION
Add `if: github.actor != 'release-please[bot]'` to all three jobs (test, lint, e2e) so CI is skipped on automated release PRs. The source branch must already be green before release-please opens a PR, and the release workflow validates on push to main.