### PR TITLE
refactor: remove dead code and inline trivial single-use helpers

### DIFF
--- a/internal/chunker/structured.go
+++ b/internal/chunker/structured.go
@@ -79,7 +79,10 @@ func (c *StructuredChunker) Chunk(filePath string, content []byte) ([]Chunk, err
 // maxChars, it emits a single chunk. Otherwise it recurses into children.
 func (c *StructuredChunker) recurse(filePath string, node *yaml.Node, path string) []Chunk {
 	text := serializeNode(node)
-	symbol := normalizeSymbol(path)
+	symbol := path
+	if symbol == "" {
+		symbol = "root"
+	}
 
 	if len(text) <= c.maxChars {
 		return c.createNodeChunk(filePath, symbol, text, node)
@@ -93,13 +96,6 @@ func (c *StructuredChunker) recurse(filePath string, node *yaml.Node, path strin
 	default:
 		return c.createNodeChunk(filePath, symbol, text, node)
 	}
-}
-
-func normalizeSymbol(path string) string {
-	if path == "" {
-		return "root"
-	}
-	return path
 }
 
 func (c *StructuredChunker) createNodeChunk(filePath, symbol, text string, node *yaml.Node) []Chunk {
@@ -123,7 +119,10 @@ func (c *StructuredChunker) recurseMapping(filePath string, node *yaml.Node, pat
 func (c *StructuredChunker) processMappingPair(filePath string, node *yaml.Node, path string, i int) []Chunk {
 	keyNode := node.Content[i]
 	valNode := node.Content[i+1]
-	childPath := joinKeyPath(path, keyNode.Value)
+	childPath := keyNode.Value
+	if path != "" {
+		childPath = path + "." + keyNode.Value
+	}
 	wrapper := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{keyNode, valNode}}
 	wrapText := serializeNode(wrapper)
 
@@ -153,10 +152,3 @@ func serializeNode(node *yaml.Node) string {
 	return strings.TrimRight(buf.String(), "\n")
 }
 
-// joinKeyPath builds "parent.child"; if parent is empty returns child.
-func joinKeyPath(parent, child string) string {
-	if parent == "" {
-		return child
-	}
-	return parent + "." + child
-}

--- a/internal/embedder/models.go
+++ b/internal/embedder/models.go
@@ -31,12 +31,6 @@ const DefaultLMStudioModel = "nomic-ai/nomic-embed-code-GGUF"
 // DefaultModel is an alias for DefaultOllamaModel for backward compatibility.
 const DefaultModel = DefaultOllamaModel
 
-// ModelAliases maps alternative model names to their canonical names.
-// LM Studio exposes some models under different names than their repository ID.
-var ModelAliases = map[string]string{
-	"text-embedding-nomic-embed-code": "nomic-ai/nomic-embed-code-GGUF",
-}
-
 // DefaultMinScore is the fallback noise-floor threshold used when the active
 // model is not in KnownModels and dimensions are unknown.
 const DefaultMinScore = 0.20

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -166,7 +166,7 @@ func ListWorktrees(projectPath string) ([]string, error) {
 	}
 
 	var paths []string
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		if path, ok := strings.CutPrefix(line, "worktree "); ok {
 			// Resolve symlinks so paths are comparable across macOS
 			// /var → /private/var symlink boundaries.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -371,7 +371,7 @@ func (s *Store) insertChunksInTransaction(chunks []chunker.Chunk, vectors [][]fl
 }
 
 func insertChunkAndVector(chunkStmt, vecStmt interface {
-	Exec(...interface{}) (sql.Result, error)
+	Exec(...any) (sql.Result, error)
 }, c chunker.Chunk, vec []float32, idx int) error {
 	if _, err := chunkStmt.Exec(c.ID, c.FilePath, c.Symbol, c.Kind, c.StartLine, c.EndLine); err != nil {
 		return fmt.Errorf("insert chunk %s: %w", c.ID, err)


### PR DESCRIPTION
## Summary

- Remove `embedder.ModelAliases`: exported map defined but never referenced anywhere in the codebase
- Inline `normalizeSymbol` and `joinKeyPath` in `structured.go`: trivial 3–5 line functions each with exactly one call site, no readability benefit from being separate
- Replace `interface{}` with `any` in `store.go` `insertChunkAndVector` signature (lint fix)
- Use `strings.SplitSeq` in `git/worktree.go` to avoid allocating a string slice when iterating `git worktree list` output

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)