### PR TITLE
fix(ci): configure npm trusted publishing for OIDC auth

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,5 +56,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
       - run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Bump Node from 20 to 22 (npm trusted publishing requires npm >= 11.5.1)
- Add `registry-url` to `setup-node` so `.npmrc` is created for OIDC auth
- Fixes `ENEEDAUTH` error in npm publish step (no `NODE_AUTH_TOKEN` needed with trusted publishing)

## Test plan
- [ ] Merge and trigger a release to verify npm publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)