### PR TITLE
feat(purge): support purging individual project directories

### DIFF
--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -16,10 +16,14 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/git"
+	"github.com/ory/lumen/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -28,20 +32,41 @@ func init() {
 }
 
 var purgeCmd = &cobra.Command{
-	Use:   "purge",
-	Short: "Remove all lumen index data",
-	Long:  "Deletes all lumen index databases from ~/.local/share/lumen/. This is irreversible — indexes will be rebuilt on the next search.",
-	Args:  cobra.NoArgs,
-	RunE:  runPurge,
+	Use:   "purge [path...]",
+	Short: "Remove lumen index data",
+	Long: `Deletes lumen index databases under ~/.local/share/lumen/.
+
+With no arguments, removes every index (irreversible — all indexes will be
+rebuilt on the next search).
+
+With one or more paths, removes only the index directories associated with
+those projects. Each path is normalized to its git root first, then matched
+against the project_path recorded inside each index database, so switching
+embedding models or using custom models never leaves orphan indexes.
+
+Indexes created by older binaries that did not record project_path cannot be
+matched by path; run "lumen purge" with no arguments to wipe those.
+
+Note: a concurrently running indexer for a purged project may log a write
+error and exit; re-run "lumen index" afterwards to rebuild.`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runPurge,
 }
 
-func runPurge(_ *cobra.Command, _ []string) error {
+func runPurge(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return purgeAll(cmd.ErrOrStderr())
+	}
+	return purgeProjects(cmd.ErrOrStderr(), cmd.OutOrStdout(), args)
+}
+
+func purgeAll(stderr io.Writer) error {
 	dataDir := filepath.Join(config.XDGDataDir(), "lumen")
 
 	info, err := os.Stat(dataDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintln(os.Stderr, "No index data found — nothing to purge.")
+			_, _ = fmt.Fprintln(stderr, "No index data found — nothing to purge.")
 			return nil
 		}
 		return fmt.Errorf("stat data directory: %w", err)
@@ -53,6 +78,125 @@ func runPurge(_ *cobra.Command, _ []string) error {
 	if err := os.RemoveAll(dataDir); err != nil {
 		return fmt.Errorf("remove index data: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Removed all index data (%s)\n", dataDir)
+	_, _ = fmt.Fprintf(stderr, "Removed all index data (%s)\n", dataDir)
 	return nil
+}
+
+func purgeProjects(stderr, stdout io.Writer, args []string) error {
+	dataDir := filepath.Join(config.XDGDataDir(), "lumen")
+	indexMap, err := scanIndexes(dataDir)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool)
+	totalRemoved := 0
+	for _, arg := range args {
+		removed, err := purgeOneTarget(stderr, indexMap, seen, arg)
+		if err != nil {
+			return err
+		}
+		totalRemoved += removed
+	}
+	_, _ = fmt.Fprintf(stdout, "Removed %d index director%s.\n", totalRemoved, pluralY(totalRemoved))
+	return nil
+}
+
+// scanIndexes walks dataDir (one level deep) and returns a map of stored
+// project_path → list of hash directories for that project. Hash directories
+// that can't be read or lack project_path metadata are silently skipped so a
+// single broken index never blocks purging of others.
+func scanIndexes(dataDir string) (map[string][]string, error) {
+	result := make(map[string][]string)
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return nil, fmt.Errorf("read data dir: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		hashDir := filepath.Join(dataDir, entry.Name())
+		dbPath := filepath.Join(hashDir, "index.db")
+		stored, err := store.ReadMetaAt(dbPath, "project_path")
+		if err != nil || stored == "" {
+			continue
+		}
+		result[stored] = append(result[stored], hashDir)
+	}
+	return result, nil
+}
+
+// purgeOneTarget resolves arg to a project root and removes every hash
+// directory whose stored project_path matches. seen tracks hash directories
+// already deleted during this invocation so two args resolving to the same
+// project are not double-counted.
+func purgeOneTarget(stderr io.Writer, indexMap map[string][]string, seen map[string]bool, arg string) (int, error) {
+	abs, err := filepath.Abs(arg)
+	if err != nil {
+		return 0, fmt.Errorf("resolve %q: %w", arg, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+
+	target := abs
+	inGitRepo := false
+	if root, err := git.RepoRoot(abs); err == nil {
+		target = root
+		inGitRepo = true
+	}
+
+	match := ""
+	if _, ok := indexMap[target]; ok {
+		match = target
+	} else if !inGitRepo {
+		// Non-git fallback: match the deepest stored path that contains the
+		// target. Mirrors `findAncestorIndex` semantics used by index/search.
+		match = longestAncestor(indexMap, target)
+	}
+
+	if match == "" {
+		_, _ = fmt.Fprintf(stderr, "No index found for %s.\n", abs)
+		return 0, nil
+	}
+
+	removed := 0
+	for _, hashDir := range indexMap[match] {
+		if seen[hashDir] {
+			continue
+		}
+		seen[hashDir] = true
+		if err := os.RemoveAll(hashDir); err != nil {
+			return removed, fmt.Errorf("remove %s: %w", hashDir, err)
+		}
+		removed++
+	}
+	_, _ = fmt.Fprintf(stderr, "Removed %d index director%s for %s.\n",
+		removed, pluralY(removed), match)
+	return removed, nil
+}
+
+// longestAncestor returns the longest key in indexMap that is either equal to
+// target or an ancestor directory of target, or "" if no such key exists.
+func longestAncestor(indexMap map[string][]string, target string) string {
+	best := ""
+	for stored := range indexMap {
+		if stored == target || strings.HasPrefix(target, stored+string(filepath.Separator)) {
+			if len(stored) > len(best) {
+				best = stored
+			}
+		}
+	}
+	return best
+}
+
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
 }

--- a/cmd/purge_test.go
+++ b/cmd/purge_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/embedder"
+	"github.com/ory/lumen/internal/store"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedIndex creates a real SQLite index DB at the hash-named directory for
+// (projectPath, model) with project_path recorded in project_meta, so that
+// tests exercise the same metadata-scan code path as production.
+func seedIndex(t *testing.T, projectPath, model string) string {
+	t.Helper()
+	dbPath := config.DBPathForProject(projectPath, model)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	s, err := store.New(dbPath, 4)
+	require.NoError(t, err)
+	require.NoError(t, s.SetMeta("project_path", projectPath))
+	require.NoError(t, s.Close())
+	return filepath.Dir(dbPath)
+}
+
+// runPurgeCmd invokes runPurge with the provided args and returns captured
+// stdout, stderr, and the error (if any).
+func runPurgeCmd(t *testing.T, args []string) (stdout, stderr string, err error) {
+	t.Helper()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	cmd := &cobra.Command{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+	err = runPurge(cmd, args)
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestPurge_NoArgs_RemovesEverything(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	seedIndex(t, "/project/a", embedder.DefaultModel)
+	seedIndex(t, "/project/b", embedder.DefaultModel)
+
+	lumenRoot := filepath.Join(tmp, "lumen")
+	entries, err := os.ReadDir(lumenRoot)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "should have seeded two hash dirs")
+
+	_, stderrOut, err := runPurgeCmd(t, nil)
+	require.NoError(t, err)
+	assert.Contains(t, stderrOut, "Removed all index data")
+
+	_, err = os.Stat(lumenRoot)
+	assert.True(t, os.IsNotExist(err), "lumen data dir should be gone, got err=%v", err)
+}
+
+func TestPurge_NoArgs_NothingToPurge(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	_, stderrOut, err := runPurgeCmd(t, nil)
+	require.NoError(t, err)
+	assert.Contains(t, stderrOut, "No index data found")
+}
+
+func TestPurge_SinglePath_RemovesOnlyThatProject(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Two independent projects with seeded indexes.
+	projectA := filepath.Join(tmp, "projectA")
+	projectB := filepath.Join(tmp, "projectB")
+	require.NoError(t, os.MkdirAll(projectA, 0o755))
+	require.NoError(t, os.MkdirAll(projectB, 0o755))
+	runGit(t, projectA, "init")
+	runGit(t, projectB, "init")
+
+	hashDirA := seedIndex(t, projectA, embedder.DefaultModel)
+	hashDirB := seedIndex(t, projectB, embedder.DefaultModel)
+
+	_, stderrOut, err := runPurgeCmd(t, []string{projectA})
+	require.NoError(t, err)
+	assert.Contains(t, stderrOut, projectA, "should log the purged project path")
+
+	_, err = os.Stat(hashDirA)
+	assert.True(t, os.IsNotExist(err), "project A hash dir should be gone")
+	_, err = os.Stat(hashDirB)
+	assert.NoError(t, err, "project B hash dir should be untouched")
+}
+
+func TestPurge_PathInsideGitRepo_ResolvesToGitRoot(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	repoDir := filepath.Join(tmp, "repo")
+	subDir := filepath.Join(repoDir, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	runGit(t, repoDir, "init")
+
+	hashDir := seedIndex(t, repoDir, embedder.DefaultModel)
+
+	_, _, err := runPurgeCmd(t, []string{subDir})
+	require.NoError(t, err)
+
+	_, err = os.Stat(hashDir)
+	assert.True(t, os.IsNotExist(err), "git-root hash dir should be removed when passing a subdirectory")
+}
+
+func TestPurge_PathWithAncestorIndex_ResolvesToAncestor(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	grandparent := filepath.Join(tmp, "workspace")
+	child := filepath.Join(grandparent, "a", "b")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+
+	hashDir := seedIndex(t, grandparent, embedder.DefaultModel)
+
+	_, _, err := runPurgeCmd(t, []string{child})
+	require.NoError(t, err)
+
+	_, err = os.Stat(hashDir)
+	assert.True(t, os.IsNotExist(err), "ancestor hash dir should be removed")
+}
+
+func TestPurge_PathWithoutIndex_ReportsNoneAndExitsZero(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Path exists but has no index anywhere up the tree.
+	dir := filepath.Join(tmp, "empty")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	_, stderrOut, err := runPurgeCmd(t, []string{dir})
+	require.NoError(t, err)
+	assert.Contains(t, strings.ToLower(stderrOut), "no index found")
+}
+
+func TestPurge_MultiplePaths_RemovesEach(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	projectA := filepath.Join(tmp, "projectA")
+	projectB := filepath.Join(tmp, "projectB")
+	require.NoError(t, os.MkdirAll(projectA, 0o755))
+	require.NoError(t, os.MkdirAll(projectB, 0o755))
+	runGit(t, projectA, "init")
+	runGit(t, projectB, "init")
+
+	hashDirA := seedIndex(t, projectA, embedder.DefaultModel)
+	hashDirB := seedIndex(t, projectB, embedder.DefaultModel)
+
+	_, _, err := runPurgeCmd(t, []string{projectA, projectB})
+	require.NoError(t, err)
+
+	_, err = os.Stat(hashDirA)
+	assert.True(t, os.IsNotExist(err), "project A hash dir should be gone")
+	_, err = os.Stat(hashDirB)
+	assert.True(t, os.IsNotExist(err), "project B hash dir should be gone")
+}
+
+func TestPurge_UnknownModelName_StillPurgedByStoredMetadata(t *testing.T) {
+	// Indexes created with custom or aliased model names (not in KnownModels)
+	// must still be purged — the match is by stored project_path, not by
+	// enumerating known models and recomputing the hash.
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	project := filepath.Join(tmp, "project")
+	require.NoError(t, os.MkdirAll(project, 0o755))
+	runGit(t, project, "init")
+
+	hashDir := seedIndex(t, project, "some-custom-alias-model-not-in-registry")
+
+	_, _, err := runPurgeCmd(t, []string{project})
+	require.NoError(t, err)
+
+	_, err = os.Stat(hashDir)
+	assert.True(t, os.IsNotExist(err), "custom-model hash dir should be removed via stored project_path")
+}
+
+func TestPurge_MultiplePaths_MixedHitsAndMisses(t *testing.T) {
+	tmp := resolvedTempDir(t)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	projectA := filepath.Join(tmp, "projectA")
+	empty := filepath.Join(tmp, "empty")
+	require.NoError(t, os.MkdirAll(projectA, 0o755))
+	require.NoError(t, os.MkdirAll(empty, 0o755))
+	runGit(t, projectA, "init")
+
+	hashDirA := seedIndex(t, projectA, embedder.DefaultModel)
+
+	_, stderrOut, err := runPurgeCmd(t, []string{projectA, empty})
+	require.NoError(t, err)
+
+	_, err = os.Stat(hashDirA)
+	assert.True(t, os.IsNotExist(err), "project A hash dir should be gone")
+	assert.Contains(t, strings.ToLower(stderrOut), "no index found", "miss should be reported")
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -368,6 +368,7 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir, oldRootHash s
 		metaSaved = true
 		_ = idx.store.SetMeta("root_hash", curTree.RootHash)
 		_ = idx.store.SetMeta("embedding_model", idx.emb.ModelName())
+		_ = idx.store.SetMeta("project_path", projectDir)
 		_ = idx.store.SetMeta("last_indexed_at", time.Now().UTC().Format(time.RFC3339))
 		_ = idx.store.SetMeta("total_files", strconv.Itoa(stats.TotalFiles))
 	}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -986,3 +986,27 @@ func writeGoFile(t *testing.T, dir, name, content string) {
 		t.Fatal(err)
 	}
 }
+
+func TestIndexer_StoresProjectPathMeta(t *testing.T) {
+	projectDir := t.TempDir()
+	writeGoFile(t, projectDir, "main.go", "package main\n\nfunc Hello() {}\n")
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	if _, err := idx.Index(context.Background(), projectDir, false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := idx.store.GetMeta("project_path")
+	if err != nil {
+		t.Fatalf("GetMeta(project_path): %v", err)
+	}
+	if got != projectDir {
+		t.Fatalf("project_path meta = %q, want %q", got, projectDir)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -295,6 +295,37 @@ func resetAndRecreateVecTable(db *sql.DB, dimensions int) error {
 	return createVecTable(db, dimensions)
 }
 
+// ReadMetaAt opens the SQLite database at dbPath read-only and returns the
+// project_meta value for key, or "" if the key is missing. It is safe to call
+// on databases created by older binaries with a different schema version; the
+// function performs no migrations and holds no write lock. Returns an error
+// only when the file cannot be opened (missing file, permission denied) or
+// when the project_meta table is missing (the file is not a lumen index).
+func ReadMetaAt(dbPath, key string) (string, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return "", fmt.Errorf("stat %s: %w", dbPath, err)
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", dbPath, err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA query_only=ON"); err != nil {
+		return "", fmt.Errorf("set query_only: %w", err)
+	}
+
+	var val string
+	err = db.QueryRow("SELECT value FROM project_meta WHERE key = ?", key).Scan(&val)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("query project_meta: %w", err)
+	}
+	return val, nil
+}
+
 // SetMeta upserts a key-value pair in the project_meta table.
 func (s *Store) SetMeta(key, value string) error {
 	_, err := s.db.Exec(

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -522,3 +522,51 @@ func TestStore_FileBasedReadConnection(t *testing.T) {
 		t.Fatal("expected write on read connection to fail (query_only=ON)")
 	}
 }
+
+func TestReadMetaAt_ReturnsStoredValue(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+	s, err := New(dbPath, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetMeta("project_path", "/some/project"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadMetaAt(dbPath, "project_path")
+	if err != nil {
+		t.Fatalf("ReadMetaAt: %v", err)
+	}
+	if got != "/some/project" {
+		t.Fatalf("ReadMetaAt(project_path) = %q, want %q", got, "/some/project")
+	}
+}
+
+func TestReadMetaAt_MissingKeyReturnsEmpty(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+	s, err := New(dbPath, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadMetaAt(dbPath, "project_path")
+	if err != nil {
+		t.Fatalf("ReadMetaAt on empty meta: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("ReadMetaAt missing key = %q, want empty", got)
+	}
+}
+
+func TestReadMetaAt_MissingFileReturnsError(t *testing.T) {
+	_, err := ReadMetaAt(filepath.Join(t.TempDir(), "does-not-exist.db"), "project_path")
+	if err == nil {
+		t.Fatal("expected error for missing DB file")
+	}
+}

--- a/skills/reindex/SKILL.md
+++ b/skills/reindex/SKILL.md
@@ -15,7 +15,10 @@ Refresh or rebuild the bundled Lumen index for the current project.
    `semantic_search` tool with a broad natural-language query and set `path` or
    `cwd` to the current working directory. The search tool refreshes stale or
    missing indexes automatically.
-3. If the user explicitly asks for a clean rebuild, explain that
-   `lumen purge && lumen index .` deletes cached indexes before rebuilding,
-   then run it via the shell.
+3. If the user explicitly asks for a clean rebuild, explain the options and
+   run one via the shell:
+   - `lumen purge . && lumen index .` — deletes only the current project's
+     cached index before rebuilding. Prefer this.
+   - `lumen purge && lumen index .` — deletes every cached index on the host
+     before rebuilding. Use only when the user asks for a full wipe.
 4. After the refresh or rebuild, report the new index status.


### PR DESCRIPTION
## Summary
- `lumen purge` now accepts one or more paths; no-arg wipes everything (unchanged).
- Matching is by `project_path` recorded inside each index DB (new meta key), so custom/aliased model names still resolve to the right hash dir.
- Paths normalize via git root / ancestor-index walk, matching `lumen index` and `lumen search` semantics.

## Notes
- Old indexes (pre-this-change) lack `project_path` meta and can only be purged with no-arg `lumen purge`. Documented in `--help`.
- `internal/store.ReadMetaAt` is a new read-only meta accessor that never migrates schema, so it is safe to call on any-version DB file.

## Test plan
- [x] `go test ./...` green (new: 9 purge cases in `cmd/purge_test.go`, 1 in `internal/index/index_test.go`, 3 in `internal/store/store_test.go`)
- [x] `make lint` clean
- [x] Manual smoke: index two repos against real LM Studio (aliased model), `lumen purge repoA` removes only repoA, `lumen purge` wipes all, non-existent path exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `purge` command now accepts optional path arguments to selectively remove cached indexes for specific projects, rather than only supporting full wipes.

* **Documentation**
  * Updated reindex guidance with two purge options: `lumen purge .` to clear the current project's cache (preferred) or `lumen purge` for a complete wipe of all cached indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->