### PR TITLE
feat: add LUMEN_EMBED_DIMS/LUMEN_EMBED_CTX escape hatch for custom models

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,14 +58,26 @@ func Load() (Config, error) {
 	}
 
 	model := EnvOrDefault("LUMEN_EMBED_MODEL", defaultModel)
-	spec, ok := embedder.KnownModels[model]
-	if !ok {
-		return Config{}, fmt.Errorf("unknown embedding model %q", model)
+
+	// Allow fully custom models via LUMEN_EMBED_DIMS + LUMEN_EMBED_CTX,
+	// bypassing the KnownModels registry. Useful for any OpenAI-compat server.
+	var dims, ctxLength int
+	if d := EnvOrDefaultInt("LUMEN_EMBED_DIMS", 0); d > 0 {
+		dims = d
+		ctxLength = EnvOrDefaultInt("LUMEN_EMBED_CTX", 8192)
+	} else {
+		spec, ok := embedder.KnownModels[model]
+		if !ok {
+			return Config{}, fmt.Errorf("unknown embedding model %q: set LUMEN_EMBED_DIMS to use an unlisted model", model)
+		}
+		dims = spec.Dims
+		ctxLength = spec.CtxLength
 	}
+
 	return Config{
 		Model:          model,
-		Dims:           spec.Dims,
-		CtxLength:      spec.CtxLength,
+		Dims:           dims,
+		CtxLength:      ctxLength,
 		MaxChunkTokens: EnvOrDefaultInt("LUMEN_MAX_CHUNK_TOKENS", 512),
 		OllamaHost:     EnvOrDefault("OLLAMA_HOST", "http://localhost:11434"),
 		Backend:        backend,

--- a/internal/embedder/models_test.go
+++ b/internal/embedder/models_test.go
@@ -44,6 +44,7 @@ func TestKnownModels(t *testing.T) {
 	}
 }
 
+
 func TestDefaultModelInRegistry(t *testing.T) {
 	if _, ok := KnownModels[DefaultModel]; !ok {
 		t.Errorf("DefaultModel %q is not in KnownModels", DefaultModel)


### PR DESCRIPTION
## Summary

- Adds `LUMEN_EMBED_DIMS` and `LUMEN_EMBED_CTX` env vars that bypass the `KnownModels` registry
- When `LUMEN_EMBED_DIMS` is set, `LUMEN_EMBED_MODEL` can be any model name served by the existing `lmstudio` or `ollama` backends — no source changes needed
- Unlisted models (quantized MLX variants, local fine-tunes, models on non-standard ports) now work without forking

## Motivation

The current registry hard-fail (`unknown embedding model %q`) blocks users running models that are functionally compatible but not yet listed in `KnownModels`. For example, `mlx-community/Qwen3-Embedding-8B-4bit-DWQ` served via an OpenAI-compatible server produces valid 4096-dim embeddings but isn't in the registry.

## Usage

```sh
# Any OpenAI-compat server (omlx, vLLM, LocalAI, etc.)
LUMEN_BACKEND=lmstudio
LM_STUDIO_HOST=http://localhost:8801
LUMEN_EMBED_MODEL=Qwen3-Embedding-8B-4bit-DWQ
LUMEN_EMBED_DIMS=4096
LUMEN_EMBED_CTX=40960   # optional, defaults to 8192
```

The registry is still used when `LUMEN_EMBED_DIMS` is not set — no behaviour change for existing users.

## Test plan

- [ ] `go test ./internal/config/...` passes with and without `LUMEN_EMBED_DIMS` set
- [ ] `lumen index` with an unlisted model name + `LUMEN_EMBED_DIMS` indexes successfully
- [ ] `lumen index` with an unlisted model name but no `LUMEN_EMBED_DIMS` still returns the helpful error message