### PR TITLE
fix(scripts): download binary synchronously in stdio mode on first install

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -24,13 +24,6 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
-  :: MCP stdio mode: fail fast if binary missing — the SessionStart hook
-  :: downloads the binary, so by the time stdio is retried it will be ready.
-  if "%~1"=="stdio" (
-    echo Binary not yet downloaded; waiting for SessionStart hook to complete. >&2
-    exit /b 1
-  )
-
   set "REPO=ory/lumen"
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -24,6 +24,24 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
+  :: In stdio mode poll for the SessionStart hook to finish downloading
+  :: rather than blocking with a curl download ourselves.
+  if "%~1"=="stdio" (
+    set "_waited=0"
+    :poll_loop
+    if exist "%BINARY%" goto poll_done
+    if !_waited! GEQ 30 goto poll_done
+    ping -n 2 127.0.0.1 >nul
+    set /a "_waited+=1"
+    goto poll_loop
+    :poll_done
+    if exist "%BINARY%" (
+      "%BINARY%" %*
+      exit /b %ERRORLEVEL%
+    )
+    :: Binary still missing after 30 s — fall through and download it now
+  )
+
   set "REPO=ory/lumen"
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -24,24 +24,6 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
-  :: In stdio mode poll for the SessionStart hook to finish downloading
-  :: rather than blocking with a curl download ourselves.
-  if "%~1"=="stdio" (
-    set "_waited=0"
-    :poll_loop
-    if exist "%BINARY%" goto poll_done
-    if !_waited! GEQ 30 goto poll_done
-    ping -n 2 127.0.0.1 >nul
-    set /a "_waited+=1"
-    goto poll_loop
-    :poll_done
-    if exist "%BINARY%" (
-      "%BINARY%" %*
-      exit /b %ERRORLEVEL%
-    )
-    :: Binary still missing after 30 s — fall through and download it now
-  )
-
   set "REPO=ory/lumen"
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -29,13 +29,6 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 
-  # MCP stdio mode: fail fast if binary missing — the SessionStart hook
-  # downloads the binary, so by the time stdio is retried it will be ready.
-  if [ "${1:-}" = "stdio" ]; then
-    echo "Binary not yet downloaded; waiting for SessionStart hook to complete." >&2
-    exit 1
-  fi
-
   REPO="ory/lumen"
 
   # Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -29,22 +29,6 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 
-  # In stdio mode the MCP server and SessionStart hook start concurrently.
-  # Poll for the hook to finish downloading rather than doing it ourselves —
-  # this keeps the process alive so Claude Code doesn't time out waiting for
-  # the MCP initialise handshake.
-  if [ "${1:-}" = "stdio" ]; then
-    _waited=0
-    while [ $_waited -lt 30 ] && [ ! -x "$BINARY" ]; do
-      sleep 1
-      _waited=$((_waited + 1))
-    done
-    if [ -x "$BINARY" ]; then
-      exec "$BINARY" "$@"
-    fi
-    # Binary still missing after 30 s — fall through and download it now
-  fi
-
   REPO="ory/lumen"
 
   # Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -29,6 +29,22 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 
+  # In stdio mode the MCP server and SessionStart hook start concurrently.
+  # Poll for the hook to finish downloading rather than doing it ourselves —
+  # this keeps the process alive so Claude Code doesn't time out waiting for
+  # the MCP initialise handshake.
+  if [ "${1:-}" = "stdio" ]; then
+    _waited=0
+    while [ $_waited -lt 30 ] && [ ! -x "$BINARY" ]; do
+      sleep 1
+      _waited=$((_waited + 1))
+    done
+    if [ -x "$BINARY" ]; then
+      exec "$BINARY" "$@"
+    fi
+    # Binary still missing after 30 s — fall through and download it now
+  fi
+
   REPO="ory/lumen"
 
   # Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -197,6 +197,37 @@ FAKECURL
   echo "  PASS: run.sh stdio with missing binary attempts download instead of fast-failing"
 ) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
+# Verifies that run.sh stdio exits cleanly when the binary appears during the
+# poll window (simulating the SessionStart hook delivering the binary).
+(
+  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _TMPROOT="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT"' EXIT
+
+  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
+  mkdir -p "${_TMPROOT}/bin"
+
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH_RAW="$(uname -m)"
+  case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
+  _BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
+
+  # Simulate SessionStart hook: write the binary after a short delay
+  ( sleep 2; printf '#!/usr/bin/env bash\nexit 0\n' > "$_BINARY"; chmod +x "$_BINARY" ) &
+  _HOOK_PID=$!
+
+  EXIT_CODE=0
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
+  wait "$_HOOK_PID" 2>/dev/null || true
+
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "  FAIL: run.sh stdio should exec binary once hook delivers it (exit $EXIT_CODE)"
+    exit 1
+  fi
+  echo "  PASS: run.sh stdio polls and execs binary once SessionStart hook delivers it"
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
 echo ""
 echo "=== GitHub API tag parsing tests ==="
 

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -159,19 +159,23 @@ assert_eq "pre-release version preserved" \
 echo ""
 echo "=== stdio download-on-first-run integration test ==="
 
-# Verifies that run.sh does NOT fast-exit when called with 'stdio' and no
-# binary present. It should fall through to the download path instead.
-# curl is stubbed in PATH so no real network calls are made.
+# Verifies that run.sh stdio downloads the binary and execs it when no binary
+# is present (first install). curl is stubbed in PATH — no real network calls.
 (
   _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
 
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH_RAW="$(uname -m)"
+  case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
+  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
+
   printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
   mkdir -p "${_TMPROOT}/bin"
 
-  # Stub: write a minimal executable to the -o destination and succeed
+  # Stub curl: write a minimal executable to the -o destination and succeed
   cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
 #!/usr/bin/env bash
 while [ $# -gt 0 ]; do
@@ -188,44 +192,15 @@ FAKECURL
   CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
     bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
 
-  if [ "$EXIT_CODE" -eq 1 ]; then
-    echo "  FAIL: run.sh stdio with missing binary should attempt download, not exit 1"
-    echo "        expected: exit code != 1"
-    echo "        got:      exit code 1 (fast-fail still present)"
-    exit 1
-  fi
-  echo "  PASS: run.sh stdio with missing binary attempts download instead of fast-failing"
-) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
-
-# Verifies that run.sh stdio exits cleanly when the binary appears during the
-# poll window (simulating the SessionStart hook delivering the binary).
-(
-  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-  _TMPROOT="$(mktemp -d)"
-  trap 'rm -rf "$_TMPROOT"' EXIT
-
-  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
-  mkdir -p "${_TMPROOT}/bin"
-
-  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  ARCH_RAW="$(uname -m)"
-  case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
-  _BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
-
-  # Simulate SessionStart hook: write the binary after a short delay
-  ( sleep 2; printf '#!/usr/bin/env bash\nexit 0\n' > "$_BINARY"; chmod +x "$_BINARY" ) &
-  _HOOK_PID=$!
-
-  EXIT_CODE=0
-  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
-    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
-  wait "$_HOOK_PID" 2>/dev/null || true
-
   if [ "$EXIT_CODE" -ne 0 ]; then
-    echo "  FAIL: run.sh stdio should exec binary once hook delivers it (exit $EXIT_CODE)"
+    echo "  FAIL: run.sh stdio with missing binary should download and exec (exit $EXIT_CODE)"
     exit 1
   fi
-  echo "  PASS: run.sh stdio polls and execs binary once SessionStart hook delivers it"
+  if [ ! -x "$_EXPECTED_BINARY" ]; then
+    echo "  FAIL: run.sh stdio should have downloaded binary to ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  echo "  PASS: run.sh stdio downloads binary and execs it on first install"
 ) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
 echo ""

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -157,42 +157,45 @@ assert_eq "pre-release version preserved" \
   "$(printf '{\n  ".": "0.0.1-alpha.4"\n}\n' | grep '"[.]"' | sed 's/.*"[^"]*"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/v\1/')"
 
 echo ""
-echo "=== stdio early-exit guard tests ==="
+echo "=== stdio download-on-first-run integration test ==="
 
-# Mirrors the guard condition in run.sh: first arg == "stdio" → early exit
-stdio_guard_fires() {
-  [ "${1:-}" = "stdio" ]
-}
+# Verifies that run.sh does NOT fast-exit when called with 'stdio' and no
+# binary present. It should fall through to the download path instead.
+# curl is stubbed in PATH so no real network calls are made.
+(
+  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _TMPROOT="$(mktemp -d)"
+  _FAKE_CURL_DIR="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
 
-if stdio_guard_fires "stdio"; then
-  ok "stdio guard fires for 'stdio' arg"
-else
-  fail "stdio guard fires for 'stdio' arg" "true" "false"
-fi
+  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
+  mkdir -p "${_TMPROOT}/bin"
 
-if ! stdio_guard_fires "index"; then
-  ok "stdio guard does not fire for 'index' arg"
-else
-  fail "stdio guard does not fire for 'index' arg" "false" "true"
-fi
+  # Stub: write a minimal executable to the -o destination and succeed
+  cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+exit 0
+FAKECURL
+  chmod +x "${_FAKE_CURL_DIR}/curl"
 
-if ! stdio_guard_fires "hook"; then
-  ok "stdio guard does not fire for 'hook' arg"
-else
-  fail "stdio guard does not fire for 'hook' arg" "false" "true"
-fi
+  EXIT_CODE=0
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
 
-if ! stdio_guard_fires ""; then
-  ok "stdio guard does not fire for empty arg"
-else
-  fail "stdio guard does not fire for empty arg" "false" "true"
-fi
-
-if ! stdio_guard_fires; then
-  ok "stdio guard does not fire for no args"
-else
-  fail "stdio guard does not fire for no args" "false" "true"
-fi
+  if [ "$EXIT_CODE" -eq 1 ]; then
+    echo "  FAIL: run.sh stdio with missing binary should attempt download, not exit 1"
+    echo "        expected: exit code != 1"
+    echo "        got:      exit code 1 (fast-fail still present)"
+    exit 1
+  fi
+  echo "  PASS: run.sh stdio with missing binary attempts download instead of fast-failing"
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
 echo ""
 echo "=== GitHub API tag parsing tests ==="


### PR DESCRIPTION
## Summary

- Removes the `stdio` fast-fail block from `scripts/run.sh` and `scripts/run.bat` that exited 1 when the binary wasn't present
- On first install, the MCP server now blocks ~5–10s to download the binary then starts normally — tools are available in the same session
- Replaces stale stdio guard unit tests with an integration test that stubs `curl` in `PATH` and verifies `run.sh stdio` reaches the download path instead of fast-exiting

## Root cause

The fast-fail assumed Claude Code would retry failed MCP servers after the `SessionStart` hook downloaded the binary. It doesn't — a failed MCP server is dead for the entire session. So on first marketplace install, `lumen` tools were silently unavailable.

## Test plan

- [x] `bash scripts/test_run.sh` — all 30 tests pass (including new integration test)
- [x] Verified the new integration test fails on the unfixed script (TDD red/green)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)