### PR TITLE
fix: skip permission-denied files instead of aborting index/search

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -75,69 +75,41 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	// When the project directory is not a git repo, discover nested git repos
 	// and index each one separately before indexing the parent (which will
 	// only contain "loose" files not belonging to any nested repo).
-	if nestedRepos := git.DiscoverNestedGitRepos(projectPath); len(nestedRepos) > 0 {
-		for _, repo := range nestedRepos {
-			if err := indexSingleProject(cmd, cfg, repo, logger); err != nil {
-				logger.Error("indexing nested repo failed", "repo", repo, "err", err)
-				fmt.Fprintf(os.Stderr, "Warning: failed to index nested repo %s: %v\n", repo, err)
-			}
+	for _, repo := range git.DiscoverNestedGitRepos(projectPath) {
+		p := tui.NewProgress(os.Stderr)
+		p.Info(fmt.Sprintf("Indexing nested repo %s", repo))
+		stats, elapsed, skipped, err := runIndexer(cmd, &cfg, repo, p, logger)
+		switch {
+		case err != nil:
+			logger.Error("indexing nested repo failed", "repo", repo, "err", err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to index nested repo %s: %v\n", repo, err)
+		case skipped:
+			logger.Info("index skipped: another indexer is already running", "project", repo)
+			fmt.Fprintf(os.Stderr, "Skipping %s: another indexer is already running.\n", repo)
+		default:
+			logger.Info("nested repo indexed", "project", repo,
+				"indexed_files", stats.IndexedFiles, "chunks_created", stats.ChunksCreated,
+				"elapsed", elapsed.String())
+			fmt.Printf("Nested repo %s: %d files, %d chunks in %s.\n", repo, stats.IndexedFiles, stats.ChunksCreated, elapsed)
 		}
 	}
 
-	dbPath := config.DBPathForProject(projectPath, cfg.Model)
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
-		return fmt.Errorf("create db directory: %w", err)
-	}
-
-	lockPath := indexlock.LockPathForDB(dbPath)
-	lock, err := indexlock.TryAcquire(lockPath)
+	p := tui.NewProgress(os.Stderr)
+	logger.Info("indexing started", "project", projectPath, "model", cfg.Model, "dims", cfg.Dims)
+	p.Info(fmt.Sprintf("Indexing %s (model: %s, dims: %d)", projectPath, cfg.Model, cfg.Dims))
+	stats, elapsed, skipped, err := runIndexer(cmd, &cfg, projectPath, p, logger)
 	if err != nil {
-		return fmt.Errorf("acquire index lock: %w", err)
+		logger.Error("indexing failed", "project", projectPath, "err", err)
+		return err
 	}
-	if lock == nil {
-		// Another indexer is already running for this project — skip silently.
-		// This is the normal case when multiple Claude terminals are open.
+	if skipped {
 		logger.Info("index skipped: another indexer is already running", "project", projectPath)
 		fmt.Fprintln(os.Stderr, "Another indexer is already running for this project. Skipping.")
 		return nil
 	}
-	defer lock.Release()
 
-	// Cancel context on SIGTERM or SIGINT so the indexer stops cleanly and
-	// the deferred lock.Release() runs before exit.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
-	idx, err := setupIndexer(&cfg, dbPath, logger)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = idx.Close() }()
-
-	logger.Info("indexing started", "project", projectPath, "model", cfg.Model, "dims", cfg.Dims)
-	p := tui.NewProgress(os.Stderr)
-	p.Info(fmt.Sprintf("Indexing %s (model: %s, dims: %d)", projectPath, cfg.Model, cfg.Dims))
-
-	start := time.Now()
-	stats, err := performIndexing(ctx, cmd, idx, projectPath, p)
-	if err != nil {
-		if ctx.Err() != nil {
-			// A signal arrived; treat as clean exit. If an unrelated error
-			// also occurred in the same instant, it is intentionally dropped —
-			// the cancellation is the primary cause and the lock will be released.
-			logger.Info("indexing cancelled by signal", "project", projectPath)
-			return nil
-		}
-		logger.Error("indexing failed", "project", projectPath, "err", err)
-		return err
-	}
-
-	elapsed := time.Since(start).Round(time.Millisecond)
 	if stats.Reason == "already fresh" {
-		logger.Info("index already fresh",
-			"project", projectPath,
-			"elapsed", elapsed.String(),
-		)
+		logger.Info("index already fresh", "project", projectPath, "elapsed", elapsed.String())
 	} else {
 		logger.Info("indexing complete",
 			"project", projectPath,
@@ -199,56 +171,49 @@ func setupIndexer(cfg *config.Config, dbPath string, logger *slog.Logger) (*inde
 	return idx, nil
 }
 
-// indexSingleProject indexes a single project path with its own DB, lock, and
-// indexer. Used to auto-index nested git repos discovered in a non-git parent.
-func indexSingleProject(cmd *cobra.Command, cfg config.Config, projectPath string, logger *slog.Logger) error {
+// runIndexer acquires the index lock for projectPath, runs performIndexing, and
+// returns the stats and elapsed time. skipped is true when another indexer holds
+// the lock. err is nil if indexing was cancelled by a signal.
+func runIndexer(cmd *cobra.Command, cfg *config.Config, projectPath string, p *tui.Progress, logger *slog.Logger) (stats index.Stats, elapsed time.Duration, skipped bool, err error) {
 	dbPath := config.DBPathForProject(projectPath, cfg.Model)
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
-		return fmt.Errorf("create db directory: %w", err)
+	if mkErr := os.MkdirAll(filepath.Dir(dbPath), 0o755); mkErr != nil {
+		err = fmt.Errorf("create db directory: %w", mkErr)
+		return
 	}
 
 	lockPath := indexlock.LockPathForDB(dbPath)
-	lock, err := indexlock.TryAcquire(lockPath)
-	if err != nil {
-		return fmt.Errorf("acquire index lock: %w", err)
+	lock, lockErr := indexlock.TryAcquire(lockPath)
+	if lockErr != nil {
+		err = fmt.Errorf("acquire index lock: %w", lockErr)
+		return
 	}
 	if lock == nil {
-		logger.Info("index skipped: another indexer is already running", "project", projectPath)
-		fmt.Fprintf(os.Stderr, "Skipping %s: another indexer is already running.\n", projectPath)
-		return nil
+		skipped = true
+		return
 	}
 	defer lock.Release()
 
+	// Cancel context on SIGTERM or SIGINT so the indexer stops cleanly and
+	// the deferred lock.Release() runs before exit.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	idx, err := setupIndexer(&cfg, dbPath, logger)
-	if err != nil {
-		return err
+	idx, setupErr := setupIndexer(cfg, dbPath, logger)
+	if setupErr != nil {
+		err = setupErr
+		return
 	}
 	defer func() { _ = idx.Close() }()
 
-	logger.Info("indexing nested repo", "project", projectPath, "model", cfg.Model)
-	p := tui.NewProgress(os.Stderr)
-	p.Info(fmt.Sprintf("Indexing nested repo %s", projectPath))
-
 	start := time.Now()
-	stats, err := performIndexing(ctx, cmd, idx, projectPath, p)
-	if err != nil {
-		if ctx.Err() != nil {
-			logger.Info("indexing cancelled by signal", "project", projectPath)
-			return nil
-		}
-		return err
+	stats, err = performIndexing(ctx, cmd, idx, projectPath, p)
+	elapsed = time.Since(start).Round(time.Millisecond)
+	if err != nil && ctx.Err() != nil {
+		// A signal arrived; treat as clean exit.
+		logger.Info("indexing cancelled by signal", "project", projectPath)
+		err = nil
 	}
-
-	elapsed := time.Since(start).Round(time.Millisecond)
-	logger.Info("nested repo indexed", "project", projectPath,
-		"indexed_files", stats.IndexedFiles, "chunks_created", stats.ChunksCreated,
-		"elapsed", elapsed.String())
-	fmt.Printf("Nested repo %s: %d files, %d chunks in %s.\n",
-		projectPath, stats.IndexedFiles, stats.ChunksCreated, elapsed)
-	return nil
+	return
 }
 
 func performIndexing(ctx context.Context, cmd *cobra.Command, idx *index.Indexer, projectPath string, p *tui.Progress) (index.Stats, error) {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -413,6 +413,12 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir, oldRootHash s
 		absPath := filepath.Join(projectDir, relPath)
 		content, err := os.ReadFile(absPath)
 		if err != nil {
+			if os.IsPermission(err) {
+				if idx.logger != nil {
+					idx.logger.Warn("skipping inaccessible file", "path", relPath, "error", err)
+				}
+				continue
+			}
 			return stats, fmt.Errorf("read file %s: %w", relPath, err)
 		}
 

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -934,6 +934,48 @@ func Nested() {}
 	}
 }
 
+func TestIndexer_SkipsPermissionDeniedFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file permission checks")
+	}
+
+	dir := t.TempDir()
+	writeGoFile(t, dir, "ok.go", `package p
+
+func OK() {}
+`)
+	writeGoFile(t, dir, "secret.go", `package p
+
+func Secret() {}
+`)
+	if err := os.Chmod(filepath.Join(dir, "secret.go"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "secret.go"), 0o644) })
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	_, err = idx.Index(context.Background(), dir, false, nil)
+	if err != nil {
+		t.Fatalf("expected no error when a file is permission-denied, got: %v", err)
+	}
+
+	results, err := idx.Search(context.Background(), dir, []float32{0.1, 0.1, 0.1, 0.1}, 10, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if strings.Contains(r.FilePath, "secret.go") {
+			t.Errorf("secret.go should not be indexed, found: %s", r.FilePath)
+		}
+	}
+}
+
 func writeGoFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/merkle/merkle.go
+++ b/internal/merkle/merkle.go
@@ -90,6 +90,12 @@ func collectFilePaths(rootDir string, skip SkipFunc) ([]string, error) {
 	var relPaths []string
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				if d != nil && d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
 			return err
 		}
 		rel, _ := filepath.Rel(rootDir, path)
@@ -142,6 +148,9 @@ func hashFilesInParallel(rootDir string, relPaths []string) (*Tree, error) {
 			for rel := range work {
 				data, err := os.ReadFile(filepath.Join(rootDir, rel))
 				if err != nil {
+					if os.IsPermission(err) {
+						continue
+					}
 					results <- result{err: err}
 					return
 				}

--- a/internal/merkle/merkle_test.go
+++ b/internal/merkle/merkle_test.go
@@ -217,6 +217,30 @@ func TestCollectFilePaths_SkipsLargeFiles(t *testing.T) {
 	}
 }
 
+func TestBuildTree_SkipsPermissionDeniedFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file permission checks")
+	}
+	dir := t.TempDir()
+	writeFile(t, dir, "accessible.go", "package main\n")
+	writeFile(t, dir, "secret.go", "package main\n")
+	if err := os.Chmod(filepath.Join(dir, "secret.go"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "secret.go"), 0o644) })
+
+	tree, err := BuildTree(dir, nil)
+	if err != nil {
+		t.Fatalf("expected no error for permission-denied file, got: %v", err)
+	}
+	if _, ok := tree.Files["accessible.go"]; !ok {
+		t.Error("expected accessible.go in tree")
+	}
+	if _, ok := tree.Files["secret.go"]; ok {
+		t.Error("expected secret.go to be skipped")
+	}
+}
+
 func writeFile(t *testing.T, dir, rel, content string) {
 	t.Helper()
 	abs := filepath.Join(dir, rel)


### PR DESCRIPTION
## Summary

- **Skip permission-denied files** (`internal/merkle`, `internal/index`): instead of aborting, `collectFilePaths` now returns `filepath.SkipDir` for inaccessible directories and skips inaccessible files; `indexWithTree` continues past permission errors rather than surfacing them
- **Normalize cwd/projectPath to git root** (`cmd/hook.go`, `cmd/index.go`): both the SessionStart hook and `lumen index` now call `git.RepoRoot` so a subdirectory always resolves to the same DB as the repo root
- **Skip nested git repos in non-git parent** (`internal/index`, `internal/git`): new `IsGitRoot`/`DiscoverNestedGitRepos` helpers; `makeSkip` excludes nested repos from the parent walk; `lumen index` indexes each nested repo separately first

## Refactoring

Extracted `runIndexer` (lock → signal-context → setup → index → elapsed) from the now-deleted `indexSingleProject`, eliminating ~50 lines of duplication. Both the main project path and nested repos share the helper; callers handle their own log/output.

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` returns 0 issues
- [ ] `lumen index <subdirectory>` produces the same DB as `lumen index <repo-root>`
- [ ] `lumen index <non-git-dir-with-nested-repos>` indexes each nested repo separately
- [ ] Files/dirs with permission errors are skipped without aborting indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)