### PR TITLE
Create generic lumen binary for direct CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,25 @@ install it automatically.
 lumen help
 ```
 
+**Using lumen directly from your shell**
+
+When installed as a plugin, the `lumen` binary is available at:
+
+- **Claude Code**: `~/.claude/plugins/cache/ory/lumen/<version>/bin/lumen`
+- **Cursor**: `~/.cursor/extensions/lumen/bin/lumen`
+- **Codex**: `${CODEX_HOME:-~/.codex}/lumen/bin/lumen`
+- **OpenCode**: `~/.opencode/plugins/lumen/bin/lumen`
+
+Add the appropriate path to your `$PATH` to use `lumen` commands directly:
+
+```bash
+# Example for Claude Code (add to ~/.bashrc or ~/.zshrc)
+export PATH="$HOME/.claude/plugins/cache/ory/lumen/latest/bin:$PATH"
+```
+
+The plugin's `run.sh`/`run.bat` scripts automatically create a platform-agnostic
+`lumen` binary (from `lumen-linux-amd64`, `lumen-darwin-arm64`, etc.) on first run.
+
 ## Troubleshooting
 
 **Ollama not running / "connection refused"**

--- a/README.md
+++ b/README.md
@@ -420,19 +420,26 @@ When installed as a plugin, the `lumen` binary is available at:
 - **Codex**: `${CODEX_HOME:-~/.codex}/lumen/bin/lumen`
 - **OpenCode**: `~/.opencode/plugins/lumen/bin/lumen`
 
-Add the appropriate path to your `$PATH` to use `lumen` commands directly:
+### Automatic CLI Installation
+
+On first run, the plugin automatically installs the `lumen` CLI to a standard location:
+
+- **Linux/macOS**: `~/.local/bin/lumen` (symlinked)
+- **Windows**: `%USERPROFILE%\bin\lumen.exe` (copied)
+
+If these directories aren't in your PATH, add them once:
 
 ```bash
-# Example for Claude Code (add to ~/.bashrc or ~/.zshrc)
-# Replace 0.0.38 with your installed version, or use a glob pattern
-export PATH="$HOME/.claude/plugins/cache/ory/lumen/0.0.38/bin:$PATH"
-
-# For Codex
-export PATH="${CODEX_HOME:-$HOME/.codex}/lumen/bin:$PATH"
+# Linux/macOS - add to ~/.bashrc or ~/.zshrc
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-The plugin's `run.sh`/`run.bat` scripts automatically create a platform-agnostic
-`lumen` binary (from `lumen-linux-amd64`, `lumen-darwin-arm64`, etc.) when first invoked.
+```powershell
+# Windows - add %USERPROFILE%\bin to your user PATH via:
+# Settings → System → About → Advanced system settings → Environment Variables
+```
+
+After adding to PATH, you can run `lumen` commands from anywhere without going through the plugin.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -424,11 +424,15 @@ Add the appropriate path to your `$PATH` to use `lumen` commands directly:
 
 ```bash
 # Example for Claude Code (add to ~/.bashrc or ~/.zshrc)
-export PATH="$HOME/.claude/plugins/cache/ory/lumen/latest/bin:$PATH"
+# Replace 0.0.38 with your installed version, or use a glob pattern
+export PATH="$HOME/.claude/plugins/cache/ory/lumen/0.0.38/bin:$PATH"
+
+# For Codex
+export PATH="${CODEX_HOME:-$HOME/.codex}/lumen/bin:$PATH"
 ```
 
 The plugin's `run.sh`/`run.bat` scripts automatically create a platform-agnostic
-`lumen` binary (from `lumen-linux-amd64`, `lumen-darwin-arm64`, etc.) on first run.
+`lumen` binary (from `lumen-linux-amd64`, `lumen-darwin-arm64`, etc.) when first invoked.
 
 ## Troubleshooting
 

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -111,4 +111,47 @@ if not exist "%GENERIC_BINARY%" (
   )
 )
 
+:: Auto-install to %USERPROFILE%\bin for CLI usage (no admin required).
+:: Copy instead of symlink because mklink requires elevation on Windows.
+if exist "%GENERIC_BINARY%" (
+  set "USER_BIN=%USERPROFILE%\bin"
+  set "USER_LUMEN=%USER_BIN%\lumen.exe"
+
+  :: Create %USERPROFILE%\bin if it doesn't exist
+  if not exist "!USER_BIN!" (
+    mkdir "!USER_BIN!" >nul 2>&1
+    if exist "!USER_BIN!" echo Created !USER_BIN! >&2
+  )
+
+  :: Copy to user bin if directory exists and file doesn't match
+  if exist "!USER_BIN!" (
+    set "NEEDS_COPY=0"
+    if not exist "!USER_LUMEN!" set "NEEDS_COPY=1"
+    if exist "!USER_LUMEN!" (
+      fc /b "%GENERIC_BINARY%" "!USER_LUMEN!" >nul 2>&1
+      if errorlevel 1 set "NEEDS_COPY=1"
+    )
+
+    if "!NEEDS_COPY!"=="1" (
+      copy /y "%GENERIC_BINARY%" "!USER_LUMEN!" >nul 2>&1
+      if exist "!USER_LUMEN!" (
+        echo Installed lumen CLI to !USER_LUMEN! >&2
+
+        :: Check if %USERPROFILE%\bin is in PATH
+        echo %PATH% | findstr /i /c:"!USER_BIN!" >nul
+        if errorlevel 1 (
+          echo. >&2
+          echo To use 'lumen' from anywhere, add to your PATH: >&2
+          echo. >&2
+          echo   1. Press Win+X, select "System" >&2
+          echo   2. Click "Advanced system settings" ^> "Environment Variables" >&2
+          echo   3. Under "User variables", edit "Path" >&2
+          echo   4. Add: %USERPROFILE%\bin >&2
+          echo. >&2
+        )
+      )
+    )
+  )
+)
+
 "%BINARY%" %*

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -96,12 +96,14 @@ if not exist "%BINARY%" (
   )
 
   echo Installed lumen to %BINARY% >&2
+)
 
-  :: Create a platform-agnostic copy so `lumen` works in PATH
-  set "GENERIC_BINARY=%PLUGIN_ROOT%\bin\lumen.exe"
-  if not exist "!GENERIC_BINARY!" (
-    copy "%BINARY%" "!GENERIC_BINARY!" >nul
-    echo Created !GENERIC_BINARY! for direct CLI usage >&2
+:: Always ensure generic binary exists for PATH usage (backfills old installs)
+set "GENERIC_BINARY=%PLUGIN_ROOT%\bin\lumen.exe"
+if not exist "%GENERIC_BINARY%" (
+  if exist "%BINARY%" (
+    copy "%BINARY%" "%GENERIC_BINARY%" >nul
+    echo Created %GENERIC_BINARY% for direct CLI usage >&2
   )
 )
 

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -103,6 +103,10 @@ set "GENERIC_BINARY=%PLUGIN_ROOT%\bin\lumen.exe"
 if not exist "%GENERIC_BINARY%" (
   if exist "%BINARY%" (
     copy "%BINARY%" "%GENERIC_BINARY%" >nul
+    if errorlevel 1 (
+      echo Error: failed to create generic binary at %GENERIC_BINARY% >&2
+      exit /b 1
+    )
     echo Created %GENERIC_BINARY% for direct CLI usage >&2
   )
 )

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -96,6 +96,13 @@ if not exist "%BINARY%" (
   )
 
   echo Installed lumen to %BINARY% >&2
+
+  :: Create a platform-agnostic copy so `lumen` works in PATH
+  set "GENERIC_BINARY=%PLUGIN_ROOT%\bin\lumen.exe"
+  if not exist "!GENERIC_BINARY!" (
+    copy "%BINARY%" "!GENERIC_BINARY!" >nul
+    echo Created !GENERIC_BINARY! for direct CLI usage >&2
+  )
 )
 
 "%BINARY%" %*

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -98,4 +98,38 @@ if [ ! -e "$GENERIC_BINARY" ] || [ ! -x "$GENERIC_BINARY" ]; then
   fi
 fi
 
+# Auto-install symlink to $HOME/.local/bin for CLI usage (no sudo required).
+# Only attempt this if we have a working generic binary.
+if [ -x "$GENERIC_BINARY" ]; then
+  LOCAL_BIN="${HOME}/.local/bin"
+  SYMLINK_TARGET="${LOCAL_BIN}/lumen"
+
+  # Create ~/.local/bin if it doesn't exist
+  if [ ! -d "$LOCAL_BIN" ]; then
+    if mkdir -p "$LOCAL_BIN" 2>/dev/null; then
+      echo "Created ${LOCAL_BIN}" >&2
+    fi
+  fi
+
+  # Create symlink if directory exists and symlink doesn't point to our binary
+  if [ -d "$LOCAL_BIN" ] && [ ! -L "$SYMLINK_TARGET" ] || [ "$(readlink "$SYMLINK_TARGET" 2>/dev/null)" != "$GENERIC_BINARY" ]; then
+    # Remove old symlink/file if it exists
+    rm -f "$SYMLINK_TARGET" 2>/dev/null || true
+
+    if ln -sf "$GENERIC_BINARY" "$SYMLINK_TARGET" 2>/dev/null; then
+      echo "Installed lumen CLI to ${SYMLINK_TARGET}" >&2
+
+      # Check if $LOCAL_BIN is in PATH
+      if ! echo "$PATH" | tr ':' '\n' | grep -qx "$LOCAL_BIN"; then
+        echo "" >&2
+        echo "✨ To use 'lumen' from anywhere, add to your PATH:" >&2
+        echo "" >&2
+        echo "  # Add to ~/.bashrc or ~/.zshrc:" >&2
+        echo "  export PATH=\"\$HOME/.local/bin:\$PATH\"" >&2
+        echo "" >&2
+      fi
+    fi
+  fi
+fi
+
 exec "$BINARY" "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -78,6 +78,14 @@ if [ -z "$BINARY" ]; then
 
   chmod +x "$BINARY"
   echo "Installed lumen to ${BINARY}" >&2
+
+  # Create a platform-agnostic symlink/copy so `lumen` works in PATH
+  GENERIC_BINARY="${PLUGIN_ROOT}/bin/lumen"
+  if [ ! -e "$GENERIC_BINARY" ] || [ ! -x "$GENERIC_BINARY" ]; then
+    cp "$BINARY" "$GENERIC_BINARY"
+    chmod +x "$GENERIC_BINARY"
+    echo "Created ${GENERIC_BINARY} for direct CLI usage" >&2
+  fi
 fi
 
 exec "$BINARY" "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -86,8 +86,14 @@ PLATFORM_BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 if [ ! -e "$GENERIC_BINARY" ] || [ ! -x "$GENERIC_BINARY" ]; then
   # If we have a platform-specific binary, copy it to the generic name
   if [ -x "$PLATFORM_BINARY" ]; then
-    cp "$PLATFORM_BINARY" "$GENERIC_BINARY"
-    chmod +x "$GENERIC_BINARY"
+    if ! cp "$PLATFORM_BINARY" "$GENERIC_BINARY"; then
+      echo "Error: failed to create generic binary at ${GENERIC_BINARY}" >&2
+      exit 1
+    fi
+    if ! chmod +x "$GENERIC_BINARY"; then
+      echo "Error: failed to make ${GENERIC_BINARY} executable" >&2
+      exit 1
+    fi
     echo "Created ${GENERIC_BINARY} for direct CLI usage" >&2
   fi
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -78,11 +78,15 @@ if [ -z "$BINARY" ]; then
 
   chmod +x "$BINARY"
   echo "Installed lumen to ${BINARY}" >&2
+fi
 
-  # Create a platform-agnostic symlink/copy so `lumen` works in PATH
-  GENERIC_BINARY="${PLUGIN_ROOT}/bin/lumen"
-  if [ ! -e "$GENERIC_BINARY" ] || [ ! -x "$GENERIC_BINARY" ]; then
-    cp "$BINARY" "$GENERIC_BINARY"
+# Always ensure generic binary exists for PATH usage (backfills old installs)
+GENERIC_BINARY="${PLUGIN_ROOT}/bin/lumen"
+PLATFORM_BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
+if [ ! -e "$GENERIC_BINARY" ] || [ ! -x "$GENERIC_BINARY" ]; then
+  # If we have a platform-specific binary, copy it to the generic name
+  if [ -x "$PLATFORM_BINARY" ]; then
+    cp "$PLATFORM_BINARY" "$GENERIC_BINARY"
     chmod +x "$GENERIC_BINARY"
     echo "Created ${GENERIC_BINARY} for direct CLI usage" >&2
   fi

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -204,6 +204,58 @@ FAKECURL
 ) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
 echo ""
+echo "=== generic binary creation test ==="
+
+# Verifies that run.sh creates bin/lumen alongside the platform-specific binary
+# so users can add it to PATH. Addresses GitHub issue #143.
+(
+  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _TMPROOT="$(mktemp -d)"
+  _FAKE_CURL_DIR="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
+
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH_RAW="$(uname -m)"
+  case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
+  _PLATFORM_BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
+  _GENERIC_BINARY="${_TMPROOT}/bin/lumen"
+
+  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
+  mkdir -p "${_TMPROOT}/bin"
+
+  # Stub curl: write a minimal executable to the -o destination
+  cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    *)  shift ;;
+  esac
+done
+exit 0
+FAKECURL
+  chmod +x "${_FAKE_CURL_DIR}/curl"
+
+  EXIT_CODE=0
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "  FAIL: run.sh stdio with missing binary should download and exec (exit $EXIT_CODE)"
+    exit 1
+  fi
+  if [ ! -x "$_PLATFORM_BINARY" ]; then
+    echo "  FAIL: platform-specific binary not created at ${_PLATFORM_BINARY}"
+    exit 1
+  fi
+  if [ ! -x "$_GENERIC_BINARY" ]; then
+    echo "  FAIL: generic binary not created at ${_GENERIC_BINARY} (issue #143)"
+    exit 1
+  fi
+  echo "  PASS: run.sh creates both platform-specific and generic binaries"
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+echo ""
 echo "=== GitHub API tag parsing tests ==="
 
 # Simulates the sed command used in run.sh to extract tag_name from JSON

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -256,6 +256,48 @@ FAKECURL
 ) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
 
 echo ""
+echo "=== generic binary backfill test (upgrade scenario) ==="
+
+# Verifies that run.sh backfills bin/lumen when only the platform-specific
+# binary exists (e.g., from an old installation). Addresses CodeRabbit feedback.
+(
+  _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  _TMPROOT="$(mktemp -d)"
+  trap 'rm -rf "$_TMPROOT"' EXIT
+
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH_RAW="$(uname -m)"
+  case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
+  _PLATFORM_BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
+  _GENERIC_BINARY="${_TMPROOT}/bin/lumen"
+
+  printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
+  mkdir -p "${_TMPROOT}/bin"
+
+  # Simulate old installation: platform-specific binary exists, generic does not
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$_PLATFORM_BINARY"
+  chmod +x "$_PLATFORM_BINARY"
+
+  EXIT_CODE=0
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
+    bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "  FAIL: run.sh should succeed when platform binary exists (exit $EXIT_CODE)"
+    exit 1
+  fi
+  if [ ! -x "$_PLATFORM_BINARY" ]; then
+    echo "  FAIL: platform-specific binary should remain intact"
+    exit 1
+  fi
+  if [ ! -x "$_GENERIC_BINARY" ]; then
+    echo "  FAIL: generic binary not backfilled from existing platform binary"
+    exit 1
+  fi
+  echo "  PASS: run.sh backfills generic binary from existing platform-specific binary"
+) && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+echo ""
 echo "=== GitHub API tag parsing tests ==="
 
 # Simulates the sed command used in run.sh to extract tag_name from JSON


### PR DESCRIPTION
## Summary

Fixes #143 - enables users to add the lumen binary to their PATH for direct CLI usage.

Currently, the launcher downloads platform-specific binaries (`lumen-linux-amd64`, `lumen-darwin-arm64`, etc.) but never creates a generic `lumen` binary, making it impossible to use from PATH even after adding the bin directory.

## Changes

- **run.sh**: After downloading the platform-specific binary, copy it to `bin/lumen`
- **run.bat**: Same for Windows (creates `bin/lumen.exe`)  
- **README.md**: Document where binaries live for each plugin host and how to add to PATH
- **test_run.sh**: Add test case verifying generic binary creation

## Test Plan

- [x] All existing tests pass (32/32)
- [x] New test verifies generic binary is created alongside platform-specific one
- [x] Launchers still prefer local dev builds (`bin/lumen`) over downloaded binaries
- [x] No breaking changes to existing plugin installations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ensures a stable, generic "lumen" CLI binary is created/backfilled on first run across platforms and auto-installs it into user bin locations so you can run `lumen` directly.

* **Documentation**
  * Added README section describing plugin-provided binary locations, automatic first-run install paths (~/.local/bin and %USERPROFILE%\bin) and PATH update examples.

* **Tests**
  * Added integration checks validating creation/backfill and upgrade behavior of the generic binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->