### PR TITLE
test(scripts): cross-platform MCP handshake tests for first-install (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: github.actor != 'release-please[bot]'
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
 
       - name: Unix script tests
         if: runner.os != 'Windows'
@@ -154,7 +160,12 @@ jobs:
           bash scripts/test_run.sh
           bash scripts/test_run_cmd.sh
 
-      - name: Windows script tests
+      - name: Windows script tests (run.cmd delegation)
         if: runner.os == 'Windows'
         shell: cmd
         run: call scripts\test_run_cmd_windows.bat
+
+      - name: Windows launcher MCP handshake (run.bat stdio)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: pwsh -File scripts/test_run_windows.ps1

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -269,19 +269,30 @@ assert_eq "garbage tag"         "invalid" "$(validate_tag "not-a-version")"
 assert_eq "html fragment"       "invalid" "$(validate_tag "<html>")"
 
 echo ""
-echo "=== stdio first-install integration test ==="
+echo "=== stdio first-install MCP handshake test ==="
 
 # End-to-end guard against the bug in #125: when the binary is missing and
 # run.sh is invoked as `run.sh stdio` (how Claude Code starts the MCP server
-# on first install), the launcher must download the binary and exec it. If
-# the stdio path fast-exits before reaching the download, the MCP server is
-# dead for the entire session because Claude Code does not retry failed MCP
-# servers. This test stubs curl so no real network call is made.
+# on first install), the launcher must download the binary AND the resulting
+# process must speak MCP over stdio. If the stdio path fast-exits before
+# reaching the download, or the downloaded artefact is never actually exec'd
+# with stdin/stdout intact, the MCP server is dead for the entire session —
+# Claude Code does not retry failed MCP servers.
+#
+# A cross-compiled mock MCP server stands in for the real binary. A stubbed
+# `curl` (shadowing real curl via PATH) copies the mock into place. A real
+# JSON-RPC initialize request is sent on stdin; the stdout response must be
+# a well-formed MCP initialize result from the mock. Passing transitively
+# proves the launcher did not fast-exit, reached the download code path,
+# wrote the artefact where it would exec it, made it executable, and
+# exec'd it with stdin/stdout inherited correctly.
 (
   _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _REPO_ROOT="$(cd "${_SCRIPT_DIR}/.." && pwd)"
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
-  trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
+  _MOCK_BIN_DIR="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR" "$_MOCK_BIN_DIR"' EXIT
 
   _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
   _ARCH_RAW="$(uname -m)"
@@ -292,15 +303,22 @@ echo "=== stdio first-install integration test ==="
   esac
   _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${_OS}-${_ARCH}"
 
+  _MOCK_BIN="${_MOCK_BIN_DIR}/mock_lumen"
+  if ! (cd "${_REPO_ROOT}" && CGO_ENABLED=0 go build -o "${_MOCK_BIN}" ./scripts/testdata/mock_mcp_server) >"${_TMPROOT}/mock_build.log" 2>&1; then
+    echo "  FAIL: could not build mock MCP server"
+    sed 's/^/          /' "${_TMPROOT}/mock_build.log"
+    exit 1
+  fi
+
   printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
   mkdir -p "${_TMPROOT}/bin"
 
-  # Stub curl: write a trivial executable to the -o target and succeed.
+  # Stub curl: parse -o <target> and copy the prebuilt mock into place.
   cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
 #!/usr/bin/env bash
 while [ $# -gt 0 ]; do
   case "$1" in
-    -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    -o) mkdir -p "$(dirname "$2")"; cp "$LUMEN_MOCK_BINARY" "$2"; chmod +x "$2"; shift 2 ;;
     *)  shift ;;
   esac
 done
@@ -308,19 +326,41 @@ exit 0
 FAKECURL
   chmod +x "${_FAKE_CURL_DIR}/curl"
 
+  _INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+
+  _STDOUT="${_TMPROOT}/stdout.txt"
+  _STDERR="${_TMPROOT}/stderr.txt"
   EXIT_CODE=0
-  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
-    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
+  printf '%s\n' "$_INIT_REQ" | \
+    CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
+    PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    LUMEN_MOCK_BINARY="${_MOCK_BIN}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >"${_STDOUT}" 2>"${_STDERR}" \
+    || EXIT_CODE=$?
 
   if [ "$EXIT_CODE" -ne 0 ]; then
-    echo "  FAIL: run.sh stdio with missing binary exited $EXIT_CODE — MCP server would be dead for the session"
+    echo "  FAIL: run.sh stdio exited $EXIT_CODE — MCP server would be dead for the session"
+    echo "        stderr:"
+    sed 's/^/          /' "${_STDERR}"
     exit 1
   fi
   if [ ! -x "$_EXPECTED_BINARY" ]; then
-    echo "  FAIL: run.sh stdio did not download binary to ${_EXPECTED_BINARY}"
+    echo "  FAIL: run.sh stdio did not place artefact at ${_EXPECTED_BINARY}"
     exit 1
   fi
-  echo "  PASS: run.sh stdio downloads binary and execs it on first install"
+  if ! grep -q '"jsonrpc":"2.0"' "${_STDOUT}"; then
+    echo "  FAIL: MCP initialize produced no JSON-RPC 2.0 response on stdout"
+    echo "        stdout:"
+    sed 's/^/          /' "${_STDOUT}"
+    exit 1
+  fi
+  if ! grep -q '"name":"mock-lumen"' "${_STDOUT}"; then
+    echo "  FAIL: MCP response did not come from the exec'd mock — launcher may be swallowing stdout"
+    echo "        stdout:"
+    sed 's/^/          /' "${_STDOUT}"
+    exit 1
+  fi
+  echo "  PASS: run.sh stdio downloads, execs, and brokers MCP initialize on first install"
 ) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
 echo ""

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -269,6 +269,61 @@ assert_eq "garbage tag"         "invalid" "$(validate_tag "not-a-version")"
 assert_eq "html fragment"       "invalid" "$(validate_tag "<html>")"
 
 echo ""
+echo "=== stdio first-install integration test ==="
+
+# End-to-end guard against the bug in #125: when the binary is missing and
+# run.sh is invoked as `run.sh stdio` (how Claude Code starts the MCP server
+# on first install), the launcher must download the binary and exec it. If
+# the stdio path fast-exits before reaching the download, the MCP server is
+# dead for the entire session because Claude Code does not retry failed MCP
+# servers. This test stubs curl so no real network call is made.
+(
+  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _TMPROOT="$(mktemp -d)"
+  _FAKE_CURL_DIR="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
+
+  _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  _ARCH_RAW="$(uname -m)"
+  case "$_ARCH_RAW" in
+    x86_64)  _ARCH="amd64" ;;
+    aarch64) _ARCH="arm64" ;;
+    *)       _ARCH="$_ARCH_RAW" ;;
+  esac
+  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${_OS}-${_ARCH}"
+
+  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
+  mkdir -p "${_TMPROOT}/bin"
+
+  # Stub curl: write a trivial executable to the -o target and succeed.
+  cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+exit 0
+FAKECURL
+  chmod +x "${_FAKE_CURL_DIR}/curl"
+
+  EXIT_CODE=0
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "  FAIL: run.sh stdio with missing binary exited $EXIT_CODE — MCP server would be dead for the session"
+    exit 1
+  fi
+  if [ ! -x "$_EXPECTED_BINARY" ]; then
+    echo "  FAIL: run.sh stdio did not download binary to ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  echo "  PASS: run.sh stdio downloads binary and execs it on first install"
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+echo ""
 echo "=== summary ==="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -94,8 +94,13 @@ exit /b 0
         $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
 
         $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.WriteLine($initReq)
-        $proc.StandardInput.Close()
+
+        # If run.bat fast-exits in stdio mode, its stdin pipe is already
+        # closed by the time we try to write — that IS the #125 symptom,
+        # so swallow the broken-pipe exception and let the exit-code check
+        # below produce the real diagnostic.
+        try { $proc.StandardInput.WriteLine($initReq) } catch { }
+        try { $proc.StandardInput.Close() } catch { }
 
         $stdout = $proc.StandardOutput.ReadToEnd()
         $stderr = $proc.StandardError.ReadToEnd()

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -1,0 +1,132 @@
+#!/usr/bin/env pwsh
+# End-to-end test for run.bat on Windows, mirroring the POSIX MCP handshake
+# test in test_run.sh. Exercises the first-install code path: no binary in
+# bin/, a stub curl.bat shadows real curl via PATH, the "download" copies a
+# cross-compiled mock MCP server into place, and a real JSON-RPC initialize
+# request is piped into `run.bat stdio` with the response asserted.
+#
+# Passing proves run.bat did not fast-exit in stdio mode, reached the
+# download path, wrote the artefact where it would exec it, and invoked
+# it with stdin/stdout inherited correctly.
+
+$ErrorActionPreference = 'Stop'
+
+$PASS = 0
+$FAIL = 0
+
+function Pass($msg) { Write-Host "  PASS: $msg"; $script:PASS++ }
+function Fail($msg) { Write-Host "  FAIL: $msg"; $script:FAIL++ }
+
+Write-Host "=== stdio first-install MCP handshake test (run.bat) ==="
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+
+$TmpRoot     = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "lumen-stdio-$([guid]::NewGuid().ToString('N'))")).FullName
+$FakeCurlDir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "fakecurl-$([guid]::NewGuid().ToString('N'))")).FullName
+$MockBinDir  = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "mockbin-$([guid]::NewGuid().ToString('N'))")).FullName
+
+$origPath = $env:PATH
+
+try {
+    $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'amd64' }
+    $expectedBinary = Join-Path $TmpRoot "bin\lumen-windows-$arch.exe"
+
+    # Build the mock MCP server — pure Go, no CGO.
+    $mockBin = Join-Path $MockBinDir 'mock_lumen.exe'
+    $env:CGO_ENABLED = '0'
+    Push-Location $RepoRoot
+    try {
+        $buildOutput = & go build -o $mockBin ./scripts/testdata/mock_mcp_server 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Fail "could not build mock MCP server (exit $LASTEXITCODE)"
+            $buildOutput | ForEach-Object { Write-Host "          $_" }
+            return
+        }
+    } finally {
+        Pop-Location
+    }
+
+    # Minimal plugin root: manifest only.
+    $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
+    [IO.File]::WriteAllText((Join-Path $TmpRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
+    New-Item -ItemType Directory -Path (Join-Path $TmpRoot 'bin') | Out-Null
+
+    # Stub curl: curl.bat parses -o <target> and copies the prebuilt mock in.
+    # cmd.exe's PATHEXT search is per-directory: our fake dir is prepended
+    # to PATH and contains only curl.bat, so it wins over C:\Windows\System32
+    # regardless of PATHEXT ordering.
+    $curlStub = @'
+@echo off
+setlocal enabledelayedexpansion
+:loop
+if "%~1"=="" goto done
+if "%~1"=="-o" (
+  copy /Y "%LUMEN_MOCK_BINARY%" "%~2" >nul
+  shift
+  shift
+  goto loop
+)
+shift
+goto loop
+:done
+exit /b 0
+'@
+    [IO.File]::WriteAllText((Join-Path $FakeCurlDir 'curl.bat'), $curlStub, [Text.Encoding]::ASCII)
+
+    # Write the MCP initialize request (LF-terminated) to a stdin file.
+    $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+    $stdinFile  = Join-Path $TmpRoot 'stdin.txt'
+    $stdoutFile = Join-Path $TmpRoot 'stdout.txt'
+    $stderrFile = Join-Path $TmpRoot 'stderr.txt'
+    [IO.File]::WriteAllText($stdinFile, $initReq + "`n", [Text.Encoding]::ASCII)
+
+    $env:CLAUDE_PLUGIN_ROOT = $TmpRoot
+    $env:LUMEN_MOCK_BINARY  = $mockBin
+    $env:PATH = "$FakeCurlDir;$origPath"
+
+    $runBat = Join-Path $ScriptDir 'run.bat'
+    $proc = Start-Process -FilePath cmd.exe `
+        -ArgumentList '/c', "`"$runBat`" stdio" `
+        -RedirectStandardInput  $stdinFile `
+        -RedirectStandardOutput $stdoutFile `
+        -RedirectStandardError  $stderrFile `
+        -NoNewWindow -Wait -PassThru
+
+    $exitCode = $proc.ExitCode
+
+    if ($exitCode -ne 0) {
+        Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
+        Write-Host "        stderr:"
+        if (Test-Path $stderrFile) { Get-Content $stderrFile | ForEach-Object { Write-Host "          $_" } }
+        return
+    }
+    if (-not (Test-Path $expectedBinary)) {
+        Fail "run.bat stdio did not place artefact at $expectedBinary"
+        return
+    }
+    $stdout = if (Test-Path $stdoutFile) { Get-Content $stdoutFile -Raw } else { '' }
+    if ($stdout -notmatch '"jsonrpc":"2\.0"') {
+        Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
+        Write-Host "        stdout:"
+        ($stdout -split "`n") | ForEach-Object { Write-Host "          $_" }
+        return
+    }
+    if ($stdout -notmatch '"name":"mock-lumen"') {
+        Fail "MCP response did not come from the exec'd mock — run.bat may be swallowing stdout"
+        Write-Host "        stdout:"
+        ($stdout -split "`n") | ForEach-Object { Write-Host "          $_" }
+        return
+    }
+    Pass "run.bat stdio downloads, execs, and brokers MCP initialize on first install"
+} finally {
+    $env:PATH = $origPath
+    Remove-Item -Recurse -Force $TmpRoot, $FakeCurlDir, $MockBinDir -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host '=== summary ==='
+Write-Host "  passed: $PASS"
+Write-Host "  failed: $FAIL"
+if ($FAIL -gt 0) { exit 1 }
+exit 0

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -4,10 +4,6 @@
 # bin/, a stub curl.bat shadows real curl via PATH, the "download" copies a
 # cross-compiled mock MCP server into place, and a real JSON-RPC initialize
 # request is piped into `run.bat stdio` with the response asserted.
-#
-# Passing proves run.bat did not fast-exit in stdio mode, reached the
-# download path, wrote the artefact where it would exec it, and invoked
-# it with stdin/stdout inherited correctly.
 
 $ErrorActionPreference = 'Stop'
 
@@ -27,6 +23,8 @@ $FakeCurlDir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "fakecur
 $MockBinDir  = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "mockbin-$([guid]::NewGuid().ToString('N'))")).FullName
 
 $origPath = $env:PATH
+$buildOK  = $false
+$proc     = $null
 
 try {
     $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'amd64' }
@@ -38,25 +36,27 @@ try {
     Push-Location $RepoRoot
     try {
         $buildOutput = & go build -o $mockBin ./scripts/testdata/mock_mcp_server 2>&1
-        if ($LASTEXITCODE -ne 0) {
+        if ($LASTEXITCODE -eq 0) {
+            $buildOK = $true
+        } else {
             Fail "could not build mock MCP server (exit $LASTEXITCODE)"
             $buildOutput | ForEach-Object { Write-Host "          $_" }
-            return
         }
     } finally {
         Pop-Location
     }
 
-    # Minimal plugin root: manifest only.
-    $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
-    [IO.File]::WriteAllText((Join-Path $TmpRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
-    New-Item -ItemType Directory -Path (Join-Path $TmpRoot 'bin') | Out-Null
+    if ($buildOK) {
+        # Minimal plugin root: manifest only.
+        $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
+        [IO.File]::WriteAllText((Join-Path $TmpRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
+        New-Item -ItemType Directory -Path (Join-Path $TmpRoot 'bin') | Out-Null
 
-    # Stub curl: curl.bat parses -o <target> and copies the prebuilt mock in.
-    # cmd.exe's PATHEXT search is per-directory: our fake dir is prepended
-    # to PATH and contains only curl.bat, so it wins over C:\Windows\System32
-    # regardless of PATHEXT ordering.
-    $curlStub = @'
+        # Stub curl: curl.bat parses -o <target> and copies the prebuilt mock in.
+        # cmd.exe's PATHEXT search is per-directory: our fake dir is prepended
+        # to PATH and contains only curl.bat, so it wins regardless of PATHEXT
+        # ordering (each directory is tried fully before moving to the next).
+        $curlStub = @'
 @echo off
 setlocal enabledelayedexpansion
 :loop
@@ -72,55 +72,65 @@ goto loop
 :done
 exit /b 0
 '@
-    [IO.File]::WriteAllText((Join-Path $FakeCurlDir 'curl.bat'), $curlStub, [Text.Encoding]::ASCII)
+        [IO.File]::WriteAllText((Join-Path $FakeCurlDir 'curl.bat'), $curlStub, [Text.Encoding]::ASCII)
 
-    # Write the MCP initialize request (LF-terminated) to a stdin file.
-    $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
-    $stdinFile  = Join-Path $TmpRoot 'stdin.txt'
-    $stdoutFile = Join-Path $TmpRoot 'stdout.txt'
-    $stderrFile = Join-Path $TmpRoot 'stderr.txt'
-    [IO.File]::WriteAllText($stdinFile, $initReq + "`n", [Text.Encoding]::ASCII)
+        # Launch run.bat via System.Diagnostics.Process for reliable exit-code
+        # propagation and explicit stdin/stdout/stderr wiring. Start-Process
+        # with -RedirectStandardInput is unreliable here.
+        $runBat  = Join-Path $ScriptDir 'run.bat'
+        $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
 
-    $env:CLAUDE_PLUGIN_ROOT = $TmpRoot
-    $env:LUMEN_MOCK_BINARY  = $mockBin
-    $env:PATH = "$FakeCurlDir;$origPath"
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = 'cmd.exe'
+        $psi.Arguments = "/c `"$runBat`" stdio"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput  = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError  = $true
+        $psi.CreateNoWindow = $true
+        $psi.WorkingDirectory = $RepoRoot
+        $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $TmpRoot
+        $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
+        $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
 
-    $runBat = Join-Path $ScriptDir 'run.bat'
-    $proc = Start-Process -FilePath cmd.exe `
-        -ArgumentList '/c', "`"$runBat`" stdio" `
-        -RedirectStandardInput  $stdinFile `
-        -RedirectStandardOutput $stdoutFile `
-        -RedirectStandardError  $stderrFile `
-        -NoNewWindow -Wait -PassThru
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.WriteLine($initReq)
+        $proc.StandardInput.Close()
 
-    $exitCode = $proc.ExitCode
+        $stdout = $proc.StandardOutput.ReadToEnd()
+        $stderr = $proc.StandardError.ReadToEnd()
+        if (-not $proc.WaitForExit(60000)) {
+            $proc.Kill()
+            Fail "run.bat stdio did not exit within 60s"
+        } else {
+            $exitCode = $proc.ExitCode
 
-    if ($exitCode -ne 0) {
-        Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
-        Write-Host "        stderr:"
-        if (Test-Path $stderrFile) { Get-Content $stderrFile | ForEach-Object { Write-Host "          $_" } }
-        return
+            Write-Host "    launcher exit code: $exitCode"
+            if ($stderr) {
+                Write-Host "    launcher stderr:"
+                ($stderr -split "`r?`n") | ForEach-Object { if ($_) { Write-Host "      $_" } }
+            }
+
+            if ($exitCode -ne 0) {
+                Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
+            } elseif (-not (Test-Path $expectedBinary)) {
+                Fail "run.bat stdio did not place artefact at $expectedBinary"
+            } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
+                Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
+                Write-Host "        stdout:"
+                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+            } elseif ($stdout -notmatch '"name":"mock-lumen"') {
+                Fail "MCP response did not come from the exec'd mock — run.bat may be swallowing stdout"
+                Write-Host "        stdout:"
+                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+            } else {
+                Pass "run.bat stdio downloads, execs, and brokers MCP initialize on first install"
+            }
+        }
     }
-    if (-not (Test-Path $expectedBinary)) {
-        Fail "run.bat stdio did not place artefact at $expectedBinary"
-        return
-    }
-    $stdout = if (Test-Path $stdoutFile) { Get-Content $stdoutFile -Raw } else { '' }
-    if ($stdout -notmatch '"jsonrpc":"2\.0"') {
-        Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
-        Write-Host "        stdout:"
-        ($stdout -split "`n") | ForEach-Object { Write-Host "          $_" }
-        return
-    }
-    if ($stdout -notmatch '"name":"mock-lumen"') {
-        Fail "MCP response did not come from the exec'd mock — run.bat may be swallowing stdout"
-        Write-Host "        stdout:"
-        ($stdout -split "`n") | ForEach-Object { Write-Host "          $_" }
-        return
-    }
-    Pass "run.bat stdio downloads, execs, and brokers MCP initialize on first install"
 } finally {
     $env:PATH = $origPath
+    if ($proc -and -not $proc.HasExited) { try { $proc.Kill() } catch {} }
     Remove-Item -Recurse -Force $TmpRoot, $FakeCurlDir, $MockBinDir -ErrorAction SilentlyContinue
 }
 

--- a/scripts/testdata/mock_mcp_server/main.go
+++ b/scripts/testdata/mock_mcp_server/main.go
@@ -1,0 +1,38 @@
+// Mock MCP server used by launcher integration tests.
+//
+// Reads exactly one line from stdin. If that line looks like a JSON-RPC
+// `initialize` request, prints a minimal JSON-RPC response on stdout and
+// exits 0. Any other input is treated as a test failure.
+//
+// The mock is cross-compiled per-OS by the launcher test harness and dropped
+// into place by a stub `curl`, simulating the first-install download path.
+// Running the real launcher against this mock proves that the launcher:
+//
+//   1. Reaches the download code path (not the stdio fast-fail),
+//   2. Places the downloaded artefact where it will be exec'd,
+//   3. Sets the artefact executable,
+//   4. Passes stdin/stdout straight through to the artefact.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const initializeResponse = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"mock-lumen","version":"0.0.0"}}}`
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		fmt.Fprintln(os.Stderr, "mock_mcp_server: stdin closed before a request arrived:", err)
+		os.Exit(2)
+	}
+	if !strings.Contains(line, `"method":"initialize"`) {
+		fmt.Fprintln(os.Stderr, "mock_mcp_server: expected initialize request, got:", strings.TrimSpace(line))
+		os.Exit(3)
+	}
+	fmt.Println(initializeResponse)
+}


### PR DESCRIPTION
## Summary

Adds a **deliberately failing** end-to-end test suite in `scripts/test_run.sh` and a new `scripts/test_run_windows.ps1` that reproduce the first-install MCP failure from #125 on both POSIX and Windows launchers. Expect CI to go red on ubuntu, macos, and windows — that is the point of this PR.

## Why the existing CI suite missed the bug

Two gaps, stacked:

1. **No end-to-end invocation of the launchers.** The previous `stdio early-exit guard tests` block reimplemented the guard condition inline as a local helper and asserted "the guard fires for the `stdio` arg" as correct behaviour — codifying the bug as the spec. Nothing actually ran `bash run.sh stdio` (let alone `run.bat stdio`) with a missing binary.
2. **No Windows coverage at all** for `run.bat`'s first-install code path. `run.bat` has the identical fast-fail guard at lines 28–32. #127 only fixes POSIX; a Windows-only fix still needs to land, and nothing in CI would have told us that.

## What this PR adds

- **`scripts/testdata/mock_mcp_server/main.go`** — a tiny pure-Go mock MCP server. Reads one line from stdin, and if it is a JSON-RPC `initialize` request it writes a valid MCP `initialize` response and exits 0. Cross-compiles on all three runners, no CGO.
- **Real MCP handshake in `test_run.sh`** — replaces the old stub-curl-plus-`exit 0` test. The test now builds the mock, stubs `curl` in PATH to drop the mock binary into place, pipes a real `initialize` request into `bash run.sh stdio`, and asserts the stdout response contains `"jsonrpc":"2.0"` and `"name":"mock-lumen"`. A pass transitively proves the launcher didn't fast-exit, reached the download path, wrote the artefact where it would exec it, chmod'd it executable, and exec'd it with stdin/stdout inherited correctly.
- **`scripts/test_run_windows.ps1`** — same shape, against `run.bat`, via PowerShell. Uses a `curl.bat` stub on a PATH-prepended dir (cmd.exe's PATHEXT lookup finds the `.bat` first).
- **CI matrix** — `scripts` job expanded to `ubuntu-latest + macos-latest + windows-latest`, `fail-fast: false`, `actions/setup-go` added. New pwsh step runs the Windows launcher test.

## Bugs this kind of test catches that the old one couldn't

Beyond the #125 fast-fail, a stubbed-curl / stubbed-binary test can pass even when the launcher has any of these real bugs:

- Launcher closes stdin or stdout before exec
- Launcher writes the binary to one path but execs from another
- Launcher forgets to `chmod +x`
- Binary actually runs but doesn't speak MCP (broken flag parsing, crash on startup, etc.)
- CRLF / quoting mishaps in `run.bat` that prevent the process from ever starting

A real MCP handshake against a real process is the only way to catch these.

## Red / green

- Against `main` today → **RED on POSIX and Windows** (both launchers still contain the stdio fast-fail)
- Against #127 + an equivalent `run.bat` fix → **GREEN on all three OSes**

## Next steps

Merge #127 and add the matching `run.bat` change to flip both tests green, or fold these commits into that PR as its TDD red-phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)