### PR TITLE
fix(search): resolve index root from search path, not cwd

### DIFF
--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/git"
+)
+
+// resolveIndexRoot determines the index root and search path for a given
+// combination of path and cwd flags. This is the shared path resolution logic
+// used by both the CLI search command and the MCP handler.
+//
+// The returned indexRoot is the directory whose DB should be opened (the
+// project-level index root). searchPath is the directory to use for path-prefix
+// filtering (may equal indexRoot when no subdirectory narrowing is needed).
+//
+// Resolution order:
+//  1. Determine the search target (path flag, cwd flag, or working directory).
+//  2. Resolve the index root via git root, then ancestor index, then cwd if an
+//     index already exists there.
+//  3. If cwd is provided and differs from the resolved index root, use it as a
+//     preferred root only when an index already exists at that location —
+//     matching the MCP guard that avoids creating a brand-new index at a large
+//     ancestor tree.
+func resolveIndexRoot(pathFlag, cwdFlag, model string) (indexRoot, searchPath string, err error) {
+	// Determine the search target path.
+	searchPath = pathFlag
+	if searchPath == "" {
+		if cwdFlag != "" {
+			searchPath = cwdFlag
+		} else {
+			searchPath, err = os.Getwd()
+			if err != nil {
+				return "", "", fmt.Errorf("get working directory: %w", err)
+			}
+		}
+	}
+	searchPath, err = filepath.Abs(searchPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve search path: %w", err)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(searchPath); resolveErr == nil {
+		searchPath = resolved
+	}
+
+	// Resolve the index root from the search path: try git root first, then
+	// ancestor index walk.
+	indexRoot = searchPath
+	if root, gitErr := git.RepoRoot(searchPath); gitErr == nil {
+		indexRoot = root
+	} else if ancestor := findAncestorIndex(searchPath, model); ancestor != "" {
+		indexRoot = ancestor
+	}
+
+	// When cwd is provided and the search path resolved to itself (no git root,
+	// no ancestor), check if cwd has an existing index and adopt it.  This
+	// matches the MCP guard: only reuse cwd as index root when an index already
+	// exists there, to avoid triggering a full scan of a large ancestor tree.
+	if cwdFlag != "" {
+		absCwd, absErr := filepath.Abs(cwdFlag)
+		if absErr != nil {
+			return "", "", fmt.Errorf("resolve cwd: %w", absErr)
+		}
+
+		if indexRoot == searchPath {
+			// searchPath had no git root and no ancestor — check if cwd has an index.
+			if _, statErr := os.Stat(config.DBPathForProject(absCwd, model)); statErr == nil {
+				indexRoot = absCwd
+			}
+		}
+	}
+
+	return indexRoot, searchPath, nil
+}

--- a/cmd/resolve_test.go
+++ b/cmd/resolve_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/ory/lumen/internal/config"
+)
+
+// resolvedTempDir returns a t.TempDir() with symlinks resolved (macOS /var → /private/var).
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	d := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func TestResolveIndexRoot(t *testing.T) {
+	const model = "test-model"
+
+	t.Run("path only with git repo uses git root", func(t *testing.T) {
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		// Create a git repo at tmp/repo.
+		repoDir := filepath.Join(tmp, "repo")
+		if err := os.MkdirAll(filepath.Join(repoDir, "sub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repoDir, "init")
+
+		indexRoot, searchPath, err := resolveIndexRoot(filepath.Join(repoDir, "sub"), "", model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if indexRoot != repoDir {
+			t.Fatalf("expected indexRoot=%q (git root), got %q", repoDir, indexRoot)
+		}
+		if searchPath != filepath.Join(repoDir, "sub") {
+			t.Fatalf("expected searchPath=%q, got %q", filepath.Join(repoDir, "sub"), searchPath)
+		}
+	})
+
+	t.Run("path only without git repo and no ancestor index uses path itself", func(t *testing.T) {
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		dir := filepath.Join(tmp, "nongit", "sub")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		indexRoot, searchPath, err := resolveIndexRoot(dir, "", model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if indexRoot != dir {
+			t.Fatalf("expected indexRoot=%q, got %q", dir, indexRoot)
+		}
+		if searchPath != dir {
+			t.Fatalf("expected searchPath=%q, got %q", dir, searchPath)
+		}
+	})
+
+	t.Run("cwd with path where subproject is git repo uses git root of subproject", func(t *testing.T) {
+		// This is the exact scenario from issue #97:
+		// lumen search "..." --cwd /project -p /project/sub-project-a
+		// where sub-project-a is a git repo.
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		parentDir := filepath.Join(tmp, "project")
+		subDir := filepath.Join(parentDir, "sub-project-a")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, subDir, "init")
+
+		indexRoot, searchPath, err := resolveIndexRoot(subDir, parentDir, model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Should resolve to the git root of sub-project-a, NOT parentDir.
+		if indexRoot != subDir {
+			t.Fatalf("expected indexRoot=%q (git root of subproject), got %q", subDir, indexRoot)
+		}
+		if searchPath != subDir {
+			t.Fatalf("expected searchPath=%q, got %q", subDir, searchPath)
+		}
+	})
+
+	t.Run("cwd with existing index at cwd is adopted when path has no git root", func(t *testing.T) {
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		parentDir := filepath.Join(tmp, "project")
+		subDir := filepath.Join(parentDir, "sub")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a fake index at parentDir.
+		dbPath := config.DBPathForProject(parentDir, model)
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dbPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		indexRoot, searchPath, err := resolveIndexRoot(subDir, parentDir, model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// parentDir has an existing index and path has no git root, so cwd is adopted.
+		if indexRoot != parentDir {
+			t.Fatalf("expected indexRoot=%q (cwd with existing index), got %q", parentDir, indexRoot)
+		}
+		if searchPath != subDir {
+			t.Fatalf("expected searchPath=%q, got %q", subDir, searchPath)
+		}
+	})
+
+	t.Run("cwd without existing index is not adopted", func(t *testing.T) {
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		parentDir := filepath.Join(tmp, "project")
+		subDir := filepath.Join(parentDir, "sub")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// No index at parentDir.
+
+		indexRoot, searchPath, err := resolveIndexRoot(subDir, parentDir, model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// No git root, no ancestor index, no index at cwd → falls back to searchPath.
+		if indexRoot != subDir {
+			t.Fatalf("expected indexRoot=%q, got %q", subDir, indexRoot)
+		}
+		if searchPath != subDir {
+			t.Fatalf("expected searchPath=%q, got %q", subDir, searchPath)
+		}
+	})
+
+	t.Run("ancestor index found via walk", func(t *testing.T) {
+		tmp := resolvedTempDir(t)
+		t.Setenv("XDG_DATA_HOME", tmp)
+
+		grandparentDir := filepath.Join(tmp, "workspace")
+		subDir := filepath.Join(grandparentDir, "a", "b")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a fake index at grandparentDir.
+		dbPath := config.DBPathForProject(grandparentDir, model)
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dbPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		indexRoot, searchPath, err := resolveIndexRoot(subDir, "", model)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if indexRoot != grandparentDir {
+			t.Fatalf("expected indexRoot=%q (ancestor index), got %q", grandparentDir, indexRoot)
+		}
+		if searchPath != subDir {
+			t.Fatalf("expected searchPath=%q, got %q", subDir, searchPath)
+		}
+	})
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ory/lumen/internal/config"
 	"github.com/ory/lumen/internal/embedder"
-	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/index"
 	"github.com/spf13/cobra"
 )
@@ -123,37 +122,9 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	projectPath := pathFlag
-	if projectPath == "" {
-		if cwdFlag != "" {
-			projectPath = cwdFlag
-		} else {
-			projectPath, err = os.Getwd()
-			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
-			}
-		}
-	}
-	projectPath, err = filepath.Abs(projectPath)
+	indexRoot, projectPath, err := resolveIndexRoot(pathFlag, cwdFlag, cfg.Model)
 	if err != nil {
-		return fmt.Errorf("resolve path: %w", err)
-	}
-
-	// When --cwd and --path both given, cwd is the index root.
-	indexRoot := projectPath
-	if cwdFlag != "" {
-		abs, err := filepath.Abs(cwdFlag)
-		if err != nil {
-			return fmt.Errorf("resolve cwd: %w", err)
-		}
-		indexRoot = abs
-	}
-
-	// Normalize to git root, or fall back to ancestor index for non-git dirs.
-	if root, err := git.RepoRoot(indexRoot); err == nil {
-		indexRoot = root
-	} else if ancestor := findAncestorIndex(indexRoot, cfg.Model); ancestor != "" {
-		indexRoot = ancestor
+		return fmt.Errorf("resolve paths: %w", err)
 	}
 
 	tr.record("path resolution", indexRoot)
@@ -246,7 +217,10 @@ func finishSearch(
 		}
 	}
 
-	results, err := idx.Search(ctx, indexRoot, queryVec, fetchLimit, maxDistance, pathPrefix)
+	searchCtx, searchCancel := context.WithTimeout(ctx, defaultSearchTimeout)
+	defer searchCancel()
+
+	results, err := idx.Search(searchCtx, indexRoot, queryVec, fetchLimit, maxDistance, pathPrefix)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Fixes #97**: `lumen search` with `--cwd` + `--path` returned no results because the CLI blindly used `cwd` as the index root, opening the wrong DB
- Extracts `resolveIndexRoot()` as shared path resolution logic that resolves from the search path (git root → ancestor index → cwd-if-indexed), matching the MCP handler's behavior
- Adds 20s search timeout to CLI search, matching the MCP handler's `defaultSearchTimeout`

## Root Cause

When both `--cwd /project` and `--path /project/sub-project-a` were provided, the old code set `indexRoot = cwd` directly. If `/project` had no index (the real index lived at `sub-project-a`'s git root), the CLI opened an empty DB and found nothing.

The MCP handler (`getOrCreate`) already handles this correctly by only adopting `cwd` as preferred root when an index exists there. The CLI had diverged from this logic.

## Test plan

- [x] `TestResolveIndexRoot` — 6 cases covering git root, non-git, cwd+path (the #97 scenario), cwd-with-index, cwd-without-index, ancestor walk
- [x] All existing `cmd/` tests pass
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)