### PR TITLE
fix(ci): restore Windows MCP server support and add cross-platform script tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
           file: coverage.out
           format: golang
 
-      - name: Script tests
-        run: bash scripts/test_run.sh
-
       - name: Vet
         run: go vet -tags=fts5 ./...
 
@@ -140,3 +137,24 @@ jobs:
           echo "Binary reported version: $VER"
           echo "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]' \
             || { echo "ERROR: version output does not match semver pattern"; exit 1; }
+
+  scripts:
+    name: Script tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: github.actor != 'release-please[bot]'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Unix script tests
+        if: runner.os != 'Windows'
+        run: |
+          bash scripts/test_run.sh
+          bash scripts/test_run_cmd.sh
+
+      - name: Windows script tests
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: call scripts\test_run_cmd_windows.bat

--- a/scripts/run.cmd
+++ b/scripts/run.cmd
@@ -1,8 +1,6 @@
-#!/usr/bin/env -S 2>/dev/null=2>NUL sh
-@goto batch 2>NUL;rm -f NUL
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec "${SCRIPT_DIR}/run.sh" "$@"
+#!/bin/sh
+# 2>NUL & @goto batch
+exec "$(dirname "$0")/run.sh" "$@"
 
 :batch
 @echo off

--- a/scripts/test_run_cmd_windows.bat
+++ b/scripts/test_run_cmd_windows.bat
@@ -1,0 +1,80 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Test that run.cmd correctly delegates to run.bat on Windows.
+:: Mirrors test_run_cmd.sh but for the batch (Windows) code path.
+
+set "PASS=0"
+set "FAIL=0"
+
+set "TMP_DIR=%TEMP%\lumen-test-%RANDOM%"
+mkdir "%TMP_DIR%" 2>NUL
+
+:: Copy run.cmd to temp dir
+copy "%~dp0run.cmd" "%TMP_DIR%\run.cmd" >NUL
+
+:: Create a mock run.bat that echoes its arguments
+(
+  echo @echo off
+  echo echo delegated:%%*
+) > "%TMP_DIR%\run.bat"
+
+:: --- Test 1: run.cmd delegates to run.bat with correct arguments ---
+set "OUTPUT="
+for /f "tokens=*" %%i in ('"%TMP_DIR%\run.cmd" stdio --flag 2^>NUL') do set "OUTPUT=%%i"
+
+if "!OUTPUT!"=="delegated:stdio --flag" (
+  echo   PASS: run.cmd delegates to run.bat with correct arguments
+  set /a PASS+=1
+) else (
+  echo   FAIL: run.cmd delegates to run.bat with correct arguments
+  echo         expected: delegated:stdio --flag
+  echo         got:      !OUTPUT!
+  set /a FAIL+=1
+)
+
+:: --- Test 2: run.cmd delegates hook subcommand ---
+set "OUTPUT="
+for /f "tokens=*" %%i in ('"%TMP_DIR%\run.cmd" hook session-start lumen --host claude 2^>NUL') do set "OUTPUT=%%i"
+
+if "!OUTPUT!"=="delegated:hook session-start lumen --host claude" (
+  echo   PASS: run.cmd delegates hook subcommand
+  set /a PASS+=1
+) else (
+  echo   FAIL: run.cmd delegates hook subcommand
+  echo         expected: delegated:hook session-start lumen --host claude
+  echo         got:      !OUTPUT!
+  set /a FAIL+=1
+)
+
+:: --- Test 3: run.cmd produces no unexpected stderr ---
+set "STDERR_FILE=%TMP_DIR%\stderr.txt"
+"%TMP_DIR%\run.cmd" stdio 2>"%STDERR_FILE%" >NUL
+
+:: Check stderr is empty or contains only the expected "not recognized" from shebang line
+set "STDERR_SIZE=0"
+for %%A in ("%STDERR_FILE%") do set "STDERR_SIZE=%%~zA"
+
+:: Stderr should only contain the harmless shebang error (if any)
+:: We check it doesn't contain "-S" which was the old broken error
+findstr /i "\-S" "%STDERR_FILE%" >NUL 2>&1
+if errorlevel 1 (
+  echo   PASS: no '-S' error in stderr
+  set /a PASS+=1
+) else (
+  echo   FAIL: stderr contains '-S' error from old broken polyglot
+  type "%STDERR_FILE%"
+  set /a FAIL+=1
+)
+
+:: Cleanup
+rmdir /s /q "%TMP_DIR%" 2>NUL
+
+:: Summary
+echo.
+echo === summary ===
+echo   passed: %PASS%
+echo   failed: %FAIL%
+
+if %FAIL% GTR 0 exit /b 1
+exit /b 0


### PR DESCRIPTION
Fixes #114.

## Summary

- Fixes the polyglot shebang in `scripts/run.cmd` — the old `env -S` pattern caused an error on some Unix platforms, preventing the batch (Windows) code path from being reached cleanly. The new pattern uses a plain `#!/bin/sh` shebang with the batch redirect comment on the next line.
- Adds `scripts/test_run_cmd_windows.bat` — a Windows batch test that verifies `run.cmd` correctly delegates to `run.bat` with the right arguments and produces no unexpected stderr.
- Adds a dedicated `scripts` CI job that runs on both `ubuntu-latest` and `windows-latest`, covering `test_run.sh`, `test_run_cmd.sh` (Unix), and `test_run_cmd_windows.bat` (Windows).

## Test plan

- [x] `bash scripts/test_run.sh` — all 34 tests pass
- [x] `bash scripts/test_run_cmd.sh` — Unix delegation test passes
- [x] Windows script tests covered by new CI job (`scripts` matrix job on `windows-latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)