### PR TITLE
fix(mcp): rename n_results to limit in semantic_search tool

### DIFF
--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -56,7 +56,7 @@ type SemanticSearchInput struct {
 	Query    string   `json:"query" jsonschema:"Natural language search query"`
 	Path     string   `json:"path,omitempty" jsonschema:"Absolute path to search in. Defaults to cwd. When a subdirectory of cwd, results are filtered to that subtree."`
 	Cwd      string   `json:"cwd,omitempty" jsonschema:"The current working directory / project root. Used as index root when provided."`
-	NResults int      `json:"n_results,omitempty" jsonschema:"Max results to return, default 8"`
+	Limit    int      `json:"limit,omitempty" jsonschema:"Max results to return, default 8. Pass a higher value for broader coverage."`
 	MinScore *float64 `json:"min_score,omitempty" jsonschema:"Minimum score threshold (-1 to 1). Results below this score are excluded. Default depends on embedding model. Use -1 to return all results."`
 	Summary  bool     `json:"summary,omitempty" jsonschema:"When true, return only file path, symbol, kind, line range, and score — no code content. Useful for location-only queries."`
 	MaxLines int      `json:"max_lines,omitempty" jsonschema:"Truncate each code snippet to this many lines. Default: unlimited."`
@@ -426,7 +426,7 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 	ic.logger().Debug("semantic search request",
 		"cwd", input.Cwd,
 		"search_path", input.Path,
-		"n_results", input.NResults,
+		"limit", input.Limit,
 	)
 
 	idx, effectiveRoot, seedWarning, err := ic.getOrCreate(input.Path, input.Cwd)
@@ -460,7 +460,7 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 
 	// Over-fetch from KNN so that merging overlapping split chunks doesn't
 	// reduce the final result count below the requested limit.
-	fetchLimit := input.NResults * 2
+	fetchLimit := input.Limit * 2
 
 	// Defense-in-depth: bound the search call so that even if a future
 	// regression reintroduces mutex contention, we return within a
@@ -511,8 +511,8 @@ func (ic *indexerCache) handleSemanticSearch(ctx context.Context, req *mcp.CallT
 	})
 
 	// Cap to the originally requested limit after merging.
-	if len(items) > input.NResults {
-		items = items[:input.NResults]
+	if len(items) > input.Limit {
+		items = items[:input.Limit]
 	}
 
 	// Extract snippets for merged results.
@@ -567,8 +567,8 @@ func validateSearchInput(input *SemanticSearchInput) error {
 	if input.Query == "" {
 		return fmt.Errorf("query is required")
 	}
-	if input.NResults <= 0 {
-		input.NResults = 8
+	if input.Limit <= 0 {
+		input.Limit = 8
 	}
 	return nil
 }
@@ -1262,7 +1262,7 @@ This includes:
 
 Auto-indexes if the index is stale or empty.
 
-Tip: If a search returns no results, retry with a lower min_score (e.g. 0.0 or -1) before trying a completely different query. Increase limit beyond 10 if you need broader coverage.`,
+Tip: If a search returns no results, retry with a lower min_score (e.g. 0.0 or -1) before trying a completely different query. Increase limit (e.g. limit: 20) for broader coverage.`,
 	}, indexers.handleSemanticSearch)
 
 	mcp.AddTool(server, &mcp.Tool{

--- a/cmd/stdio_test.go
+++ b/cmd/stdio_test.go
@@ -1020,7 +1020,7 @@ func TestEnsureIndexed_SkipsWhenLockHeld(t *testing.T) {
 	}
 
 	// With the lock held by the subprocess, ensureIndexed must skip EnsureFresh.
-	input := SemanticSearchInput{Cwd: projectPath, Path: projectPath, Query: "test", NResults: 8}
+	input := SemanticSearchInput{Cwd: projectPath, Path: projectPath, Query: "test", Limit: 8}
 	out, err := ic.ensureIndexed(idx, input, effectiveRoot, dbPath, nil)
 	if err != nil {
 		t.Fatalf("ensureIndexed returned unexpected error: %v", err)
@@ -1246,7 +1246,7 @@ func TestEnsureIndexed_FreshnessTTL(t *testing.T) {
 		Path:     projectDir,
 		Cwd:      projectDir,
 		Query:    "test",
-		NResults: 8,
+		Limit: 8,
 	}
 
 	dbPath := config.DBPathForProject(effectiveRoot, ic.model)

--- a/e2e_lang_test.go
+++ b/e2e_lang_test.go
@@ -89,7 +89,7 @@ func langSearch(t *testing.T, session *mcp.ClientSession, lang, query string) st
 	out := callSearch(t, session, map[string]any{
 		"query":     query,
 		"path":      dir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1.0,
 	})
 	// Sort by (filePath, startLine) for deterministic snapshots across environments.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -450,7 +450,7 @@ func TestE2E_IndexAndSearchResults(t *testing.T) {
 	out := callSearch(t, session, map[string]any{
 		"query":     "authentication token validation",
 		"path":      projectPath,
-		"n_results": 5,
+		"limit": 5,
 	})
 
 	if !out.Reindexed {
@@ -527,7 +527,7 @@ func TestE2E_PlaintextContent(t *testing.T) {
 	result := callSearchRaw(t, session, map[string]any{
 		"query":     "authentication token validation",
 		"path":      projectPath,
-		"n_results": 3,
+		"limit": 3,
 	})
 
 	if result.IsError {
@@ -589,7 +589,7 @@ func TestE2E_SearchRelevanceRanking(t *testing.T) {
 	out := callSearch(t, session, map[string]any{
 		"query":     "HTTP request handler for health check endpoint",
 		"path":      projectPath,
-		"n_results": 50,
+		"limit": 50,
 		"min_score": -1,
 	})
 	healthRank := rankOf(out.Results, "HandleHealth")
@@ -599,7 +599,7 @@ func TestE2E_SearchRelevanceRanking(t *testing.T) {
 		raw := callSearchRaw(t, session, map[string]any{
 			"query":     "HTTP request handler for health check endpoint",
 			"path":      projectPath,
-			"n_results": 50,
+			"limit": 50,
 			"min_score": -1,
 		})
 		t.Logf("raw text:\n%s", getTextContent(t, raw))
@@ -617,7 +617,7 @@ func TestE2E_SearchRelevanceRanking(t *testing.T) {
 	out2 := callSearch(t, session, map[string]any{
 		"query":     "database query pagination",
 		"path":      projectPath,
-		"n_results": 50,
+		"limit": 50,
 		"min_score": -1,
 	})
 	queryRank := rankOf(out2.Results, "QueryUsers")
@@ -634,41 +634,41 @@ func TestE2E_SearchRelevanceRanking(t *testing.T) {
 	}
 }
 
-func TestE2E_NResultsParameter(t *testing.T) {
+func TestE2E_LimitParameter(t *testing.T) {
 	t.Parallel()
 	session := startServer(t)
 	projectPath := sampleProjectPath(t)
 
-	// n_results=1 should return exactly 1. Use min_score=-1 to bypass score filtering.
+	// limit=1 should return exactly 1. Use min_score=-1 to bypass score filtering.
 	out1 := callSearch(t, session, map[string]any{
 		"query":     "user",
 		"path":      projectPath,
-		"n_results": 1,
+		"limit": 1,
 		"min_score": -1,
 	})
 	if len(out1.Results) != 1 {
-		t.Errorf("n_results=1: expected exactly 1 result, got %d", len(out1.Results))
+		t.Errorf("limit=1: expected exactly 1 result, got %d", len(out1.Results))
 	}
 
-	// n_results=3 should return at most 3.
+	// limit=3 should return at most 3.
 	out3 := callSearch(t, session, map[string]any{
 		"query":     "user",
 		"path":      projectPath,
-		"n_results": 3,
+		"limit": 3,
 		"min_score": -1,
 	})
 	if len(out3.Results) > 3 {
-		t.Errorf("n_results=3: expected at most 3 results, got %d", len(out3.Results))
+		t.Errorf("limit=3: expected at most 3 results, got %d", len(out3.Results))
 	}
 
-	// No n_results (omitted) should return results (default 8 kicks in).
+	// No limit (omitted) should return results (default 8 kicks in).
 	outDefault := callSearch(t, session, map[string]any{
 		"query":     "user",
 		"path":      projectPath,
 		"min_score": -1,
 	})
 	if len(outDefault.Results) == 0 {
-		t.Error("no n_results: expected results with default")
+		t.Error("no limit: expected results with default")
 	}
 }
 
@@ -681,7 +681,7 @@ func TestE2E_MinScoreFilter(t *testing.T) {
 	outAll := callSearch(t, session, map[string]any{
 		"query":     "authentication token validation",
 		"path":      projectPath,
-		"n_results": 50,
+		"limit": 50,
 		"min_score": -1,
 	})
 	if len(outAll.Results) == 0 {
@@ -692,7 +692,7 @@ func TestE2E_MinScoreFilter(t *testing.T) {
 	outFiltered := callSearch(t, session, map[string]any{
 		"query":     "authentication token validation",
 		"path":      projectPath,
-		"n_results": 50,
+		"limit": 50,
 		"min_score": 0.5,
 	})
 
@@ -1175,7 +1175,7 @@ func ValidateTokenV2(token string) bool {
 		"query":     "token validation",
 		"path":      wtDir,
 		"cwd":       wtDir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if !out1.Reindexed {
@@ -1266,7 +1266,7 @@ func HandleRequest(w http.ResponseWriter, r *http.Request) {
 		"query":     "HTTP request handler",
 		"path":      subDir,
 		"cwd":       repoDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if !out1.Reindexed {
@@ -1279,7 +1279,7 @@ func HandleRequest(w http.ResponseWriter, r *http.Request) {
 		"query":     "HTTP request handler",
 		"path":      subDir,
 		"cwd":       repoDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if out2.Reindexed {
@@ -1303,7 +1303,7 @@ func HandleRequest(w http.ResponseWriter, r *http.Request) {
 		"query":     "HTTP request handler",
 		"path":      subDir,
 		"cwd":       repoDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if out3.Reindexed {
@@ -1354,7 +1354,7 @@ func HandleLogin() {}
 	out1 := callSearch(t, session, map[string]any{
 		"query":     "start server",
 		"path":      pkgDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if !out1.Reindexed {
@@ -1369,7 +1369,7 @@ func HandleLogin() {}
 	out2 := callSearch(t, session, map[string]any{
 		"query":     "login handler",
 		"path":      apiDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if out2.Reindexed {
@@ -1383,7 +1383,7 @@ func HandleLogin() {}
 	out3 := callSearch(t, session, map[string]any{
 		"query":     "start server",
 		"path":      repoDir,
-		"n_results": 5,
+		"limit": 5,
 		"min_score": -1,
 	})
 	if findResult(out3.Results, "StartServer") == nil {
@@ -1523,7 +1523,7 @@ func FeatureFlag() bool { return false }
 		"query":     "feature flag rollout",
 		"path":      repoDir,
 		"cwd":       repoDir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if findResult(out2.Results, "FeatureFlag") != nil {

--- a/e2e_topology_test.go
+++ b/e2e_topology_test.go
@@ -316,7 +316,7 @@ func AuthenticateUser() {}
 			args := map[string]any{
 				"query":     tc.query,
 				"path":      setup.searchPath,
-				"n_results": 10,
+				"limit": 10,
 				"min_score": -1,
 			}
 			if setup.cwd != "" {
@@ -364,7 +364,7 @@ func AuthenticateUser() {}
 				secondArgs := map[string]any{
 					"query":     tc.second.query,
 					"path":      secondPath,
-					"n_results": 10,
+					"limit": 10,
 					"min_score": -1,
 				}
 
@@ -415,7 +415,7 @@ func SubHelper() {}
 	out1 := callSearch(t, session, map[string]any{
 		"query":     "start server",
 		"path":      dir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if !out1.Reindexed {
@@ -432,7 +432,7 @@ func SubHelper() {}
 	out2 := callSearch(t, session, map[string]any{
 		"query":     "sub helper",
 		"path":      subDir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if out2.Reindexed {
@@ -469,7 +469,7 @@ func NpmHelper() {}
 	out1 := callSearch(t, session, map[string]any{
 		"query":     "start server",
 		"path":      dir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if !out1.Reindexed {
@@ -480,7 +480,7 @@ func NpmHelper() {}
 	out2 := callSearch(t, session, map[string]any{
 		"query":     "npm helper",
 		"path":      nmDir,
-		"n_results": 10,
+		"limit": 10,
 		"min_score": -1,
 	})
 	if !out2.Reindexed {


### PR DESCRIPTION
## Summary

- Renames the `n_results` parameter of `semantic_search` to `limit`
- Fixes a mismatch: the tool description already said "Increase limit beyond 10" but the actual parameter was `n_results`, so agents guessed wrong names (e.g. `k`, the KNN convention) and hit MCP validation errors
- Updates all usages in `cmd/stdio.go`, `cmd/stdio_test.go`, `e2e_test.go`, `e2e_topology_test.go`, and `e2e_lang_test.go`

## Test plan

- [x] `make build-local` — compiles clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)