### PR TITLE
fix(index): skip unparsable files; fix config test env isolation

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,12 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
+	// Ensure ambient shell env vars don't leak into subtests.
+	t.Setenv("LUMEN_BACKEND", "")
+	t.Setenv("LUMEN_EMBED_MODEL", "")
+	t.Setenv("LUMEN_EMBED_DIMS", "")
+	t.Setenv("LUMEN_EMBED_CTX", "")
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("LUMEN_EMBED_MODEL", tc.model)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -441,7 +441,10 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir, oldRootHash s
 
 		chunks, err := idx.chunker.Chunk(relPath, content)
 		if err != nil {
-			return stats, fmt.Errorf("chunk %s: %w", relPath, err)
+			if idx.logger != nil {
+				idx.logger.Warn("skipping unparsable file", "path", relPath, "error", err)
+			}
+			continue
 		}
 
 		chunks = splitOversizedChunks(chunks, idx.maxChunkTokens)

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -976,6 +976,45 @@ func Secret() {}
 	}
 }
 
+func TestIndexer_SkipsUnparsableFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Valid Go file that will be indexed.
+	writeGoFile(t, dir, "ok.go", `package p
+
+func OK() {}
+`)
+	// Syntactically invalid Go file — simulates the snippet files that LLM
+	// docs repos embed mid-page without a package declaration.
+	writeGoFile(t, dir, "broken.go", `func broken() {
+	mux.HandleFunc("/", handler)
+}
+`)
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	_, err = idx.Index(context.Background(), dir, false, nil)
+	if err != nil {
+		t.Fatalf("expected no error when a file fails to parse, got: %v", err)
+	}
+
+	results, err := idx.Search(context.Background(), dir, []float32{0.1, 0.1, 0.1, 0.1}, 10, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if strings.Contains(r.FilePath, "broken.go") {
+			t.Errorf("broken.go should not be indexed, found: %s", r.FilePath)
+		}
+	}
+}
+
 func writeGoFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary

- **Skip unparsable files during indexing** (`internal/index/index.go`): files that fail to parse (e.g. Go snippet files without a `package` declaration, as found in docs repos) now log a warning and continue instead of aborting the entire index run — same pattern as permission-denied files.
- **Fix `TestLoad` env isolation** (`internal/config/config_test.go`): subtests were inheriting `LUMEN_BACKEND`, `LUMEN_EMBED_MODEL`, `LUMEN_EMBED_DIMS`, and `LUMEN_EMBED_CTX` from the shell environment, causing spurious failures when those vars are set (e.g. to `lmstudio` / `text-embedding-nomic-embed-code` / `3584`). Parent test now clears them before the subtest loop.

## Test plan

- [x] `TestIndexer_SkipsUnparsableFile` — new test, watched it fail before fix, passes after
- [x] `TestLoad` subtests all pass regardless of ambient shell env
- [x] `go test ./...` fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)