### PR TITLE
fix(scripts): use call curl in run.bat so batch control returns after download

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -52,7 +52,7 @@ if not exist "%BINARY%" (
   echo Downloading lumen !VERSION! for windows/!ARCH!... >&2
   if not exist "%PLUGIN_ROOT%\bin" mkdir "%PLUGIN_ROOT%\bin"
 
-  curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
+  call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
   if errorlevel 1 (
     :: Fallback: manifest version not released yet — resolve latest from GitHub API
     echo Version !VERSION! not found, resolving latest release... >&2
@@ -61,7 +61,7 @@ if not exist "%BINARY%" (
     if defined GITHUB_TOKEN set "AUTH_HEADER=-H "Authorization: token %GITHUB_TOKEN%""
 
     set "TMPJSON=%TEMP%\lumen-latest.json"
-    curl -sfL !AUTH_HEADER! --max-time 30 --retry 2 --retry-delay 2 ^
+    call curl -sfL !AUTH_HEADER! --max-time 30 --retry 2 --retry-delay 2 ^
       "https://api.github.com/repos/!REPO!/releases/latest" -o "!TMPJSON!"
 
     set "LATEST_TAG="
@@ -88,7 +88,7 @@ if not exist "%BINARY%" (
     set "ASSET=lumen-!VERSION:~1!-windows-!ARCH!.exe"
     set "URL=https://github.com/!REPO!/releases/download/!VERSION!/!ASSET!"
 
-    curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
+    call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
     if errorlevel 1 (
       echo Error: fallback download also failed >&2
       exit /b 1


### PR DESCRIPTION
## Root cause

CMD batch files silently swallow control when one `.bat` file invokes another without `call` — the called batch runs, but execution never returns to the caller.

The Windows CI test (`test_run_windows.ps1`) stubs real `curl` with a `curl.bat` shim placed at the front of `PATH`. When `run.bat` reaches the download step and invokes:

```bat
curl -sfL ... -o "%BINARY%"
```

CMD finds `curl.bat` first. Without `call`, control transfers to `curl.bat`, the fake download completes (copying the mock binary into place), but `run.bat` never resumes — `"%BINARY%" %*` is never executed, stdout is empty, and the MCP handshake assertion fails.

## Fix

Add `call` before all three `curl` invocations in `run.bat`. `call` is a no-op for real `.exe` files, so production behaviour is unchanged. For `.bat`/`.cmd` files on `PATH`, it ensures the caller gets control back.

## Test plan

- [ ] Windows CI test `Windows launcher MCP handshake (run.bat stdio)` should now pass
- [ ] `call curl.exe` works identically to `curl.exe` for the real binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)