### PR TITLE
feat(index): reuse ancestor index for non-git subdirectories

### DIFF
--- a/cmd/ancestor.go
+++ b/cmd/ancestor.go
@@ -21,13 +21,16 @@ import (
 	"github.com/ory/lumen/internal/config"
 )
 
-// findAncestorIndex walks up from filepath.Dir(path) checking whether any
-// ancestor directory has an existing lumen index DB on disk. Returns the
-// ancestor path if found, or "" if none exists.
+// findAncestorIndex walks up from path's parent directory, checking whether
+// any ancestor has an existing lumen index DB on disk. Returns the ancestor
+// path if found, or "" if none exists.
 //
 // This is the CLI equivalent of indexerCache.findEffectiveRoot for one-shot
 // commands (index, search, hook) that don't maintain an in-memory cache.
 // Only use for non-git directories; callers should try git.RepoRoot first.
+//
+// Unlike findEffectiveRoot (MCP), this does not cap the walk at the git root
+// because callers have already confirmed path is not inside a git repo.
 func findAncestorIndex(path, model string) string {
 	candidate := filepath.Dir(path)
 	for {

--- a/cmd/ancestor.go
+++ b/cmd/ancestor.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ory/lumen/internal/config"
+)
+
+// findAncestorIndex walks up from filepath.Dir(path) checking whether any
+// ancestor directory has an existing lumen index DB on disk. Returns the
+// ancestor path if found, or "" if none exists.
+//
+// This is the CLI equivalent of indexerCache.findEffectiveRoot for one-shot
+// commands (index, search, hook) that don't maintain an in-memory cache.
+// Only use for non-git directories; callers should try git.RepoRoot first.
+func findAncestorIndex(path, model string) string {
+	candidate := filepath.Dir(path)
+	for {
+		if !pathCrossesSkipDir(candidate, path) {
+			if _, err := os.Stat(config.DBPathForProject(candidate, model)); err == nil {
+				return candidate
+			}
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			break
+		}
+		candidate = parent
+	}
+	return ""
+}

--- a/cmd/ancestor_test.go
+++ b/cmd/ancestor_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ory/lumen/internal/config"
+)
+
+func TestFindAncestorIndex(t *testing.T) {
+	const model = "test-model"
+
+	t.Run("returns empty when no ancestor has an index", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		got := findAncestorIndex("/some/deep/nonexistent/path", model)
+		if got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("finds parent with existing DB on disk", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Create a fake DB for /project.
+		parentDBPath := config.DBPathForProject("/project", model)
+		if err := os.MkdirAll(filepath.Dir(parentDBPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(parentDBPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := findAncestorIndex("/project/scripts/util", model)
+		if got != "/project" {
+			t.Fatalf("expected /project, got %q", got)
+		}
+	})
+
+	t.Run("skips ancestor when path crosses a SkipDir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Create a fake DB for /project.
+		parentDBPath := config.DBPathForProject("/project", model)
+		if err := os.MkdirAll(filepath.Dir(parentDBPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(parentDBPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		// "testdata" is in merkle.SkipDirs — the parent index would never
+		// contain these files, so findAncestorIndex must return "".
+		got := findAncestorIndex("/project/testdata/fixtures/go", model)
+		if got != "" {
+			t.Fatalf("expected empty string (skip dir in route), got %q", got)
+		}
+	})
+
+	t.Run("stops at filesystem root without panicking", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// No DBs exist anywhere — should return "" without panic.
+		got := findAncestorIndex("/a/b/c/d/e", model)
+		if got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns nearest ancestor when multiple exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Create fake DBs for both /project and /project/src.
+		for _, dir := range []string{"/project", "/project/src"} {
+			dbPath := config.DBPathForProject(dir, model)
+			if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(dbPath, []byte{}, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Searching from /project/src/pkg should find /project/src (nearest).
+		got := findAncestorIndex("/project/src/pkg", model)
+		if got != "/project/src" {
+			t.Fatalf("expected /project/src (nearest ancestor), got %q", got)
+		}
+	})
+}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -116,15 +116,18 @@ func generateSessionContextInternal(mcpName, cwd string, findDonor func(string, 
 	toolRef := "mcp__" + mcpName + "__semantic_search"
 	directive := "Call " + toolRef + " first for any code discovery task — before Grep, Bash, or Read."
 
-	// Normalize cwd to the git repository root so the DB path matches what
-	// `lumen index` and the MCP handler use.
-	if root, err := git.RepoRoot(cwd); err == nil {
-		cwd = root
-	}
-
 	cfg, err := config.Load()
 	if err != nil {
 		return directive + " No index yet — auto-created on first call."
+	}
+
+	// Normalize cwd to the git repository root so the DB path matches what
+	// `lumen index` and the MCP handler use. For non-git directories, walk
+	// up to reuse an existing ancestor index.
+	if root, err := git.RepoRoot(cwd); err == nil {
+		cwd = root
+	} else if ancestor := findAncestorIndex(cwd, cfg.Model); ancestor != "" {
+		cwd = ancestor
 	}
 
 	dbPath := config.DBPathForProject(cwd, cfg.Model)

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -360,6 +360,50 @@ func TestGenerateSessionContextInternal_NormalizesToGitRoot(t *testing.T) {
 	}
 }
 
+func TestGenerateSessionContextInternal_NonGitUsesParentIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	// Create a non-git directory hierarchy.
+	parentDir := filepath.Join(tmpDir, "parent")
+	deepDir := filepath.Join(parentDir, "child", "deep")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve symlinks to match what filepath.Abs would produce on macOS.
+	resolvedParent, err := filepath.EvalSymlinks(parentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a DB for the parent directory.
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil {
+		t.Fatalf("config.Load: %v", cfgErr)
+	}
+	dbPath := config.DBPathForProject(resolvedParent, cfg.Model)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeHookTestDB(t, dbPath, time.Now().Add(-30*time.Second))
+
+	// Pass a deep subdirectory as cwd — the hook should walk up and find
+	// the parent's index.
+	resolvedDeep, err := filepath.EvalSymlinks(deepDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := generateSessionContextInternal("lumen", resolvedDeep,
+		func(_, _ string) string { return "" },
+		func(_ string) {},
+	)
+
+	if !strings.Contains(result, "index ready") {
+		t.Errorf("expected hook to walk up to parent index and find it, got: %s", result)
+	}
+}
+
 func TestHookOutputJSON(t *testing.T) {
 	// Use the internal version with a no-op bgIndexer — same fork-bomb reason
 	// as in TestGenerateSessionContext_NoIndex.

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -68,8 +68,11 @@ func runIndex(cmd *cobra.Command, args []string) error {
 
 	// Normalize to the git repository root when inside a git repo so that
 	// indexing a subdirectory produces the same DB as indexing the repo root.
+	// For non-git directories, walk up to reuse an existing ancestor index.
 	if root, err := git.RepoRoot(projectPath); err == nil {
 		projectPath = root
+	} else if ancestor := findAncestorIndex(projectPath, cfg.Model); ancestor != "" {
+		projectPath = ancestor
 	}
 
 	// When the project directory is not a git repo, discover nested git repos

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ory/lumen/internal/config"
 	"github.com/ory/lumen/internal/embedder"
+	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/index"
 	"github.com/spf13/cobra"
 )
@@ -146,6 +147,13 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("resolve cwd: %w", err)
 		}
 		indexRoot = abs
+	}
+
+	// Normalize to git root, or fall back to ancestor index for non-git dirs.
+	if root, err := git.RepoRoot(indexRoot); err == nil {
+		indexRoot = root
+	} else if ancestor := findAncestorIndex(indexRoot, cfg.Model); ancestor != "" {
+		indexRoot = ancestor
 	}
 
 	tr.record("path resolution", indexRoot)

--- a/e2e_cli_test.go
+++ b/e2e_cli_test.go
@@ -35,6 +35,12 @@ import (
 func gitSampleProject(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
+	// Resolve symlinks so the path matches what the CLI computes via
+	// git rev-parse --show-toplevel + filepath.EvalSymlinks (e.g. on macOS
+	// /tmp → /private/tmp).
+	if resolved, err := filepath.EvalSymlinks(tmp); err == nil {
+		tmp = resolved
+	}
 	copyDir(t, sampleProjectPath(t), tmp)
 	for _, args := range [][]string{
 		{"init"},
@@ -603,6 +609,9 @@ func TestE2E_CLI_AncestorReuse_Search(t *testing.T) {
 	stdout, _, err := runCLIWithDataHome(t, dataHome, "search", "--cwd", subDir, "-p", dir, "token validation")
 	if err != nil {
 		t.Fatalf("search failed: %v", err)
+	}
+	if !strings.Contains(stdout, `symbol=`) {
+		t.Fatalf("expected at least one result from ancestor index, got stdout: %s", stdout)
 	}
 	if !strings.Contains(stdout, "ValidateToken") {
 		t.Errorf("expected ValidateToken in search results from ancestor index, got stdout: %s", stdout)

--- a/e2e_cli_test.go
+++ b/e2e_cli_test.go
@@ -546,3 +546,132 @@ func TestE2E_CLI_SQLVerifyIncremental(t *testing.T) {
 		t.Errorf("found %d orphan chunks after file deletion", orphans)
 	}
 }
+
+// TestE2E_CLI_AncestorReuse_Index verifies that `lumen index` from a non-git
+// subdirectory reuses the parent's existing on-disk index via findAncestorIndex.
+func TestE2E_CLI_AncestorReuse_Index(t *testing.T) {
+	t.Parallel()
+	dataHome := t.TempDir()
+
+	// Copy sample-project to a plain (non-git) temp dir.
+	dir := t.TempDir()
+	copyDir(t, sampleProjectPath(t), dir)
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index the parent directory.
+	_, _, err := runCLIWithDataHome(t, dataHome, "index", dir)
+	if err != nil {
+		t.Fatalf("first index failed: %v", err)
+	}
+
+	// Index from sub/ — should find ancestor's DB and report up-to-date.
+	stdout, _, err := runCLIWithDataHome(t, dataHome, "index", subDir)
+	if err != nil {
+		t.Fatalf("sub index failed: %v", err)
+	}
+	if !strings.Contains(stdout, "up to date") {
+		t.Errorf("expected 'up to date' from ancestor reuse, got stdout: %s", stdout)
+	}
+}
+
+// TestE2E_CLI_AncestorReuse_Search verifies that `lumen search` from a non-git
+// subdirectory reuses the parent's on-disk index for search results.
+// Uses --cwd to set the index root explicitly, while -p scopes the search.
+func TestE2E_CLI_AncestorReuse_Search(t *testing.T) {
+	t.Parallel()
+	dataHome := t.TempDir()
+
+	// Copy sample-project to a plain (non-git) temp dir.
+	dir := t.TempDir()
+	copyDir(t, sampleProjectPath(t), dir)
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the parent index.
+	_, _, err := runCLIWithDataHome(t, dataHome, "index", dir)
+	if err != nil {
+		t.Fatalf("index failed: %v", err)
+	}
+
+	// Search with --cwd pointing at sub/ (triggers ancestor resolution for
+	// indexRoot) and -p pointing at dir (full scope, no pathPrefix filtering).
+	stdout, _, err := runCLIWithDataHome(t, dataHome, "search", "--cwd", subDir, "-p", dir, "token validation")
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if !strings.Contains(stdout, "ValidateToken") {
+		t.Errorf("expected ValidateToken in search results from ancestor index, got stdout: %s", stdout)
+	}
+}
+
+// TestE2E_CLI_AncestorReuse_NearestWins verifies that when multiple ancestor
+// directories have indexes, the nearest one is used.
+func TestE2E_CLI_AncestorReuse_NearestWins(t *testing.T) {
+	t.Parallel()
+	dataHome := t.TempDir()
+
+	// Create grandparent with canonical files.
+	grandparent := t.TempDir()
+	pkgDir := filepath.Join(grandparent, "pkg")
+	apiDir := filepath.Join(grandparent, "api")
+	for _, d := range []string{pkgDir, apiDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "server.go"), []byte(`package pkg
+
+// StartServer starts the main server loop.
+func StartServer() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(apiDir, "handler.go"), []byte(`package api
+
+// HandleLogin processes login requests.
+func HandleLogin() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create parent with a different file.
+	parent := filepath.Join(grandparent, "parent")
+	libDir := filepath.Join(parent, "lib")
+	childDir := filepath.Join(parent, "child")
+	for _, d := range []string{libDir, childDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "worker.go"), []byte(`package lib
+
+// RunWorker executes the background worker.
+func RunWorker() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index both levels.
+	if _, _, err := runCLIWithDataHome(t, dataHome, "index", grandparent); err != nil {
+		t.Fatalf("grandparent index failed: %v", err)
+	}
+	if _, _, err := runCLIWithDataHome(t, dataHome, "index", parent); err != nil {
+		t.Fatalf("parent index failed: %v", err)
+	}
+
+	// Search from child/ — nearest ancestor is parent/, which has RunWorker.
+	// Use --cwd child/ so indexRoot resolves to parent/ via ancestor walking,
+	// and -p parent/ for full scope (no pathPrefix filtering).
+	stdout, _, err := runCLIWithDataHome(t, dataHome, "search", "--cwd", childDir, "-p", parent, "run worker")
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if !strings.Contains(stdout, `symbol="RunWorker"`) {
+		t.Errorf("expected RunWorker from nearest ancestor (parent), got stdout: %s", stdout)
+	}
+}

--- a/e2e_topology_test.go
+++ b/e2e_topology_test.go
@@ -304,6 +304,10 @@ func AuthenticateUser() {}
 		},
 	}
 
+	// "ancestor-reuse" is tested separately below (TestE2E_AncestorReuse_MCP)
+	// because the two-call pattern with dynamic paths does not fit the
+	// pathTopologyCase struct cleanly.
+
 	// Subtests run sequentially: they share session and the server's per-path index state.
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -383,5 +387,109 @@ func AuthenticateUser() {}
 				}
 			}
 		})
+	}
+}
+
+// TestE2E_AncestorReuse_MCP verifies that an MCP search from a non-git
+// subdirectory reuses the parent directory's cached index instead of creating
+// a new one.
+func TestE2E_AncestorReuse_MCP(t *testing.T) {
+	t.Parallel()
+	session := startServer(t)
+
+	dir := makeCanonicalDir(t)
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Place a file in sub/ so the pathPrefix filter has something to return.
+	if err := os.WriteFile(filepath.Join(subDir, "util.go"), []byte(`package sub
+
+// SubHelper is a helper in the subdirectory.
+func SubHelper() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First search indexes the root directory (including sub/).
+	out1 := callSearch(t, session, map[string]any{
+		"query":     "start server",
+		"path":      dir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if !out1.Reindexed {
+		t.Error("first search: expected Reindexed=true")
+	}
+	if out1.IndexedFiles < 3 {
+		t.Errorf("first search: expected IndexedFiles >= 3, got %d", out1.IndexedFiles)
+	}
+	if findResult(out1.Results, "StartServer") == nil {
+		t.Errorf("first search: expected StartServer in results, got: %v", resultSymbols(out1.Results))
+	}
+
+	// Second search from sub/ should reuse the parent's index (no re-index).
+	out2 := callSearch(t, session, map[string]any{
+		"query":     "sub helper",
+		"path":      subDir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if out2.Reindexed {
+		t.Error("sub/ search: expected Reindexed=false (parent index should be reused)")
+	}
+	if findResult(out2.Results, "SubHelper") == nil {
+		t.Errorf("sub/ search: expected SubHelper in results (from parent index), got: %v", resultSymbols(out2.Results))
+	}
+}
+
+// TestE2E_AncestorReuse_SkipDir verifies that ancestor walking does NOT cross
+// skip directories (node_modules, testdata, etc.). A search from inside
+// node_modules/ must create its own index, not reuse the parent's.
+func TestE2E_AncestorReuse_SkipDir(t *testing.T) {
+	t.Parallel()
+	session := startServer(t)
+
+	dir := makeCanonicalDir(t)
+
+	// Add a Go file inside node_modules (a skip dir).
+	nmDir := filepath.Join(dir, "node_modules", "somepkg")
+	if err := os.MkdirAll(nmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "index.go"), []byte(`package somepkg
+
+// NpmHelper is a helper function in node_modules.
+func NpmHelper() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index the root directory first.
+	out1 := callSearch(t, session, map[string]any{
+		"query":     "start server",
+		"path":      dir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if !out1.Reindexed {
+		t.Error("root search: expected Reindexed=true")
+	}
+
+	// Search from inside node_modules — must NOT reuse parent index.
+	out2 := callSearch(t, session, map[string]any{
+		"query":     "npm helper",
+		"path":      nmDir,
+		"n_results": 10,
+		"min_score": -1,
+	})
+	if !out2.Reindexed {
+		t.Error("node_modules search: expected Reindexed=true (should NOT reuse parent)")
+	}
+	if findResult(out2.Results, "NpmHelper") == nil {
+		t.Errorf("node_modules search: expected NpmHelper in results, got: %v", resultSymbols(out2.Results))
+	}
+	if findResult(out2.Results, "StartServer") != nil {
+		t.Errorf("node_modules search: unexpected StartServer (parent index should NOT be reused): %v", resultSymbols(out2.Results))
 	}
 }


### PR DESCRIPTION
## Summary

- Walk up the directory tree from non-git subdirectories to find and reuse an existing ancestor index, avoiding redundant indexing
- Wire `findAncestorIndex()` into all three CLI entry points (hook, index, search) as the CLI equivalent of the MCP server's `findEffectiveRoot()`
- Respect skip directories (node_modules, testdata, etc.) to prevent cross-contamination

## Test plan

- [x] `TestE2E_AncestorReuse_MCP` — MCP search from non-git subdir reuses parent index (Reindexed=false)
- [x] `TestE2E_AncestorReuse_SkipDir` — ancestor walking does NOT cross node_modules (fresh index created)
- [x] `TestE2E_CLI_AncestorReuse_Index` — `lumen index` from subdir reports "up to date" via ancestor reuse
- [x] `TestE2E_CLI_AncestorReuse_Search` — `lumen search` from subdir finds symbols from ancestor's index
- [x] `TestE2E_CLI_AncestorReuse_NearestWins` — nearest ancestor index wins when multiple exist
- [x] All 10 `TestE2E_PathTopologies` cases pass (regression)
- [x] `TestE2E_GitRootFallbackSharedIndex` passes (regression)
- [x] Unit tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)