### PR TITLE
feat(config): support text-embedding-nomic-embed-code alias for LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,23 @@ In Codex, use the bundled `reindex` skill to refresh the index through the MCP
 server, or run the same CLI commands for a clean rebuild. The same shared
 `reindex` skill is available in Cursor and OpenCode as well.
 
+**LM Studio: embedding model appears under LLMs instead of Embeddings**
+
+LM Studio classifies embedding models by matching the GGUF `arch` field against
+a hardcoded allowlist (`bert`, `nomic-bert`). Models built on other
+architectures — including Qwen2-based models like `nomic-embed-code` — are
+misclassified as LLMs. This affects `lms ls` output and the `/v1/embeddings`
+REST endpoint.
+
+**Fix (GGUF, v0.3.16+):** Open LM Studio → My Models, click the gear icon next
+to the model, set **Override Domain Type** → **Text Embedding**.
+
+> **macOS / Apple Silicon:** MLX format models are significantly faster on Apple
+> Silicon. However, LM Studio removed the domain type override for MLX in
+> v0.3.30+, so MLX embedding models cannot be reclassified. Use the GGUF
+> variant to retain the override option, or switch to Ollama
+> (`ordis/jina-embeddings-v2-base-code` or `qwen3-embedding:8b`).
+
 **Switching embedding models**
 
 Set `LUMEN_EMBED_MODEL` to a model from the supported table above. Each model

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,11 @@ func Load() (Config, error) {
 	overrideDims := EnvOrDefaultInt("LUMEN_EMBED_DIMS", 0)
 	overrideCtx := EnvOrDefaultInt("LUMEN_EMBED_CTX", 0)
 
-	spec, modelKnown := embedder.KnownModels[model]
+	specKey := model
+	if canonical, ok := embedder.ModelAliases[model]; ok {
+		specKey = canonical
+	}
+	spec, modelKnown := embedder.KnownModels[specKey]
 	if !modelKnown && overrideDims == 0 {
 		return Config{}, fmt.Errorf("unknown embedding model %q: set LUMEN_EMBED_DIMS to use an unlisted model", model)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -125,6 +125,27 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadAliasResolution(t *testing.T) {
+	t.Setenv("LUMEN_BACKEND", "lmstudio")
+	t.Setenv("LUMEN_EMBED_MODEL", "text-embedding-nomic-embed-code")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Dims != 3584 {
+		t.Errorf("Dims: got %d, want 3584", cfg.Dims)
+	}
+	if cfg.CtxLength != 8192 {
+		t.Errorf("CtxLength: got %d, want 8192", cfg.CtxLength)
+	}
+	// Config.Model must stay as user-configured name — LM Studio API expects
+	// "text-embedding-nomic-embed-code", not "nomic-ai/nomic-embed-code-GGUF".
+	if cfg.Model != "text-embedding-nomic-embed-code" {
+		t.Errorf("Model: got %q, want %q", cfg.Model, "text-embedding-nomic-embed-code")
+	}
+}
+
 func TestDBPathForProject(t *testing.T) {
 	t.Run("deterministic", func(t *testing.T) {
 		p1 := DBPathForProject("/home/user/project", "model-a")

--- a/internal/embedder/models_test.go
+++ b/internal/embedder/models_test.go
@@ -71,6 +71,9 @@ func TestModelAliases(t *testing.T) {
 		if alias == canonical {
 			t.Errorf("alias %q maps to itself — remove it from ModelAliases", alias)
 		}
+		if _, ok := ModelAliases[canonical]; ok {
+			t.Errorf("alias %q target %q is itself an alias — chained aliases are not supported", alias, canonical)
+		}
 	}
 }
 

--- a/internal/embedder/models_test.go
+++ b/internal/embedder/models_test.go
@@ -63,6 +63,17 @@ func TestDefaultLMStudioModelInRegistry(t *testing.T) {
 	}
 }
 
+func TestModelAliases(t *testing.T) {
+	for alias, canonical := range ModelAliases {
+		if _, ok := KnownModels[canonical]; !ok {
+			t.Errorf("alias %q points to %q which is not in KnownModels", alias, canonical)
+		}
+		if alias == canonical {
+			t.Errorf("alias %q maps to itself — remove it from ModelAliases", alias)
+		}
+	}
+}
+
 func TestDimensionAwareMinScore(t *testing.T) {
 	tests := []struct {
 		dims int


### PR DESCRIPTION
## Summary

- Wires the existing `ModelAliases` map into `config.Load()` so `LUMEN_EMBED_MODEL=text-embedding-nomic-embed-code` resolves to the correct spec (dims=3584, ctx=8192) without requiring `LUMEN_EMBED_DIMS`
- `Config.Model` retains the user-configured value so the correct identifier is sent to LM Studio's `/v1/embeddings` API
- Adds `TestLoadAliasResolution` to pin the full resolution chain (Dims, CtxLength, Model field)
- Adds `TestModelAliases` to enforce alias targets exist in `KnownModels` and catches chained/self aliases
- Documents the LM Studio model misclassification bug (Qwen2-based models shown as LLMs) and the domain type override workaround

## Test plan

- [ ] `go test ./internal/config/... -run TestLoadAliasResolution` passes
- [ ] `go test ./internal/embedder/... -run TestModelAliases` passes
- [ ] `go test ./...` passes
- [ ] Set `LUMEN_BACKEND=lmstudio LUMEN_EMBED_MODEL=text-embedding-nomic-embed-code` and verify `lumen index` starts without error (requires LM Studio running with nomic-embed-code loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)