### PR TITLE
fix: run.sh env defaults override user config file

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -62,6 +62,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	}
 
 	emb := newEmbedder(cfg)
+	emb.SetLogger(logger)
 
 	projectPath, err := filepath.Abs(args[0])
 	if err != nil {
@@ -155,7 +156,11 @@ func applyModelFlag(cmd *cobra.Command) error {
 	if m == "" {
 		return nil
 	}
-	if _, ok := embedder.KnownModels[m]; !ok {
+	canonical := m
+	if c, ok := embedder.ModelAliases[m]; ok {
+		canonical = c
+	}
+	if _, ok := embedder.KnownModels[canonical]; !ok {
 		return fmt.Errorf("unknown embedding model %q", m)
 	}
 	_ = os.Setenv("LUMEN_EMBED_MODEL", m)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -122,6 +122,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 	emb := newEmbedder(cfg)
+	logger, logFile := newDebugLogger()
+	if logFile != nil {
+		defer func() { _ = logFile.Close() }()
+	}
+	emb.SetLogger(logger)
 	modelName := emb.ModelName()
 
 	indexRoot, projectPath, err := resolveIndexRoot(pathFlag, cwdFlag, modelName)

--- a/cmd/stdio.go
+++ b/cmd/stdio.go
@@ -1348,6 +1348,7 @@ func runStdio(_ *cobra.Command, _ []string) error {
 	emb := newEmbedder(cfg)
 
 	logger, logFile := newDebugLogger()
+	emb.SetLogger(logger)
 	if logFile != nil {
 		defer func() { _ = logFile.Close() }()
 	}

--- a/internal/embedder/failover.go
+++ b/internal/embedder/failover.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ const healthCheckTimeout = 5 * time.Second
 // embedder re-initializes on the next Embed call.
 type FailoverEmbedder struct {
 	cfg           *config.ConfigService
+	logger        *slog.Logger
 	mu            sync.Mutex
 	servers       []serverEntry
 	cachedConfigs []config.ServerConfig // snapshot at last init
@@ -49,6 +51,11 @@ type serverEntry struct {
 // first Embed call.
 func NewFailoverEmbedder(cfg *config.ConfigService) *FailoverEmbedder {
 	return &FailoverEmbedder{cfg: cfg, active: -1}
+}
+
+// SetLogger attaches a logger to the embedder for structured diagnostic output.
+func (f *FailoverEmbedder) SetLogger(l *slog.Logger) {
+	f.logger = l
 }
 
 // ActiveServerIndex returns the index of the currently active server, or -1
@@ -128,6 +135,9 @@ func (f *FailoverEmbedder) Embed(ctx context.Context, texts []string) ([][]float
 			f.mu.Unlock()
 			return nil, fmt.Errorf("all embedding servers exhausted after failover: last error: %w", err)
 		}
+		if f.logger != nil {
+			f.logger.Warn("embedding server failed, trying next", "failed", active, "next", next, "error", err)
+		}
 		f.active = next
 		if err := f.ensureEmbedder(next); err != nil {
 			f.mu.Unlock()
@@ -169,15 +179,25 @@ func (f *FailoverEmbedder) initServers() {
 	for i := range servers {
 		f.servers[i] = serverEntry{}
 	}
+	if f.logger != nil {
+		f.logger.Info("probing embedding servers", "count", len(servers))
+	}
 	for i := range f.servers {
 		if f.probeHealth(i) {
 			f.servers[i].healthy = true
 			if err := f.ensureEmbedder(i); err == nil {
 				f.active = i
+				if f.logger != nil {
+					srv := servers[i]
+					f.logger.Info("selected embedding server", "server", i, "backend", srv.Backend, "host", srv.Host, "model", srv.Model)
+				}
 				return
 			}
 			// ensureEmbedder failed (e.g. unknown backend); try next server
 		}
+	}
+	if f.logger != nil {
+		f.logger.Warn("no healthy embedding server found")
 	}
 }
 
@@ -210,10 +230,19 @@ func (f *FailoverEmbedder) probeHealth(i int) bool {
 	client := &http.Client{Timeout: healthCheckTimeout}
 	resp, err := client.Get(endpoint)
 	if err != nil {
+		if f.logger != nil {
+			f.logger.Warn("health probe failed", "server", i, "backend", srv.Backend, "host", srv.Host, "error", err)
+		}
 		return false
 	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode != http.StatusOK {
+		if f.logger != nil {
+			f.logger.Warn("health probe non-200", "server", i, "backend", srv.Backend, "host", srv.Host, "status", resp.StatusCode)
+		}
+		return false
+	}
+	return true
 }
 
 // ensureEmbedder lazily initializes the backend embedder for server i.

--- a/internal/embedder/failover_test.go
+++ b/internal/embedder/failover_test.go
@@ -15,12 +15,15 @@
 package embedder
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,5 +265,210 @@ func TestFailover_ReloadPicksUpNewServers(t *testing.T) {
 	_, err = fe.Embed(context.Background(), []string{"hello"})
 	if err != nil {
 		t.Fatalf("Embed after reload: %v", err)
+	}
+}
+
+func newTestLMStudioServer(t *testing.T, healthy bool, embedStatus int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/models":
+			if healthy {
+				w.WriteHeader(200)
+				_, _ = fmt.Fprint(w, `{"data":[]}`)
+			} else {
+				w.WriteHeader(503)
+			}
+		case r.Method == "POST" && r.URL.Path == "/v1/embeddings":
+			w.WriteHeader(embedStatus)
+			if embedStatus == 200 {
+				_, _ = fmt.Fprint(w, `{"data":[{"embedding":[0.1,0.2,0.3]}]}`)
+			} else {
+				_, _ = fmt.Fprintf(w, `{"error":"status %d"}`, embedStatus)
+			}
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+}
+
+func TestFailover_PrimaryDown_FallsBackWithLogging(t *testing.T) {
+	// Simulate real scenario: remote LM Studio is down, local Ollama is up.
+	lmDown := newTestLMStudioServer(t, false, 200)
+	defer lmDown.Close()
+	ollamaUp := newTestOllamaServer(t, true, 200)
+	defer ollamaUp.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "lmstudio", Host: lmDown.URL, Model: "test-lm", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: ollamaUp.URL, Model: "test-ollama", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	result, err := fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed should succeed via fallback, got: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("expected non-empty embeddings")
+	}
+	if fe.ActiveServerIndex() != 1 {
+		t.Errorf("active = %d, want 1 (should have fallen back to ollama)", fe.ActiveServerIndex())
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "health probe non-200") {
+		t.Error("expected log entry for failed health probe on server 0")
+	}
+	if !strings.Contains(logs, "selected embedding server") {
+		t.Error("expected log entry for server selection")
+	}
+	if !strings.Contains(logs, "test-ollama") {
+		t.Error("expected selected server log to mention the ollama model name")
+	}
+}
+
+func TestFailover_PrimaryUp_SelectsPrimary(t *testing.T) {
+	// Both servers are healthy — should select primary (server 0).
+	lmUp := newTestLMStudioServer(t, true, 200)
+	defer lmUp.Close()
+	ollamaUp := newTestOllamaServer(t, true, 200)
+	defer ollamaUp.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "lmstudio", Host: lmUp.URL, Model: "test-lm", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: ollamaUp.URL, Model: "test-ollama", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if fe.ActiveServerIndex() != 0 {
+		t.Errorf("active = %d, want 0 (primary should be selected)", fe.ActiveServerIndex())
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "selected embedding server") {
+		t.Error("expected log entry for server selection")
+	}
+	if !strings.Contains(logs, "test-lm") {
+		t.Error("expected selected server log to mention the lmstudio model name")
+	}
+	if strings.Contains(logs, "health probe failed") || strings.Contains(logs, "health probe non-200") {
+		t.Error("no health probe warnings expected when primary is up")
+	}
+}
+
+func TestFailover_AllDown_LogsWarning(t *testing.T) {
+	lmDown := newTestLMStudioServer(t, false, 200)
+	defer lmDown.Close()
+	ollamaDown := newTestOllamaServer(t, false, 200)
+	defer ollamaDown.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "lmstudio", Host: lmDown.URL, Model: "test-lm", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: ollamaDown.URL, Model: "test-ollama", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected error when all servers are down")
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "no healthy embedding server found") {
+		t.Error("expected 'no healthy embedding server found' warning")
+	}
+	// Should have two health probe warnings (one per server)
+	if count := strings.Count(logs, "health probe non-200"); count != 2 {
+		t.Errorf("expected 2 health probe warnings, got %d", count)
+	}
+}
+
+func TestFailover_PrimaryFailsDuringEmbed_LogsFailover(t *testing.T) {
+	// Primary is healthy but returns 500 on embed; should failover with logging.
+	srv1 := newTestOllamaServer(t, true, 500)
+	defer srv1.Close()
+	srv2 := newTestOllamaServer(t, true, 200)
+	defer srv2.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: srv1.URL, Model: "test-a", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: srv2.URL, Model: "test-b", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed should succeed via failover, got: %v", err)
+	}
+	if fe.ActiveServerIndex() != 1 {
+		t.Errorf("active = %d, want 1", fe.ActiveServerIndex())
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "embedding server failed, trying next") {
+		t.Error("expected failover log entry")
+	}
+}
+
+func TestFailover_Unreachable_LogsConnectionError(t *testing.T) {
+	// Server 0 is unreachable (closed immediately), server 1 is healthy.
+	unreachable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	unreachable.Close() // close immediately to make it unreachable
+
+	up := newTestOllamaServer(t, true, 200)
+	defer up.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: unreachable.URL, Model: "dead", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: up.URL, Model: "alive", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("Embed should succeed via fallback, got: %v", err)
+	}
+	if fe.ActiveServerIndex() != 1 {
+		t.Errorf("active = %d, want 1", fe.ActiveServerIndex())
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "health probe failed") {
+		t.Error("expected 'health probe failed' with connection error for unreachable server")
+	}
+	if !strings.Contains(logs, "selected embedding server") {
+		t.Error("expected server selection log")
 	}
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,10 +14,6 @@ case "$ARCH" in
   aarch64) ARCH="arm64" ;;
 esac
 
-# Environment defaults
-export LUMEN_BACKEND="${LUMEN_BACKEND:-ollama}"
-export LUMEN_EMBED_MODEL="${LUMEN_EMBED_MODEL:-ordis/jina-embeddings-v2-base-code}"
-
 # Find binary: check bin/ first, then goreleaser dist/ output, then download
 BINARY=""
 for candidate in \


### PR DESCRIPTION
## Summary

- **Root cause**: `scripts/run.sh` unconditionally exported `LUMEN_BACKEND=ollama` and `LUMEN_EMBED_MODEL=ordis/jina-embeddings-v2-base-code` as environment defaults. When the config file system was added, `applyEnvOverrides` treated these as explicit overrides — resetting server[0] to Ollama defaults and silently ignoring the user's multi-server YAML config (`~/.config/lumen/config.yaml`).
- **Fix**: Remove the legacy env exports from `run.sh`. The `ConfigService` defaults map already provides the same fallback values without polluting the environment.
- **Observability**: Add structured `slog` logging to `FailoverEmbedder` so server health probes, failover decisions, and server selection are visible in `debug.log`.

## Test plan

- [x] Existing failover tests pass (`TestFailover_*`)
- [x] 5 new integration tests with mock HTTP servers covering: primary-down fallback, primary-up selection, all-down warnings, embed-time failover, unreachable server errors
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: restart Claude Code session with LM Studio as primary in config → verify `health_check` reports LM Studio, not Ollama
- [ ] Manual: check `~/.local/share/lumen/debug.log` shows server probe/selection entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)