### PR TITLE
fix: harden concurrent indexer lifecycle (close cancellation, reindex dedup, reader consistency)

### DIFF
--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -135,6 +135,7 @@ type cacheEntry struct {
 type indexerCache struct {
 	mu              sync.RWMutex
 	cache           map[string]cacheEntry
+	reindexing      map[string]bool // projects with an active background reindex goroutine
 	embedder        embedder.Embedder
 	model           string
 	cfg             config.Config
@@ -144,7 +145,9 @@ type indexerCache struct {
 	seedFunc        func(string, string) (bool, error)                                                                                       // nil uses index.SeedFromDonor
 	ensureFreshFunc func(ctx context.Context, idx *index.Indexer, projectDir string, progress index.ProgressFunc) (bool, index.Stats, error) // nil uses idx.EnsureFresh
 	log             *slog.Logger
-	wg              sync.WaitGroup // tracks background reindex goroutines
+	wg              sync.WaitGroup     // tracks background reindex goroutines
+	closeCtx        context.Context    // cancelled by Close() to signal background goroutines
+	closeFn         context.CancelFunc // cancels closeCtx
 }
 
 // logger returns ic.log, falling back to a discarding logger when the field
@@ -156,12 +159,28 @@ func (ic *indexerCache) logger() *slog.Logger {
 	return ic.log
 }
 
-// Close waits for any background reindex goroutines to finish, then
-// closes all cached indexers. Call on MCP server shutdown.
-// Worst-case wait is backgroundReindexMaxDuration (10 min) if a
-// background reindex is in progress.
+// Close cancels all background reindex goroutines, waits for them to drain
+// (up to 30 seconds), then closes all cached indexers. Call on MCP server
+// shutdown.
 func (ic *indexerCache) Close() {
-	ic.wg.Wait()
+	// Signal all background goroutines to stop.
+	if ic.closeFn != nil {
+		ic.closeFn()
+	}
+
+	// Wait for goroutines to finish, with a hard ceiling so a stuck
+	// goroutine (e.g. unresponsive embedder ignoring context) does not
+	// block shutdown indefinitely.
+	done := make(chan struct{})
+	go func() {
+		ic.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+	}
+
 	ic.mu.Lock()
 	defer ic.mu.Unlock()
 	seen := make(map[*index.Indexer]bool)
@@ -621,6 +640,22 @@ func (ic *indexerCache) ensureIndexed(idx *index.Indexer, input SemanticSearchIn
 		"effective_root", projectDir,
 	)
 
+	// If an in-process background goroutine is already reindexing this
+	// project, skip spawning another one. This prevents redundant merkle
+	// tree walks and avoids macOS flock(2) same-process reentrance issues.
+	ic.mu.Lock()
+	if ic.reindexing != nil && ic.reindexing[projectDir] {
+		ic.mu.Unlock()
+		ic.logger().Debug("skipping reindex: in-process background goroutine already running", "project", projectDir)
+		out.StaleWarning = "Index is being updated in the background. Results may be incomplete or outdated. Use standard tools for the next 10 tool calls before trying semantic_search again."
+		return out, nil
+	}
+	if ic.reindexing == nil {
+		ic.reindexing = make(map[string]bool)
+	}
+	ic.reindexing[projectDir] = true
+	ic.mu.Unlock()
+
 	// Run EnsureFresh in a goroutine with a 15s timeout. If reindexing
 	// takes longer, return stale results with a warning while the
 	// goroutine continues in the background.
@@ -632,11 +667,20 @@ func (ic *indexerCache) ensureIndexed(idx *index.Indexer, input SemanticSearchIn
 	}
 	done := make(chan freshResult, 1) // buffered: goroutine must never block on send
 
-	bgCtx, bgCancel := context.WithTimeout(context.Background(), backgroundReindexMaxDuration)
+	bgParent := context.Background()
+	if ic.closeCtx != nil {
+		bgParent = ic.closeCtx
+	}
+	bgCtx, bgCancel := context.WithTimeout(bgParent, backgroundReindexMaxDuration)
 
 	lockPath := indexlock.LockPathForDB(dbPath)
 	ic.wg.Go(func() {
 		defer bgCancel()
+		defer func() {
+			ic.mu.Lock()
+			delete(ic.reindexing, projectDir)
+			ic.mu.Unlock()
+		}()
 
 		lk, lockErr := indexlock.TryAcquire(lockPath)
 		if lockErr != nil {
@@ -1216,6 +1260,7 @@ func runStdio(_ *cobra.Command, _ []string) error {
 		"freshness_ttl", cfg.FreshnessTTL.String(),
 	)
 
+	closeCtx, closeFn := context.WithCancel(context.Background())
 	indexers := &indexerCache{
 		embedder:       emb,
 		model:          cfg.Model,
@@ -1223,6 +1268,8 @@ func runStdio(_ *cobra.Command, _ []string) error {
 		freshnessTTL:   cfg.FreshnessTTL,
 		reindexTimeout: cfg.ReindexTimeout,
 		log:            logger,
+		closeCtx:       closeCtx,
+		closeFn:        closeFn,
 	}
 	defer indexers.Close()
 

--- a/cmd/stdio_test.go
+++ b/cmd/stdio_test.go
@@ -1739,3 +1739,157 @@ func TestEnsureIndexed_EnsureFreshErrorReturnsError(t *testing.T) {
 
 	ic.Close()
 }
+
+// TestEnsureIndexed_DeduplicatesInProcessGoroutines verifies that two
+// concurrent ensureIndexed calls for the same project only spawn one
+// background goroutine. The second call should return a stale warning
+// immediately instead of spawning a redundant goroutine.
+func TestEnsureIndexed_DeduplicatesInProcessGoroutines(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	idx, err := index.NewIndexer(dbPath, &stubEmbedder{}, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	// Track how many times ensureFreshFunc is called.
+	var callCount int32
+	var callMu sync.Mutex
+	started := make(chan struct{}) // signals first ensureFresh entered
+
+	closeCtx, closeFn := context.WithCancel(context.Background())
+	defer closeFn()
+
+	ic := &indexerCache{
+		cache: map[string]cacheEntry{
+			tmpDir: {idx: idx, effectiveRoot: tmpDir},
+		},
+		reindexTimeout: 200 * time.Millisecond,
+		freshnessTTL:   1 * time.Nanosecond,
+		log:            discardLog,
+		closeCtx:       closeCtx,
+		closeFn:        closeFn,
+		ensureFreshFunc: func(ctx context.Context, _ *index.Indexer, _ string, _ index.ProgressFunc) (bool, index.Stats, error) {
+			callMu.Lock()
+			callCount++
+			callMu.Unlock()
+
+			// Signal that we're inside ensureFresh, then block.
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			// Block until context cancelled (simulating slow reindex).
+			<-ctx.Done()
+			return false, index.Stats{}, ctx.Err()
+		},
+	}
+
+	input := SemanticSearchInput{Cwd: tmpDir, Path: tmpDir, Query: "test"}
+
+	// First call: spawns background goroutine that enters ensureFreshFunc.
+	go func() {
+		_, _ = ic.ensureIndexed(idx, input, tmpDir, dbPath, nil)
+	}()
+
+	// Wait for the first goroutine to enter ensureFreshFunc.
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first ensureFresh never started")
+	}
+
+	// Second call: should detect the in-process goroutine and return
+	// immediately with a stale warning (no second goroutine spawned).
+	out, err := ic.ensureIndexed(idx, input, tmpDir, dbPath, nil)
+	if err != nil {
+		t.Fatalf("second ensureIndexed returned error: %v", err)
+	}
+	if out.StaleWarning == "" {
+		t.Fatal("expected StaleWarning from deduplicated second call")
+	}
+
+	callMu.Lock()
+	count := callCount
+	callMu.Unlock()
+	if count != 1 {
+		t.Fatalf("expected ensureFreshFunc to be called exactly once, got %d", count)
+	}
+
+	ic.Close()
+}
+
+// TestIndexerCache_CloseCancelsBackgroundGoroutines verifies that Close()
+// cancels running background goroutines via closeCtx and does not block
+// for the full backgroundReindexMaxDuration.
+func TestIndexerCache_CloseCancelsBackgroundGoroutines(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	idx, err := index.NewIndexer(dbPath, &stubEmbedder{}, 512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	var ctxErr error
+	var ctxErrMu sync.Mutex
+	started := make(chan struct{})
+
+	closeCtx, closeFn := context.WithCancel(context.Background())
+
+	ic := &indexerCache{
+		cache: map[string]cacheEntry{
+			tmpDir: {idx: idx, effectiveRoot: tmpDir},
+		},
+		reindexTimeout: 200 * time.Millisecond,
+		freshnessTTL:   1 * time.Nanosecond,
+		log:            discardLog,
+		closeCtx:       closeCtx,
+		closeFn:        closeFn,
+		ensureFreshFunc: func(ctx context.Context, _ *index.Indexer, _ string, _ index.ProgressFunc) (bool, index.Stats, error) {
+			close(started)
+			// Block until context is cancelled by Close().
+			<-ctx.Done()
+			ctxErrMu.Lock()
+			ctxErr = ctx.Err()
+			ctxErrMu.Unlock()
+			return false, index.Stats{}, ctx.Err()
+		},
+	}
+
+	input := SemanticSearchInput{Cwd: tmpDir, Path: tmpDir, Query: "test"}
+
+	// Trigger a background reindex.
+	_, _ = ic.ensureIndexed(idx, input, tmpDir, dbPath, nil)
+
+	// Wait for ensureFresh to start.
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ensureFresh never started")
+	}
+
+	// Close should cancel the background context and return promptly.
+	closeDone := make(chan struct{})
+	go func() {
+		ic.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		// Close returned within the deadline — good.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() blocked for >5s; expected prompt return after context cancellation")
+	}
+
+	ctxErrMu.Lock()
+	finalErr := ctxErr
+	ctxErrMu.Unlock()
+	if finalErr != context.Canceled {
+		t.Fatalf("expected context.Canceled in ensureFresh, got: %v", finalErr)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -594,9 +594,11 @@ func (s *Store) TopSymbols(n int) ([]string, error) {
 
 // HasSentinelFiles reports whether any files have an empty hash, indicating
 // they were registered but never fully indexed (interrupted run).
+// Uses the read-only connection when available for consistency with other
+// read methods (GetMeta, Stats, Search).
 func (s *Store) HasSentinelFiles() (bool, error) {
 	var exists bool
-	err := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM files WHERE hash = '')").Scan(&exists)
+	err := s.reader().QueryRow("SELECT EXISTS(SELECT 1 FROM files WHERE hash = '')").Scan(&exists)
 	return exists, err
 }
 


### PR DESCRIPTION
## Summary

Adversarial review of multi-instance concurrent access to Lumen's SQLite index identified three issues in the `indexerCache` lifecycle. This PR fixes all three:

- **Close() cancellation**: `Close()` now cancels a shared `closeCtx` to signal background goroutines before waiting, and enforces a 30-second hard ceiling so shutdown is never blocked by a stuck embedder or unresponsive network call. Previously, `Close()` could block for up to 10 minutes (`backgroundReindexMaxDuration`).

- **Reindex dedup map**: A per-project `reindexing` map in `indexerCache` prevents spawning redundant background goroutines for the same project. This eliminates redundant merkle tree walks and avoids macOS `flock(2)` same-process reentrance issues (on macOS/BSD, two goroutines in the same process can both "acquire" the same advisory flock since it's per-process-per-inode).

- **Reader consistency**: `HasSentinelFiles()` now uses the read-only connection (`s.reader()`) instead of `s.db` (the write connection), consistent with all other read methods (`GetMeta`, `Stats`, `Search`). Functionally equivalent but eliminates an inconsistency that could matter under write-heavy load.

## Tests

- `TestEnsureIndexed_DeduplicatesInProcessGoroutines` — verifies two concurrent `ensureIndexed` calls for the same project only spawn one background goroutine
- `TestIndexerCache_CloseCancelsBackgroundGoroutines` — verifies `Close()` cancels running goroutines via context and returns promptly

All existing tests continue to pass. `make test` and `make lint` green.