### PR TITLE
feat(cmd): select configured server via --model/--backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,37 @@ Dimensions and context length are configured automatically per model:
 Switching models creates a separate index automatically. The model name is part
 of the database path hash, so different models never collide.
 
+> **Caveat**: the DB path hash includes the model name but not the backend. If
+> the same model name is configured on two backends (e.g. an Ollama and an LM
+> Studio entry both named `foo`), they share the same index — use distinct
+> model names per backend to avoid collisions.
+
+### Selecting a server per invocation
+
+`lumen index` and `lumen search` accept `--model`/`-m` and `--backend`/`-b`
+to pick from a multi-server `config.yaml`. The selection filters the
+configured servers to those matching both fields; failover still works
+within the filtered subset.
+
+```sh
+# Index with the Ollama server matching this model name.
+lumen index --model ordis/jina-embeddings-v2-base-code .
+
+# Same model name hosted on LM Studio (present in YAML, not in the
+# static registry) — accepted because the name is configured.
+lumen index --model text-embedding-jina-embeddings-v2-base-code .
+
+# Disambiguate when the same model is configured on two backends.
+lumen index --model my-embed --backend lmstudio .
+
+# Pick the first configured Ollama server regardless of model.
+lumen search --backend ollama "…"
+```
+
+If `--model` is not configured in YAML but is a known registry model (and
+`--backend` is unset), Lumen falls back to mutating the default server's
+model — preserving `lumen index --model all-minilm .` for users with no YAML.
+
 ### Using a custom or unlisted model
 
 If your model is not in the registry above, set `LUMEN_EMBED_DIMS` to bypass the

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ory/lumen/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// flagsTestHarness sets up an isolated XDG_CONFIG_HOME with the given YAML,
+// clears server env vars, and returns the cobra command to exercise.
+func flagsTestHarness(t *testing.T, yaml string) *cobra.Command {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	for _, k := range []string{
+		"LUMEN_BACKEND", "LUMEN_EMBED_MODEL",
+		"OLLAMA_HOST", "LM_STUDIO_HOST",
+		"LUMEN_EMBED_DIMS", "LUMEN_EMBED_CTX",
+	} {
+		t.Setenv(k, "")
+	}
+
+	if yaml != "" {
+		dir := filepath.Join(home, "lumen")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().StringP("model", "m", "", "")
+	cmd.Flags().StringP("backend", "b", "", "")
+	return cmd
+}
+
+func TestLoadConfigWithFlags_NoFlagsLoadsYAML(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	if got := len(cfg.Servers()); got != 3 {
+		t.Errorf("Servers() len = %d, want 3", got)
+	}
+}
+
+func TestLoadConfigWithFlags_ModelInYAML_UnambiguousAcrossBackends(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("model", "ordis/jina-embeddings-v2-base-code")
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	servers := cfg.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != config.BackendOllama {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, config.BackendOllama)
+	}
+}
+
+func TestLoadConfigWithFlags_ModelInYAML_LMStudioOnlyName(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("model", "text-embedding-jina-embeddings-v2-base-code")
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	servers := cfg.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != config.BackendLMStudio {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, config.BackendLMStudio)
+	}
+}
+
+func TestLoadConfigWithFlags_ModelAndBackend(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("model", "ordis/jina-embeddings-v2-base-code")
+	_ = cmd.Flags().Set("backend", "ollama")
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	servers := cfg.Servers()
+	if len(servers) != 1 || servers[0].Backend != config.BackendOllama {
+		t.Fatalf("unexpected servers: %+v", servers)
+	}
+}
+
+func TestLoadConfigWithFlags_BackendOnly(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("backend", "ollama")
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	servers := cfg.Servers()
+	if len(servers) != 1 || servers[0].Backend != config.BackendOllama {
+		t.Fatalf("unexpected servers: %+v", servers)
+	}
+}
+
+func TestLoadConfigWithFlags_KnownModelFallback_NoYAML(t *testing.T) {
+	// No YAML. User passes a KnownModels entry that isn't the default. The
+	// fallback should rewrite servers[0].model via WithModelOverride.
+	cmd := flagsTestHarness(t, "")
+	_ = cmd.Flags().Set("model", "all-minilm")
+	cfg, err := loadConfigWithFlags(cmd)
+	if err != nil {
+		t.Fatalf("loadConfigWithFlags: %v", err)
+	}
+	servers := cfg.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Model != "all-minilm" {
+		t.Errorf("Model = %q, want all-minilm", servers[0].Model)
+	}
+}
+
+func TestLoadConfigWithFlags_UnknownModelYAMLConfigured(t *testing.T) {
+	// Model not in KnownModels, not in YAML → should error with the listing
+	// of configured servers.
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("model", "totally-nonexistent")
+	_, err := loadConfigWithFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+	if !strings.Contains(err.Error(), "no server matches") {
+		t.Errorf("error should name the filter mismatch, got %q", err.Error())
+	}
+}
+
+func TestLoadConfigWithFlags_InvalidBackend(t *testing.T) {
+	cmd := flagsTestHarness(t, threeServerFixture)
+	_ = cmd.Flags().Set("backend", "bogus")
+	_, err := loadConfigWithFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+	if !strings.Contains(err.Error(), "unknown backend") {
+		t.Errorf("error should mention unknown backend, got %q", err.Error())
+	}
+}
+
+func TestLoadConfigWithFlags_KnownModelButBackendMismatch(t *testing.T) {
+	// KnownModels fallback must NOT kick in when --backend is set — we don't
+	// want to silently mask a real selection error by falling back to
+	// servers[0] mutation.
+	cmd := flagsTestHarness(t, threeServerFixture)
+	// ollama-only model, but the user forces --backend lmstudio → no match,
+	// no fallback, clear error.
+	_ = cmd.Flags().Set("model", "ordis/jina-embeddings-v2-base-code")
+	_ = cmd.Flags().Set("backend", "lmstudio")
+	_, err := loadConfigWithFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error when --backend contradicts --model")
+	}
+}
+
+const threeServerFixture = `
+servers:
+  - backend: lmstudio
+    host: http://remote:1234
+    model: text-embedding-nomic-embed-code
+    dims: 3584
+  - backend: lmstudio
+    host: http://remote:1234
+    model: text-embedding-jina-embeddings-v2-base-code
+    dims: 768
+  - backend: ollama
+    host: http://localhost:11434
+    model: ordis/jina-embeddings-v2-base-code
+    dims: 768
+`

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -35,6 +35,7 @@ import (
 
 func init() {
 	indexCmd.Flags().StringP("model", "m", "", "embedding model (default: $LUMEN_EMBED_MODEL or "+embedder.DefaultModel+")")
+	indexCmd.Flags().StringP("backend", "b", "", "embedding backend to select (\"ollama\" or \"lmstudio\"); disambiguates when --model is configured on multiple backends")
 	indexCmd.Flags().BoolP("force", "f", false, "force full re-index")
 	rootCmd.AddCommand(indexCmd)
 }
@@ -52,11 +53,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		defer func() { _ = logFile.Close() }()
 	}
 
-	if err := applyModelFlag(cmd); err != nil {
-		return err
-	}
-
-	cfg, err := config.NewConfigService(config.DefaultConfigPath())
+	cfg, err := loadConfigWithFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -150,21 +147,47 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// applyModelFlag sets LUMEN_EMBED_MODEL so that NewConfigService picks it up.
-func applyModelFlag(cmd *cobra.Command) error {
-	m, _ := cmd.Flags().GetString("model")
-	if m == "" {
-		return nil
+// loadConfigWithFlags loads the ConfigService, honouring the --model and
+// --backend flags if set.
+//
+// Selection flow:
+//  1. No flags set → use YAML/env as-is.
+//  2. --model and/or --backend set → filter the configured servers to matching
+//     entries via WithServerSelection.
+//  3. If no configured server matches and --backend is unset, fall back to
+//     WithModelOverride for models present in the static KnownModels registry.
+//     This preserves backward compatibility for users with no YAML config who
+//     pass e.g. `--model all-minilm`.
+func loadConfigWithFlags(cmd *cobra.Command) (*config.ConfigService, error) {
+	model, _ := cmd.Flags().GetString("model")
+	backend, _ := cmd.Flags().GetString("backend")
+	path := config.DefaultConfigPath()
+
+	if model == "" && backend == "" {
+		return config.NewConfigService(path)
 	}
-	canonical := m
-	if c, ok := embedder.ModelAliases[m]; ok {
-		canonical = c
+	if backend != "" && backend != config.BackendOllama && backend != config.BackendLMStudio {
+		return nil, fmt.Errorf("unknown backend %q (must be %q or %q)",
+			backend, config.BackendOllama, config.BackendLMStudio)
 	}
-	if _, ok := embedder.KnownModels[canonical]; !ok {
-		return fmt.Errorf("unknown embedding model %q", m)
+
+	cfg, selErr := config.NewConfigService(path, config.WithServerSelection(model, backend))
+	if selErr == nil {
+		return cfg, nil
 	}
-	_ = os.Setenv("LUMEN_EMBED_MODEL", m)
-	return nil
+
+	// Fallback: legacy WithModelOverride path for users with no YAML who rely
+	// on the static model registry. Only applies when --backend is unset.
+	if model != "" && backend == "" {
+		canonical := model
+		if c, ok := embedder.ModelAliases[model]; ok {
+			canonical = c
+		}
+		if _, ok := embedder.KnownModels[canonical]; ok {
+			return config.NewConfigService(path, config.WithModelOverride(model))
+		}
+	}
+	return nil, selErr
 }
 
 // setupIndexer receives dbPath so it is computed exactly once in runIndex.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -80,6 +80,7 @@ func init() {
 	searchCmd.Flags().BoolP("force", "f", false, "force full re-index before searching")
 	searchCmd.Flags().Bool("trace", false, "print per-phase timing to stderr")
 	searchCmd.Flags().StringP("model", "m", "", "embedding model override")
+	searchCmd.Flags().StringP("backend", "b", "", "embedding backend to select (\"ollama\" or \"lmstudio\")")
 	rootCmd.AddCommand(searchCmd)
 }
 
@@ -114,10 +115,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	}
 
 	// Span 1: path resolution
-	if err := applyModelFlag(cmd); err != nil {
-		return err
-	}
-	cfg, err := config.NewConfigService(config.DefaultConfigPath())
+	cfg, err := loadConfigWithFlags(cmd)
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +35,8 @@ type ConfigService struct {
 	mu            sync.RWMutex
 	configPath    string
 	modelOverride string // set via WithModelOverride, applied after env vars
+	selectModel   string // set via WithServerSelection, filters server list
+	selectBackend string // set via WithServerSelection, filters server list
 	watcher       *fsnotify.Watcher
 	stopCh        chan struct{}
 	stopOnce      sync.Once
@@ -82,6 +85,18 @@ func WithModelOverride(model string) Option {
 	return func(s *ConfigService) { s.modelOverride = model }
 }
 
+// WithServerSelection restricts the servers list to entries whose model and/or
+// backend match the given values. An empty string for a field means "don't
+// filter by that field"; passing both empty is a no-op. Model names are
+// alias-resolved on both sides before comparison. If the filter matches zero
+// servers, NewConfigService returns a descriptive error.
+func WithServerSelection(model, backend string) Option {
+	return func(s *ConfigService) {
+		s.selectModel = model
+		s.selectBackend = backend
+	}
+}
+
 // NewConfigService creates a ConfigService. configPath is the YAML file path
 // (empty string means no file). Environment variables are always loaded.
 func NewConfigService(configPath string, opts ...Option) (*ConfigService, error) {
@@ -126,10 +141,65 @@ func NewConfigService(configPath string, opts ...Option) (*ConfigService, error)
 		}
 	}
 
+	// Layer 5: CLI server selection filter (WithServerSelection).
+	if svc.selectModel != "" || svc.selectBackend != "" {
+		var servers []ServerConfig
+		_ = k.Unmarshal("servers", &servers)
+		filtered := filterServers(servers, svc.selectModel, svc.selectBackend)
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf(
+				"no server matches --model=%q --backend=%q; configured: %s",
+				svc.selectModel, svc.selectBackend, describeServers(servers),
+			)
+		}
+		// Drop the existing list first — koanf merge would otherwise keep
+		// stale entries beyond the filtered length.
+		k.Delete("servers")
+		serverMaps := make([]map[string]any, len(filtered))
+		for i, s := range filtered {
+			serverMaps[i] = map[string]any{
+				"backend": s.Backend, "host": s.Host, "model": s.Model,
+				"dims": s.Dims, "ctx_length": s.CtxLength, "min_score": s.MinScore,
+			}
+		}
+		_ = k.Load(confmap.Provider(map[string]any{"servers": serverMaps}, "."), nil)
+	}
+
 	if err := svc.validate(); err != nil {
 		return nil, err
 	}
 	return svc, nil
+}
+
+// filterServers returns the subset of servers matching model and/or backend.
+// Empty model or empty backend means "don't filter by that field". Model
+// names are alias-resolved on both sides before comparison.
+func filterServers(servers []ServerConfig, model, backend string) []ServerConfig {
+	want := resolveModel(model)
+	var out []ServerConfig
+	for _, s := range servers {
+		if model != "" && resolveModel(s.Model) != want {
+			continue
+		}
+		if backend != "" && s.Backend != backend {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// describeServers renders a compact list of configured (backend, model) pairs
+// for inclusion in error messages.
+func describeServers(servers []ServerConfig) string {
+	if len(servers) == 0 {
+		return "[]"
+	}
+	parts := make([]string, len(servers))
+	for i, s := range servers {
+		parts[i] = fmt.Sprintf("(%s, %s)", s.Backend, s.Model)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 // applyEnvOverrides reads legacy env vars and merges them into koanf.

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -426,3 +426,221 @@ func TestWithModelOverride(t *testing.T) {
 		t.Errorf("ServerDims(0) = %d, want 384", got)
 	}
 }
+
+// threeServerYAML is a fixture resembling the real user config: an Ollama
+// server and two LM Studio servers with distinct model names.
+const threeServerYAML = `
+servers:
+  - backend: lmstudio
+    host: http://remote:1234
+    model: text-embedding-nomic-embed-code
+    dims: 3584
+  - backend: lmstudio
+    host: http://remote:1234
+    model: text-embedding-jina-embeddings-v2-base-code
+    dims: 768
+  - backend: ollama
+    host: http://localhost:11434
+    model: ordis/jina-embeddings-v2-base-code
+    dims: 768
+`
+
+func writeThreeServerYAML(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(f, []byte(threeServerYAML), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return f
+}
+
+func clearServerEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"LUMEN_BACKEND", "LUMEN_EMBED_MODEL", "OLLAMA_HOST", "LM_STUDIO_HOST", "LUMEN_EMBED_DIMS", "LUMEN_EMBED_CTX"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestWithServerSelection_ByModel_UnambiguousYAMLEntry(t *testing.T) {
+	clearServerEnv(t)
+	cfg := writeThreeServerYAML(t)
+	// ordis/jina-embeddings-v2-base-code appears on exactly one server — the
+	// Ollama entry. Filtering by model alone should pick it.
+	svc, err := NewConfigService(cfg, WithServerSelection("ordis/jina-embeddings-v2-base-code", ""))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	servers := svc.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != BackendOllama {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, BackendOllama)
+	}
+	if servers[0].Host != "http://localhost:11434" {
+		t.Errorf("Host = %q, want http://localhost:11434", servers[0].Host)
+	}
+}
+
+func TestWithServerSelection_ByModel_LMStudioName(t *testing.T) {
+	clearServerEnv(t)
+	cfg := writeThreeServerYAML(t)
+	// The LM-Studio-specific name is not in KnownModels, but it's in the YAML
+	// — filtering by it should pick that LM Studio server.
+	svc, err := NewConfigService(cfg, WithServerSelection("text-embedding-jina-embeddings-v2-base-code", ""))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	servers := svc.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != BackendLMStudio {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, BackendLMStudio)
+	}
+	if servers[0].Model != "text-embedding-jina-embeddings-v2-base-code" {
+		t.Errorf("Model = %q, want text-embedding-jina-embeddings-v2-base-code", servers[0].Model)
+	}
+}
+
+func TestWithServerSelection_ByModelAndBackend(t *testing.T) {
+	clearServerEnv(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config.yaml")
+	// Same model on two backends — backend flag must disambiguate.
+	_ = os.WriteFile(f, []byte(`
+servers:
+  - backend: ollama
+    host: http://a:11434
+    model: duplicate-model
+    dims: 768
+  - backend: lmstudio
+    host: http://b:1234
+    model: duplicate-model
+    dims: 768
+`), 0644)
+	svc, err := NewConfigService(f, WithServerSelection("duplicate-model", BackendLMStudio))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	servers := svc.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != BackendLMStudio {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, BackendLMStudio)
+	}
+}
+
+func TestWithServerSelection_ByBackendOnly(t *testing.T) {
+	clearServerEnv(t)
+	cfg := writeThreeServerYAML(t)
+	svc, err := NewConfigService(cfg, WithServerSelection("", BackendOllama))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	servers := svc.Servers()
+	if len(servers) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(servers))
+	}
+	if servers[0].Backend != BackendOllama {
+		t.Errorf("Backend = %q, want %q", servers[0].Backend, BackendOllama)
+	}
+}
+
+func TestWithServerSelection_AliasResolution(t *testing.T) {
+	clearServerEnv(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config.yaml")
+	// YAML stores the canonical name; user passes the alias. Alias resolution
+	// must make them match.
+	_ = os.WriteFile(f, []byte(`
+servers:
+  - backend: lmstudio
+    host: http://localhost:1234
+    model: nomic-ai/nomic-embed-code-GGUF
+`), 0644)
+	svc, err := NewConfigService(f, WithServerSelection("text-embedding-nomic-embed-code", ""))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	if len(svc.Servers()) != 1 {
+		t.Fatalf("Servers() len = %d, want 1", len(svc.Servers()))
+	}
+}
+
+func TestWithServerSelection_NoMatchReturnsError(t *testing.T) {
+	clearServerEnv(t)
+	cfg := writeThreeServerYAML(t)
+	_, err := NewConfigService(cfg, WithServerSelection("no-such-model", ""))
+	if err == nil {
+		t.Fatal("expected error for no matching server")
+	}
+}
+
+func TestWithServerSelection_BackendOnlyNoMatch(t *testing.T) {
+	clearServerEnv(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config.yaml")
+	_ = os.WriteFile(f, []byte(`
+servers:
+  - backend: ollama
+    host: http://a:11434
+    model: ordis/jina-embeddings-v2-base-code
+`), 0644)
+	_, err := NewConfigService(f, WithServerSelection("", BackendLMStudio))
+	if err == nil {
+		t.Fatal("expected error when backend filter matches nothing")
+	}
+}
+
+func TestWithServerSelection_PreservesOrder(t *testing.T) {
+	clearServerEnv(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config.yaml")
+	// Three Ollama servers, all with the same model — filtering should keep
+	// all three in their original YAML order so failover still works.
+	_ = os.WriteFile(f, []byte(`
+servers:
+  - backend: ollama
+    host: http://a:11434
+    model: ordis/jina-embeddings-v2-base-code
+  - backend: lmstudio
+    host: http://b:1234
+    model: nomic-ai/nomic-embed-code-GGUF
+  - backend: ollama
+    host: http://c:11434
+    model: ordis/jina-embeddings-v2-base-code
+  - backend: ollama
+    host: http://d:11434
+    model: ordis/jina-embeddings-v2-base-code
+`), 0644)
+	svc, err := NewConfigService(f, WithServerSelection("ordis/jina-embeddings-v2-base-code", BackendOllama))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	servers := svc.Servers()
+	if len(servers) != 3 {
+		t.Fatalf("Servers() len = %d, want 3", len(servers))
+	}
+	wantHosts := []string{"http://a:11434", "http://c:11434", "http://d:11434"}
+	for i, s := range servers {
+		if s.Host != wantHosts[i] {
+			t.Errorf("Servers()[%d].Host = %q, want %q", i, s.Host, wantHosts[i])
+		}
+	}
+}
+
+func TestWithServerSelection_EmptyArgsNoop(t *testing.T) {
+	clearServerEnv(t)
+	cfg := writeThreeServerYAML(t)
+	// Empty model and empty backend → no filter applied.
+	svc, err := NewConfigService(cfg, WithServerSelection("", ""))
+	if err != nil {
+		t.Fatalf("NewConfigService: %v", err)
+	}
+	if got := len(svc.Servers()); got != 3 {
+		t.Errorf("Servers() len = %d, want 3 (no filter should be applied)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `lumen index` / `lumen search` now accept `--backend`/`-b` alongside `--model`/`-m` and use them to **select a configured server from `config.yaml`** rather than mutating `servers[0]`.
- New `config.WithServerSelection(model, backend)` option filters the server list (alias-resolved on both sides); failover still works within the filtered subset.
- Known-model names still work without YAML via a `WithModelOverride` fallback when `--backend` is unset, preserving the old `lumen index --model all-minilm .` flow.

### Why

With a multi-server `config.yaml`, the old `--model X` flag set `LUMEN_EMBED_MODEL`, which `applyEnvOverrides` merged into `servers[0]` only. For a user whose first configured server was LM Studio and second was Ollama, `lumen index --model ordis/jina-embeddings-v2-base-code` would send an Ollama-native model name to LM Studio and fail. Separately, model names that were present in YAML but not in the static `KnownModels` registry (e.g. LM Studio's `text-embedding-jina-embeddings-v2-base-code`) were rejected as "unknown embedding model" even though they were configured.

### Behaviour

| `--model`    | `--backend`  | Resolution                                                       |
| ------------ | ------------ | ---------------------------------------------------------------- |
| unset        | unset        | Current behaviour (servers as configured).                       |
| in YAML      | unset        | Keep YAML servers whose model matches (alias-resolved).          |
| in YAML      | set          | Intersect by backend.                                            |
| in YAML, no backend match | set | Error: lists configured `(backend, model)` pairs.         |
| in KnownModels only | unset | Legacy `WithModelOverride` path — mutates servers\[0\].        |
| unknown     | any          | Error listing the configured servers.                            |
| unset        | set          | Filter by backend; error if none.                                |

## Test plan

- [x] `go test ./internal/config/ ./cmd/` — 9 new config tests + 9 new cmd tests, all passing
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] End-to-end verification against real `~/.config/lumen/config.yaml` (debug.log confirms correct host for each case):
  - `lumen index --model ordis/jina-embeddings-v2-base-code .` → `http://localhost:11434` (Ollama) ✓
  - `lumen index --model text-embedding-nomic-embed-code .` → `http://100.115.235.110:1234` (LM Studio) ✓
  - `lumen index --backend ollama .` / `--backend lmstudio .` → correct backend ✓
  - `lumen index --model bogus .` → error lists configured `(backend, model)` pairs ✓
  - `lumen index --backend weirdo .` → `unknown backend "weirdo" (must be "ollama" or "lmstudio")` ✓
- [x] `lumen index --help` shows new `--backend` flag

## Notes / follow-ups

- The DB path hash still includes `model` but not `backend`. If the same model name is configured on two backends they'd share the same index — documented as a caveat in the README. Fixing that is a breaking change (forces full re-index; needs `IndexVersion` bump), left as a follow-up.
- `LUMEN_EMBED_MODEL` env var semantics are unchanged — it still merges into `servers[0]` via `applyEnvOverrides` for users relying on shell-level overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guide for server selection via `--model` and `--backend` CLI flags.
  * Documented index selection and fallback behavior for known models.

* **New Features**
  * Added `--backend` flag to `lumen index` and `lumen search` commands.
  * Servers now filter by model and backend together.
  * Automatic model resolution for known registry models when backend unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->