### PR TITLE
fix(embedder): re-probe unhealthy servers and resolve dimension mismatch on failover

### DIFF
--- a/internal/embedder/failover.go
+++ b/internal/embedder/failover.go
@@ -27,6 +27,7 @@ import (
 )
 
 const healthCheckTimeout = 5 * time.Second
+const reprobeInterval = 30 * time.Second
 
 // FailoverEmbedder wraps multiple backend embedders with ordered health-check
 // failover. It probes servers on first use and fails over on transient errors.
@@ -40,6 +41,7 @@ type FailoverEmbedder struct {
 	cachedConfigs []config.ServerConfig // snapshot at last init
 	active        int
 	checked       bool
+	lastProbeTime time.Time
 }
 
 type serverEntry struct {
@@ -66,10 +68,17 @@ func (f *FailoverEmbedder) ActiveServerIndex() int {
 	return f.active
 }
 
-// Dimensions returns dims for the active server (or server 0 before first
-// Embed call).
+// Dimensions returns dims for the active server. On first call it probes
+// servers for health to ensure the returned dimensions match the server
+// that will actually handle embeddings.
 func (f *FailoverEmbedder) Dimensions() int {
 	f.mu.Lock()
+	needsInit := !f.checked || f.serversChanged()
+	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
+	if needsInit || needsReprobe {
+		f.initServers()
+		f.checked = true
+	}
 	idx := f.active
 	f.mu.Unlock()
 	if idx < 0 {
@@ -78,9 +87,17 @@ func (f *FailoverEmbedder) Dimensions() int {
 	return f.cfg.ServerDims(idx)
 }
 
-// ModelName returns the model name for the active server.
+// ModelName returns the model name for the active server. On first call it
+// probes servers for health to ensure the returned name matches the server
+// that will actually handle embeddings.
 func (f *FailoverEmbedder) ModelName() string {
 	f.mu.Lock()
+	needsInit := !f.checked || f.serversChanged()
+	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
+	if needsInit || needsReprobe {
+		f.initServers()
+		f.checked = true
+	}
 	idx := f.active
 	f.mu.Unlock()
 	if idx < 0 {
@@ -98,7 +115,12 @@ func (f *FailoverEmbedder) ModelName() string {
 // errors (5xx, network) it fails over to the next healthy server.
 func (f *FailoverEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
 	f.mu.Lock()
-	if !f.checked || f.serversChanged() {
+	needsInit := !f.checked || f.serversChanged()
+	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
+	if needsInit || needsReprobe {
+		if needsReprobe && f.logger != nil {
+			f.logger.Info("re-probing embedding servers after cooldown")
+		}
 		f.initServers()
 		f.checked = true
 	}
@@ -132,6 +154,7 @@ func (f *FailoverEmbedder) Embed(ctx context.Context, texts []string) ([][]float
 		f.servers[active].healthy = false
 		next := f.findNextHealthy(active)
 		if next < 0 {
+			f.active = -1
 			f.mu.Unlock()
 			return nil, fmt.Errorf("all embedding servers exhausted after failover: last error: %w", err)
 		}
@@ -171,6 +194,7 @@ func (f *FailoverEmbedder) serversChanged() bool {
 // initServers initializes the server list and probes for the first healthy
 // server. Must be called with f.mu held.
 func (f *FailoverEmbedder) initServers() {
+	f.lastProbeTime = time.Now()
 	servers := f.cfg.Servers()
 	f.servers = make([]serverEntry, len(servers))
 	f.cachedConfigs = make([]config.ServerConfig, len(servers))

--- a/internal/embedder/failover.go
+++ b/internal/embedder/failover.go
@@ -68,18 +68,27 @@ func (f *FailoverEmbedder) ActiveServerIndex() int {
 	return f.active
 }
 
+// maybeReprobe checks whether servers need (re-)initialization and does so
+// if required. Must be called with f.mu held. Returns the current active index.
+func (f *FailoverEmbedder) maybeReprobe(log bool) int {
+	needsInit := !f.checked || f.serversChanged()
+	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
+	if needsInit || needsReprobe {
+		if needsReprobe && log && f.logger != nil {
+			f.logger.Info("re-probing embedding servers after cooldown")
+		}
+		f.initServers()
+		f.checked = true
+	}
+	return f.active
+}
+
 // Dimensions returns dims for the active server. On first call it probes
 // servers for health to ensure the returned dimensions match the server
 // that will actually handle embeddings.
 func (f *FailoverEmbedder) Dimensions() int {
 	f.mu.Lock()
-	needsInit := !f.checked || f.serversChanged()
-	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
-	if needsInit || needsReprobe {
-		f.initServers()
-		f.checked = true
-	}
-	idx := f.active
+	idx := f.maybeReprobe(false)
 	f.mu.Unlock()
 	if idx < 0 {
 		idx = 0
@@ -92,13 +101,7 @@ func (f *FailoverEmbedder) Dimensions() int {
 // that will actually handle embeddings.
 func (f *FailoverEmbedder) ModelName() string {
 	f.mu.Lock()
-	needsInit := !f.checked || f.serversChanged()
-	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
-	if needsInit || needsReprobe {
-		f.initServers()
-		f.checked = true
-	}
-	idx := f.active
+	idx := f.maybeReprobe(false)
 	f.mu.Unlock()
 	if idx < 0 {
 		idx = 0
@@ -115,15 +118,7 @@ func (f *FailoverEmbedder) ModelName() string {
 // errors (5xx, network) it fails over to the next healthy server.
 func (f *FailoverEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
 	f.mu.Lock()
-	needsInit := !f.checked || f.serversChanged()
-	needsReprobe := f.active < 0 && time.Since(f.lastProbeTime) >= reprobeInterval
-	if needsInit || needsReprobe {
-		if needsReprobe && f.logger != nil {
-			f.logger.Info("re-probing embedding servers after cooldown")
-		}
-		f.initServers()
-		f.checked = true
-	}
+	f.maybeReprobe(true)
 	f.mu.Unlock()
 
 	if f.active < 0 {

--- a/internal/embedder/failover_test.go
+++ b/internal/embedder/failover_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -171,12 +172,13 @@ func TestFailover_DimensionsReflectActive(t *testing.T) {
 		config.ServerConfig{Backend: "ollama", Host: up.URL, Model: "b", Dims: 1024},
 	)
 	fe := NewFailoverEmbedder(cfg)
-	if got := fe.Dimensions(); got != 768 {
-		t.Errorf("before embed: Dimensions() = %d, want 768", got)
+	// Dimensions() eagerly inits and picks the healthy server (b, 1024 dims).
+	if got := fe.Dimensions(); got != 1024 {
+		t.Errorf("before embed: Dimensions() = %d, want 1024 (healthy server)", got)
 	}
 	_, _ = fe.Embed(context.Background(), []string{"hello"})
 	if got := fe.Dimensions(); got != 1024 {
-		t.Errorf("after failover: Dimensions() = %d, want 1024", got)
+		t.Errorf("after embed: Dimensions() = %d, want 1024", got)
 	}
 	if got := fe.ModelName(); got != "b" {
 		t.Errorf("ModelName() = %q, want %q", got, "b")
@@ -470,5 +472,180 @@ func TestFailover_Unreachable_LogsConnectionError(t *testing.T) {
 	}
 	if !strings.Contains(logs, "selected embedding server") {
 		t.Error("expected server selection log")
+	}
+}
+
+// newTogglableOllamaServer creates an Ollama test server whose health and embed
+// responses can be toggled at runtime via atomic booleans.
+func newTogglableOllamaServer(t *testing.T, healthy *atomic.Bool, embedOK *atomic.Bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/":
+			if healthy.Load() {
+				_, _ = fmt.Fprint(w, "Ollama is running")
+			} else {
+				w.WriteHeader(503)
+			}
+		case r.Method == "POST" && r.URL.Path == "/api/embed":
+			if embedOK.Load() {
+				w.WriteHeader(200)
+				_, _ = fmt.Fprint(w, `{"embeddings":[[0.1,0.2,0.3]]}`)
+			} else {
+				w.WriteHeader(500)
+				_, _ = fmt.Fprint(w, `{"error":"server error"}`)
+			}
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+}
+
+func TestFailover_ReprobesAfterCooldown(t *testing.T) {
+	// Both servers start unhealthy (health probe returns 503).
+	healthy1 := &atomic.Bool{}
+	healthy2 := &atomic.Bool{}
+	embed1 := &atomic.Bool{}
+	embed2 := &atomic.Bool{}
+	embed1.Store(true)
+	embed2.Store(true)
+
+	srv1 := newTogglableOllamaServer(t, healthy1, embed1)
+	defer srv1.Close()
+	srv2 := newTogglableOllamaServer(t, healthy2, embed2)
+	defer srv2.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: srv1.URL, Model: "test-a", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: srv2.URL, Model: "test-b", Dims: 3},
+	)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fe := NewFailoverEmbedder(cfg)
+	fe.SetLogger(logger)
+
+	// Step 1: All servers down — expect error.
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err == nil || !strings.Contains(err.Error(), "unhealthy") {
+		t.Fatalf("expected 'unhealthy' error, got: %v", err)
+	}
+
+	// Step 2: Make server 0 healthy.
+	healthy1.Store(true)
+
+	// Step 3: Embed immediately — should still fail (cooldown hasn't elapsed).
+	_, err = fe.Embed(context.Background(), []string{"hello"})
+	if err == nil {
+		t.Fatal("expected error before cooldown elapsed, but Embed succeeded")
+	}
+
+	// Step 4: Expire the cooldown by backdating lastProbeTime.
+	fe.mu.Lock()
+	fe.lastProbeTime = time.Now().Add(-reprobeInterval - time.Second)
+	fe.mu.Unlock()
+
+	// Step 5: Now Embed should re-probe and succeed.
+	_, err = fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("expected success after cooldown, got: %v", err)
+	}
+
+	// Verify re-probe was logged.
+	logs := buf.String()
+	if !strings.Contains(logs, "re-probing embedding servers after cooldown") {
+		t.Error("expected 're-probing' log entry")
+	}
+}
+
+func TestFailover_ReprobesAfterFailoverExhaustion(t *testing.T) {
+	// Both servers pass health check but return 500 on embed.
+	healthy1 := &atomic.Bool{}
+	healthy2 := &atomic.Bool{}
+	embed1 := &atomic.Bool{}
+	embed2 := &atomic.Bool{}
+	healthy1.Store(true)
+	healthy2.Store(true)
+	// embed bools default to false → 500
+
+	srv1 := newTogglableOllamaServer(t, healthy1, embed1)
+	defer srv1.Close()
+	srv2 := newTogglableOllamaServer(t, healthy2, embed2)
+	defer srv2.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: srv1.URL, Model: "test-a", Dims: 3},
+		config.ServerConfig{Backend: "ollama", Host: srv2.URL, Model: "test-b", Dims: 3},
+	)
+
+	fe := NewFailoverEmbedder(cfg)
+
+	// Step 1: Embed fails — both servers return 500, failover exhausted.
+	_, err := fe.Embed(context.Background(), []string{"hello"})
+	if err == nil || !strings.Contains(err.Error(), "exhausted") {
+		t.Fatalf("expected 'exhausted' error, got: %v", err)
+	}
+
+	// Step 2: ActiveServerIndex should be -1 after exhaustion.
+	if idx := fe.ActiveServerIndex(); idx != -1 {
+		t.Fatalf("expected ActiveServerIndex() == -1 after exhaustion, got %d", idx)
+	}
+
+	// Step 3: Fix server 0 to return 200 on embed.
+	embed1.Store(true)
+
+	// Step 4: Expire cooldown.
+	fe.mu.Lock()
+	fe.lastProbeTime = time.Now().Add(-reprobeInterval - time.Second)
+	fe.mu.Unlock()
+
+	// Step 5: Embed should re-probe and succeed.
+	_, err = fe.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("expected success after cooldown + fix, got: %v", err)
+	}
+}
+
+func TestFailover_ModelNameTriggersInit(t *testing.T) {
+	// Server 0 (LM Studio-like, 3584 dims) is DOWN.
+	// Server 1 (Ollama-like, 768 dims) is UP.
+	// ModelName() should eagerly init and return server 1's model, not server 0's.
+	down := newTestOllamaServer(t, false, 200)
+	defer down.Close()
+	up := newTestOllamaServer(t, true, 200)
+	defer up.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: down.URL, Model: "big-model", Dims: 3584},
+		config.ServerConfig{Backend: "ollama", Host: up.URL, Model: "small-model", Dims: 768},
+	)
+
+	fe := NewFailoverEmbedder(cfg)
+
+	// Before any Embed() call, ModelName() should return the healthy server's model.
+	if got := fe.ModelName(); got != "small-model" {
+		t.Errorf("ModelName() = %q, want %q (should eagerly init and pick healthy server)", got, "small-model")
+	}
+}
+
+func TestFailover_DimensionsTriggersInit(t *testing.T) {
+	// Server 0 (3584 dims) is DOWN, server 1 (768 dims) is UP.
+	// Dimensions() should eagerly init and return 768, not 3584.
+	down := newTestOllamaServer(t, false, 200)
+	defer down.Close()
+	up := newTestOllamaServer(t, true, 200)
+	defer up.Close()
+
+	cfg := testConfigService(t,
+		config.ServerConfig{Backend: "ollama", Host: down.URL, Model: "big-model", Dims: 3584},
+		config.ServerConfig{Backend: "ollama", Host: up.URL, Model: "small-model", Dims: 768},
+	)
+
+	fe := NewFailoverEmbedder(cfg)
+
+	// Before any Embed() call, Dimensions() should return the healthy server's dims.
+	if got := fe.Dimensions(); got != 768 {
+		t.Errorf("Dimensions() = %d, want 768 (should eagerly init and pick healthy server)", got)
 	}
 }


### PR DESCRIPTION
## Summary

- **Re-probe after all-unhealthy**: Once `initServers()` found all embedding servers down, `FailoverEmbedder` was permanently stuck returning errors — even after the server came back up. Now re-probes every 30 seconds when no healthy server is available.
- **Dimension mismatch on failover**: `ModelName()` and `Dimensions()` returned stale server-0 values before the first `Embed()` call. When failover selected a different server (e.g. Ollama 768-dim instead of LM Studio 3584-dim), the Indexer was created with wrong dimensions, causing sqlite-vec errors. Now both methods eagerly init to return correct values.
- **Failover exhaustion recovery**: When all servers were exhausted during embed (transient 5xx errors), `active` wasn't reset to `-1`, preventing the re-probe path from triggering on subsequent calls.

## Test plan

- [x] `TestFailover_ReprobesAfterCooldown` — all servers down, one recovers, re-probe after 30s cooldown succeeds
- [x] `TestFailover_ReprobesAfterFailoverExhaustion` — servers healthy on probe but 500 on embed, exhaustion resets active, re-probe works
- [x] `TestFailover_ModelNameTriggersInit` — `ModelName()` eagerly inits and returns healthy server's model
- [x] `TestFailover_DimensionsTriggersInit` — `Dimensions()` eagerly inits and returns healthy server's dims
- [x] Updated `TestFailover_DimensionsReflectActive` to match new eager init behavior
- [x] All 30 embedder tests pass, 0 lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure active server state is cleared after failover exhaustion to allow correct recovery.

* **Improvements**
  * Periodic health re-probing after a cooldown so recovered servers become available again.
  * Eager initialization so model name and embedding dimensions reflect the current healthy server sooner.
  * Added informational logging when a re-probe is triggered.

* **Tests**
  * Added tests covering cooldown reprobes, failover exhaustion recovery, and eager initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->