### PR TITLE
fix(index): prevent triple indexing when non-git parent contains git repos

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/store"
 )
 
@@ -114,6 +115,12 @@ func generateSessionContext(mcpName, cwd string) string {
 func generateSessionContextInternal(mcpName, cwd string, findDonor func(string, string) string, bgIndexer func(string)) string {
 	toolRef := "mcp__" + mcpName + "__semantic_search"
 	directive := "Call " + toolRef + " first for any code discovery task — before Grep, Bash, or Read."
+
+	// Normalize cwd to the git repository root so the DB path matches what
+	// `lumen index` and the MCP handler use.
+	if root, err := git.RepoRoot(cwd); err == nil {
+		cwd = root
+	}
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -301,6 +302,61 @@ func TestGenerateSessionContextInternal_MessageWithoutDonor(t *testing.T) {
 	)
 	if !strings.Contains(result, "background") {
 		t.Errorf("expected 'background' in context when no donor, got: %s", result)
+	}
+}
+
+func TestGenerateSessionContextInternal_NormalizesToGitRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	// Create a git repo with a subdirectory.
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(filepath.Join(repoDir, "sub", "deep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	// Create a DB for the git root so the hook finds it.
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	// Resolve symlinks to match what git rev-parse --show-toplevel returns.
+	resolvedRepo, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbPath := config.DBPathForProject(resolvedRepo, cfg.Model)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeHookTestDB(t, dbPath, time.Now().Add(-30*time.Second))
+
+	// Pass a subdirectory as cwd — the hook should normalize to the git root
+	// and find the existing DB.
+	subDir := filepath.Join(resolvedRepo, "sub", "deep")
+	result := generateSessionContextInternal("lumen", subDir,
+		func(_, _ string) string { return "" },
+		func(_ string) {},
+	)
+
+	// The result should contain "index ready" because the DB exists at the git root.
+	if !strings.Contains(result, "index ready") {
+		t.Errorf("expected hook to normalize cwd to git root and find index, got: %s", result)
 	}
 }
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ory/lumen/internal/config"
 	"github.com/ory/lumen/internal/embedder"
+	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/index"
 	"github.com/ory/lumen/internal/indexlock"
 	"github.com/ory/lumen/internal/tui"
@@ -63,6 +64,24 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	projectPath, err := filepath.Abs(args[0])
 	if err != nil {
 		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	// Normalize to the git repository root when inside a git repo so that
+	// indexing a subdirectory produces the same DB as indexing the repo root.
+	if root, err := git.RepoRoot(projectPath); err == nil {
+		projectPath = root
+	}
+
+	// When the project directory is not a git repo, discover nested git repos
+	// and index each one separately before indexing the parent (which will
+	// only contain "loose" files not belonging to any nested repo).
+	if nestedRepos := git.DiscoverNestedGitRepos(projectPath); len(nestedRepos) > 0 {
+		for _, repo := range nestedRepos {
+			if err := indexSingleProject(cmd, cfg, repo, logger); err != nil {
+				logger.Error("indexing nested repo failed", "repo", repo, "err", err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to index nested repo %s: %v\n", repo, err)
+			}
+		}
 	}
 
 	dbPath := config.DBPathForProject(projectPath, cfg.Model)
@@ -178,6 +197,58 @@ func setupIndexer(cfg *config.Config, dbPath string, logger *slog.Logger) (*inde
 	}
 	idx.SetLogger(logger)
 	return idx, nil
+}
+
+// indexSingleProject indexes a single project path with its own DB, lock, and
+// indexer. Used to auto-index nested git repos discovered in a non-git parent.
+func indexSingleProject(cmd *cobra.Command, cfg config.Config, projectPath string, logger *slog.Logger) error {
+	dbPath := config.DBPathForProject(projectPath, cfg.Model)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return fmt.Errorf("create db directory: %w", err)
+	}
+
+	lockPath := indexlock.LockPathForDB(dbPath)
+	lock, err := indexlock.TryAcquire(lockPath)
+	if err != nil {
+		return fmt.Errorf("acquire index lock: %w", err)
+	}
+	if lock == nil {
+		logger.Info("index skipped: another indexer is already running", "project", projectPath)
+		fmt.Fprintf(os.Stderr, "Skipping %s: another indexer is already running.\n", projectPath)
+		return nil
+	}
+	defer lock.Release()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	idx, err := setupIndexer(&cfg, dbPath, logger)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = idx.Close() }()
+
+	logger.Info("indexing nested repo", "project", projectPath, "model", cfg.Model)
+	p := tui.NewProgress(os.Stderr)
+	p.Info(fmt.Sprintf("Indexing nested repo %s", projectPath))
+
+	start := time.Now()
+	stats, err := performIndexing(ctx, cmd, idx, projectPath, p)
+	if err != nil {
+		if ctx.Err() != nil {
+			logger.Info("indexing cancelled by signal", "project", projectPath)
+			return nil
+		}
+		return err
+	}
+
+	elapsed := time.Since(start).Round(time.Millisecond)
+	logger.Info("nested repo indexed", "project", projectPath,
+		"indexed_files", stats.IndexedFiles, "chunks_created", stats.ChunksCreated,
+		"elapsed", elapsed.String())
+	fmt.Printf("Nested repo %s: %d files, %d chunks in %s.\n",
+		projectPath, stats.IndexedFiles, stats.ChunksCreated, elapsed)
+	return nil
 }
 
 func performIndexing(ctx context.Context, cmd *cobra.Command, idx *index.Indexer, projectPath string, p *tui.Progress) (index.Stats, error) {

--- a/e2e_cli_test.go
+++ b/e2e_cli_test.go
@@ -29,6 +29,28 @@ import (
 	"github.com/ory/lumen/internal/config"
 )
 
+// gitSampleProject copies testdata/sample-project into a temp directory and
+// initialises a git repo so that RepoRoot resolves to the temp dir itself
+// (not the parent lumen repo).
+func gitSampleProject(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	copyDir(t, sampleProjectPath(t), tmp)
+	for _, args := range [][]string{
+		{"init"},
+		{"add", "."},
+		{"commit", "-m", "init", "--allow-empty"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmp
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	return tmp
+}
+
 // runCLI runs the lumen binary with the given args and returns stdout, stderr, and any error.
 func runCLI(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
@@ -65,7 +87,7 @@ func runCLIWithDataHome(t *testing.T, dataHome string, args ...string) (stdout, 
 
 func TestE2E_CLI_IndexIdempotent(t *testing.T) {
 	t.Parallel()
-	projectPath := sampleProjectPath(t)
+	projectPath := gitSampleProject(t)
 	dataHome := t.TempDir()
 
 	// First index.
@@ -86,7 +108,7 @@ func TestE2E_CLI_IndexIdempotent(t *testing.T) {
 
 func TestE2E_CLI_IndexForceReindex(t *testing.T) {
 	t.Parallel()
-	projectPath := sampleProjectPath(t)
+	projectPath := gitSampleProject(t)
 	dataHome := t.TempDir()
 
 	// First index.
@@ -123,7 +145,7 @@ func openIndexDB(t *testing.T, dataHome, projectPath string) *sql.DB {
 
 func TestE2E_CLI_SQLVerifySchema(t *testing.T) {
 	t.Parallel()
-	projectPath := sampleProjectPath(t)
+	projectPath := gitSampleProject(t)
 	dataHome := t.TempDir()
 
 	// Index first.
@@ -323,7 +345,7 @@ func TestE2E_CLI_SQLVerifySchema(t *testing.T) {
 
 func TestE2E_CLI_SQLVerifyKNN(t *testing.T) {
 	t.Parallel()
-	projectPath := sampleProjectPath(t)
+	projectPath := gitSampleProject(t)
 	dataHome := t.TempDir()
 
 	// Index the project.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -115,6 +115,42 @@ func RepoRoot(projectPath string) (string, error) {
 	return root, nil
 }
 
+// IsGitRoot reports whether path is a git repository or worktree root
+// (i.e. contains a .git directory or .git file).
+func IsGitRoot(path string) bool {
+	_, err := os.Lstat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+// DiscoverNestedGitRepos walks rootPath and returns absolute paths of all
+// nested directories that are git repo roots. It stops descending into
+// discovered repos. Returns nil if rootPath is itself a git root or contains
+// no nested repos.
+func DiscoverNestedGitRepos(rootPath string) []string {
+	if IsGitRoot(rootPath) {
+		return nil
+	}
+
+	var repos []string
+	_ = filepath.WalkDir(rootPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return filepath.SkipDir
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path == rootPath {
+			return nil
+		}
+		if IsGitRoot(path) {
+			repos = append(repos, path)
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	return repos
+}
+
 // ListWorktrees returns the absolute paths of all worktrees (including the
 // main working tree) for the repository containing projectPath. Returns nil
 // if git is not available or projectPath is not inside a git repository.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -178,6 +178,150 @@ func TestListWorktrees_NotARepo(t *testing.T) {
 	}
 }
 
+func TestIsGitRoot_WithGitDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !IsGitRoot(dir) {
+		t.Fatal("expected true for directory with .git dir")
+	}
+}
+
+func TestIsGitRoot_WithGitFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /some/path\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !IsGitRoot(dir) {
+		t.Fatal("expected true for directory with .git file (worktree)")
+	}
+}
+
+func TestIsGitRoot_NoGit(t *testing.T) {
+	dir := t.TempDir()
+	if IsGitRoot(dir) {
+		t.Fatal("expected false when no .git exists")
+	}
+}
+
+func TestDiscoverNestedGitRepos_FindsNestedRepos(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Create a non-git parent with two git sub-repos.
+	parent := t.TempDir()
+	repoA := filepath.Join(parent, "sub-a")
+	repoB := filepath.Join(parent, "sub-b")
+	if err := os.Mkdir(repoA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(repoB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, repoA, "git", "init")
+	run(t, repoB, "git", "init")
+
+	repos := DiscoverNestedGitRepos(parent)
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 nested repos, got %d: %v", len(repos), repos)
+	}
+
+	// Resolve symlinks for comparison.
+	resolvedA, _ := filepath.EvalSymlinks(repoA)
+	resolvedB, _ := filepath.EvalSymlinks(repoB)
+	want := map[string]bool{resolvedA: true, resolvedB: true}
+	for _, r := range repos {
+		resolved, _ := filepath.EvalSymlinks(r)
+		if !want[resolved] {
+			t.Errorf("unexpected repo path %q", r)
+		}
+	}
+}
+
+func TestDiscoverNestedGitRepos_SkipsWhenRootIsGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Parent is itself a git repo — should return nil.
+	parent := t.TempDir()
+	run(t, parent, "git", "init")
+
+	sub := filepath.Join(parent, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, sub, "git", "init")
+
+	repos := DiscoverNestedGitRepos(parent)
+	if len(repos) != 0 {
+		t.Fatalf("expected nil when root is a git repo, got %v", repos)
+	}
+}
+
+func TestDiscoverNestedGitRepos_DeeplyNested(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Non-git parent, with a git repo nested two levels deep.
+	parent := t.TempDir()
+	deep := filepath.Join(parent, "a", "b", "repo")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, deep, "git", "init")
+
+	repos := DiscoverNestedGitRepos(parent)
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 nested repo, got %d: %v", len(repos), repos)
+	}
+
+	resolved, _ := filepath.EvalSymlinks(deep)
+	got, _ := filepath.EvalSymlinks(repos[0])
+	if got != resolved {
+		t.Errorf("expected %q, got %q", resolved, got)
+	}
+}
+
+func TestDiscoverNestedGitRepos_NoNestedRepos(t *testing.T) {
+	parent := t.TempDir()
+	repos := DiscoverNestedGitRepos(parent)
+	if len(repos) != 0 {
+		t.Fatalf("expected nil for directory with no nested repos, got %v", repos)
+	}
+}
+
+func TestDiscoverNestedGitRepos_DoesNotDescendIntoGitRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Non-git parent with a git repo that itself contains another git repo.
+	// Only the outer one should be discovered.
+	parent := t.TempDir()
+	outer := filepath.Join(parent, "outer")
+	inner := filepath.Join(outer, "inner")
+	if err := os.MkdirAll(inner, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, outer, "git", "init")
+	run(t, inner, "git", "init")
+
+	repos := DiscoverNestedGitRepos(parent)
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo (outer only), got %d: %v", len(repos), repos)
+	}
+
+	resolved, _ := filepath.EvalSymlinks(outer)
+	got, _ := filepath.EvalSymlinks(repos[0])
+	if got != resolved {
+		t.Errorf("expected %q, got %q", resolved, got)
+	}
+}
+
 func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -135,9 +135,18 @@ func (idx *Indexer) Close() error {
 	return idx.store.Close()
 }
 
-// makeSkip returns a SkipFunc for projectDir that excludes internal worktrees.
+// makeSkip returns a SkipFunc for projectDir that excludes internal worktrees
+// and, when projectDir is not itself a git repository, any nested git repos.
 func makeSkip(projectDir string) merkle.SkipFunc {
-	return merkle.MakeSkipWithExtra(projectDir, chunker.SupportedExtensions(), git.InternalWorktreePaths(projectDir))
+	extraSkip := git.InternalWorktreePaths(projectDir)
+	if !git.IsGitRoot(projectDir) {
+		for _, repoPath := range git.DiscoverNestedGitRepos(projectDir) {
+			if rel, err := filepath.Rel(projectDir, repoPath); err == nil {
+				extraSkip = append(extraSkip, rel)
+			}
+		}
+	}
+	return merkle.MakeSkipWithExtra(projectDir, chunker.SupportedExtensions(), extraSkip)
 }
 
 // Index indexes the project at projectDir. If force is true, all files are

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -879,6 +879,61 @@ func TestIndex_SkipsBinaryFiles(t *testing.T) {
 	}
 }
 
+func TestIndexer_SkipsNestedGitReposInNonGitParent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Create a non-git parent with a loose file and a nested git repo with its own file.
+	parent := t.TempDir()
+	writeGoFile(t, parent, "loose.go", `package loose
+
+func Loose() {}
+`)
+
+	nestedRepo := filepath.Join(parent, "nested-repo")
+	if err := os.Mkdir(nestedRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = nestedRepo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+	writeGoFile(t, nestedRepo, "nested.go", `package nested
+
+func Nested() {}
+`)
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	stats, err := idx.Index(context.Background(), parent, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the loose file should be indexed — nested git repo files should be skipped.
+	if stats.IndexedFiles != 1 {
+		t.Fatalf("expected 1 indexed file (loose.go only), got %d", stats.IndexedFiles)
+	}
+
+	// Verify the indexed file is loose.go, not nested.go.
+	results, err := idx.Search(context.Background(), parent, []float32{0.1, 0.1, 0.1, 0.1}, 10, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if strings.Contains(r.FilePath, "nested-repo") {
+			t.Errorf("nested repo file should not be indexed, found: %s", r.FilePath)
+		}
+	}
+}
+
 func writeGoFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary

- When indexing a non-git parent directory, nested git repos are now **skipped** in the merkle walk to prevent duplicate file indexing
- `lumen index <non-git-parent>` **auto-discovers** nested git repos and creates separate indexes for each
- Both `cmd/index.go` and `cmd/hook.go` now **normalize paths to the git root**, ensuring consistent DB paths across entry points

Closes #71

## Test plan

- [x] `TestDiscoverNestedGitRepos_*` — 5 tests covering: finds nested repos, skips when root is git, deeply nested, no nested repos, does not descend into git repo
- [x] `TestIsGitRoot_*` — 3 tests covering: git dir, git file (worktree), no git
- [x] `TestIndexer_SkipsNestedGitReposInNonGitParent` — verifies only loose files indexed, nested repo files excluded
- [x] `TestGenerateSessionContextInternal_NormalizesToGitRoot` — verifies hook finds existing index when cwd is a subdirectory
- [x] All existing tests pass (`go test ./...`)
- [x] Linter clean (`golangci-lint run` — 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)