### PR TITLE
fix(index): skip files that fail to chunk instead of aborting the run

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -93,9 +93,14 @@ func runIndex(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "Skipping %s: another indexer is already running.\n", repo)
 		default:
 			logger.Info("nested repo indexed", "project", repo,
-				"indexed_files", stats.IndexedFiles, "chunks_created", stats.ChunksCreated,
-				"elapsed", elapsed.String())
-			fmt.Printf("Nested repo %s: %d files, %d chunks in %s.\n", repo, stats.IndexedFiles, stats.ChunksCreated, elapsed)
+				"indexed_files", stats.IndexedFiles, "files_skipped", stats.FilesSkipped,
+				"chunks_created", stats.ChunksCreated, "elapsed", elapsed.String())
+			if stats.FilesSkipped > 0 {
+				fmt.Printf("Nested repo %s: %d files, %d chunks, skipped %d files (parse errors) in %s.\n",
+					repo, stats.IndexedFiles, stats.ChunksCreated, stats.FilesSkipped, elapsed)
+			} else {
+				fmt.Printf("Nested repo %s: %d files, %d chunks in %s.\n", repo, stats.IndexedFiles, stats.ChunksCreated, elapsed)
+			}
 		}
 	}
 
@@ -126,6 +131,7 @@ func runIndex(cmd *cobra.Command, args []string) error {
 			"files_modified", stats.FilesModified,
 			"files_removed", stats.FilesRemoved,
 			"indexed_files", stats.IndexedFiles,
+			"files_skipped", stats.FilesSkipped,
 			"chunks_created", stats.ChunksCreated,
 			"old_root_hash", stats.OldRootHash,
 			"new_root_hash", stats.NewRootHash,
@@ -142,8 +148,13 @@ func runIndex(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Files: %d added, %d modified, %d removed (%d total in project)\n",
 		stats.FilesAdded, stats.FilesModified, stats.FilesRemoved, stats.TotalFiles)
-	fmt.Printf("Done. Indexed %d files, %d chunks in %s.\n",
-		stats.IndexedFiles, stats.ChunksCreated, elapsed)
+	if stats.FilesSkipped > 0 {
+		fmt.Printf("Done. Indexed %d files, %d chunks, skipped %d files (parse errors — see debug log) in %s.\n",
+			stats.IndexedFiles, stats.ChunksCreated, stats.FilesSkipped, elapsed)
+	} else {
+		fmt.Printf("Done. Indexed %d files, %d chunks in %s.\n",
+			stats.IndexedFiles, stats.ChunksCreated, elapsed)
+	}
 	return nil
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -55,6 +55,7 @@ type Stats struct {
 	IndexedFiles  int
 	ChunksCreated int
 	FilesChanged  int
+	FilesSkipped  int
 
 	// Breakdown of changed files by category.
 	FilesAdded    int
@@ -442,7 +443,17 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir, oldRootHash s
 
 		chunks, err := idx.chunker.Chunk(relPath, content)
 		if err != nil {
-			return stats, fmt.Errorf("chunk %s: %w", relPath, err)
+			if idx.logger != nil {
+				idx.logger.Warn("skipping unchunkable file", "path", relPath, "error", err)
+			}
+			stats.FilesSkipped++
+			// Overwrite the sentinel hash (set above) with the real hash so this
+			// file is not retried every run. If the user later fixes the source,
+			// the hash changes and it gets re-indexed naturally.
+			if err := idx.store.UpsertFile(relPath, curTree.Files[relPath]); err != nil {
+				return stats, fmt.Errorf("upsert skipped file %s: %w", relPath, err)
+			}
+			continue
 		}
 
 		chunks = splitOversizedChunks(chunks, idx.maxChunkTokens)
@@ -496,7 +507,7 @@ func (idx *Indexer) indexWithTree(ctx context.Context, projectDir, oldRootHash s
 			fmt.Sprintf("Indexing complete: %d files, %d chunks", len(filesToIndex), totalChunks))
 	}
 
-	stats.IndexedFiles = len(filesToIndex)
+	stats.IndexedFiles = len(filesToIndex) - stats.FilesSkipped
 	stats.ChunksCreated = totalChunks
 
 	saveMeta()

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -976,6 +976,58 @@ func Secret() {}
 	}
 }
 
+func TestIndexer_SkipsUnchunkableFile(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFile(t, dir, "ok.go", `package p
+
+func OK() {}
+`)
+	// Docs-style snippet: no package declaration, body at top level. go/parser
+	// rejects this as "expected declaration, found mux".
+	writeGoFile(t, dir, "broken.go", `mux := http.NewServeMux()
+mux.HandleFunc("/", handler)
+`)
+
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(":memory:", emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	stats, err := idx.Index(context.Background(), dir, false, nil)
+	if err != nil {
+		t.Fatalf("expected no error when a file fails to parse, got: %v", err)
+	}
+	if stats.FilesSkipped != 1 {
+		t.Errorf("expected FilesSkipped=1, got %d", stats.FilesSkipped)
+	}
+	if stats.IndexedFiles != 1 {
+		t.Errorf("expected IndexedFiles=1 (only ok.go), got %d", stats.IndexedFiles)
+	}
+
+	results, err := idx.Search(context.Background(), dir, []float32{0.1, 0.1, 0.1, 0.1}, 10, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if strings.Contains(r.FilePath, "broken.go") {
+			t.Errorf("broken.go should not be indexed, found: %s", r.FilePath)
+		}
+	}
+
+	// Second run on unchanged files should short-circuit via root-hash match,
+	// which proves the real hash was persisted for broken.go (no sentinel left).
+	stats2, err := idx.Index(context.Background(), dir, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats2.FilesChanged != 0 || stats2.IndexedFiles != 0 {
+		t.Errorf("second run should be a no-op, got FilesChanged=%d IndexedFiles=%d",
+			stats2.FilesChanged, stats2.IndexedFiles)
+	}
+}
+
 func writeGoFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary
- A single un-parseable file (e.g. a docs code-example snippet without a `package` declaration) used to abort the entire `lumen index` run with `Error: indexing: chunk …: parse …: expected declaration, found mux`.
- Chunker errors are now treated as per-file skips, mirroring the existing permission-denied and binary-file handling. The real content hash is persisted for the skipped file, so subsequent runs are no-ops until the source actually changes.
- The CLI summary now shows `skipped N files (parse errors — see debug log)` when non-zero, and the structured log gains a `files_skipped` field. The skipped path with its parser error is logged at WARN level to `~/.local/share/lumen/debug.log`.

## Test plan
- [x] `go test ./...` — green
- [x] `make lint` — 0 issues
- [x] `make vet` — clean
- [x] New TDD test `TestIndexer_SkipsUnchunkableFile` covers: no error returned, `FilesSkipped==1`, broken file absent from search results, and a second run on the unchanged tree is a no-op (proves the real hash was persisted, no sentinel left behind).
- [x] Smoke run on a tempdir with 1 valid + 2 broken Go files: `Done. Indexed 1 files, 1 chunks, skipped 2 files (parse errors — see debug log) in 63ms.` with matching WARN entries in the debug log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Indexing now tolerates files that cannot be parsed, skipping them and continuing instead of failing the entire operation.

* **New Features**
  * Output now reports the count of skipped files with error details in completion messages.
  * Indexed file count now accurately reflects only successfully processed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->