### PR TITLE
fix(scripts): eliminate stdout pollution in run.cmd polyglot

### DIFF
--- a/scripts/run.cmd
+++ b/scripts/run.cmd
@@ -1,5 +1,7 @@
-#!/bin/sh
-# 2>NUL & @goto batch
+:<<"::CMDLITERAL"
+@echo off
+goto :batch
+::CMDLITERAL
 exec "$(dirname "$0")/run.sh" "$@"
 
 :batch

--- a/scripts/test_run_cmd_windows.bat
+++ b/scripts/test_run_cmd_windows.bat
@@ -47,23 +47,53 @@ if "!OUTPUT!"=="delegated:hook session-start lumen --host claude" (
   set /a FAIL+=1
 )
 
-:: --- Test 3: run.cmd produces no unexpected stderr ---
+:: --- Test 3: run.cmd produces clean stderr ---
+:: The polyglot prologue must not surface command-not-found errors
+:: from cmd.exe trying to execute the shell-only lines.
+:: NOTE: invoke via `cmd /c` to match how MCP hosts spawn run.cmd
+:: (a fresh cmd.exe with default echo state, not inheriting `call`).
 set "STDERR_FILE=%TMP_DIR%\stderr.txt"
-"%TMP_DIR%\run.cmd" stdio 2>"%STDERR_FILE%" >NUL
+set "STDOUT_FILE=%TMP_DIR%\stdout.txt"
+cmd /c ""%TMP_DIR%\run.cmd" stdio" 2>"%STDERR_FILE%" >"%STDOUT_FILE%"
 
-:: Check stderr is empty or contains only the expected "not recognized" from shebang line
 set "STDERR_SIZE=0"
 for %%A in ("%STDERR_FILE%") do set "STDERR_SIZE=%%~zA"
 
-:: Stderr should only contain the harmless shebang error (if any)
-:: We check it doesn't contain "-S" which was the old broken error
-findstr /i "\-S" "%STDERR_FILE%" >NUL 2>&1
-if errorlevel 1 (
-  echo   PASS: no '-S' error in stderr
+if "!STDERR_SIZE!"=="0" (
+  echo   PASS: stderr is empty
   set /a PASS+=1
 ) else (
-  echo   FAIL: stderr contains '-S' error from old broken polyglot
+  echo   FAIL: stderr is not empty [size: !STDERR_SIZE! bytes]
   type "%STDERR_FILE%"
+  set /a FAIL+=1
+)
+
+:: --- Test 4: run.cmd produces clean stdout (no command-echo pollution) ---
+:: cmd.exe echoes commands to stdout before @echo off takes effect, so a
+:: polyglot whose first line is treated as a command (rather than a label
+:: or @-prefixed line) prepends prompt-prefixed text to stdout. This breaks
+:: MCP stdio JSON-RPC framing on Claude Code, Cursor, and other hosts that
+:: spawn run.cmd directly via .cmd file extension association.
+set "STDOUT_FIRST="
+for /f "usebackq delims=" %%i in ("%STDOUT_FILE%") do (
+  if not defined STDOUT_FIRST set "STDOUT_FIRST=%%i"
+)
+for /f %%i in ('find /c /v "" ^< "%STDOUT_FILE%"') do set "STDOUT_LINES=%%i"
+
+set "TEST4=fail"
+if "!STDOUT_FIRST!"=="delegated:stdio" if "!STDOUT_LINES!"=="1" set "TEST4=pass"
+
+if "!TEST4!"=="pass" (
+  echo   PASS: stdout has no command-echo pollution
+  set /a PASS+=1
+) else (
+  echo   FAIL: stdout polluted before run.bat output
+  echo         expected: 1 line "delegated:stdio"
+  echo         got first line: !STDOUT_FIRST!
+  echo         line count:     !STDOUT_LINES!
+  echo         --- full stdout ---
+  type "%STDOUT_FILE%"
+  echo         --- end ---
   set /a FAIL+=1
 )
 


### PR DESCRIPTION
## Summary

`scripts/run.cmd` is a sh/cmd polyglot whose first two lines (`#!/bin/sh`
and `# 2>NUL & @goto batch`) were echoed to **stdout** by cmd.exe before
`@echo off` took effect, prepending ~92 bytes of prompt-prefixed text to
the lumen binary's output. This broke MCP stdio JSON-RPC framing for any
MCP host that spawns `run.cmd` directly via the `.cmd` file-extension
association — including **Claude Code** on native Windows.

Replace the polyglot prologue with a label-based pattern that cmd.exe
does not echo, and add a regression test that catches stdout pollution
from a fresh-shell launch.

Refs: #121.

## The bug

### Affected environment

Any MCP host that spawns `run.cmd` on Windows. Reproduced on:

- **Claude Code** (native Windows install, v0.0.39 lumen plugin):
  `claude mcp list` reported `plugin:lumen:lumen ... ✗ Failed to connect`.
  The same routing applies to other hosts that start the MCP server via
  the `.cmd` file association (Cursor's `.cursor/mcp.json` uses the same
  `run.cmd` entry point).

### Why stdout was polluted

When cmd.exe runs a `.cmd` file with the default `@echo on` state, it
echoes each command line to **stdout** (prompt-prefixed, e.g.
`C:\path>command`) before executing it. The previous polyglot turned
echo off only after the goto:

```cmd
#!/bin/sh                      <- echoed to stdout (prompt + 9 bytes)
# 2>NUL & @goto batch          <- echoed to stdout (prompt + 22 bytes)
exec "$(dirname "$0")/run.sh" "$@"

:batch
@echo off                      <- echo only off from here
```

Measured (Windows 11, default cmd.exe):

| invocation                          | stdout bytes | stderr bytes |
| ----------------------------------- | ------------ | ------------ |
| `cmd /c scripts/run.cmd version`    | 99           | 93           |
| `cmd /c scripts/run.bat version`    | 7            | 0            |

The 92-byte stdout prefix looks like:

```
[blank]
C:\path>#!/bin/sh
[blank]
C:\path>#   2>NUL  &
0.0.39
```

MCP stdio clients parse JSON-RPC framing from the first byte of stdout;
any leading non-JSON bytes fail the handshake before the lumen binary
ever speaks.

### Why CI didn't catch it

`scripts/test_run_cmd_windows.bat` (added in #121) had two relevant
gaps:

1. The stderr assertion only checked for absence of the historical `-S`
   substring (with a comment noting the shebang error was "harmless"),
   so it passed even when stderr contained a different error.
2. The stdout test used `for /f "tokens=*" %%i in ('run.cmd ...') do
   set "OUTPUT=%%i"`, which overwrites `OUTPUT` on each line and keeps
   only the **last** stdout line. The polluting prompt-echo lines came
   first and were silently discarded.

## The fix

### `scripts/run.cmd`

Replace the prologue with a label-style line that cmd.exe does not echo
(labels are skipped without echoing even with `@echo on`), while still
working as a heredoc start in sh:

```cmd
:<<"::CMDLITERAL"
@echo off
goto :batch
::CMDLITERAL
exec "$(dirname "$0")/run.sh" "$@"

:batch
@echo off
set "SCRIPT_DIR=%~dp0"
call "%SCRIPT_DIR%run.bat" %*
exit /b %ERRORLEVEL%
```

- **cmd.exe path**: line 1 is parsed as a label (silent), line 2
  `@echo off` turns echo off, line 3 `goto :batch` jumps to the batch
  block. No stdout pollution.
- **sh path**: line 1 is `:` (POSIX no-op) followed by a quoted heredoc
  with delimiter `::CMDLITERAL`; the heredoc consumes lines 2–3 until
  the matching terminator on line 4. After the heredoc closes, sh runs
  the `exec` line.
- Byte 0 is now `:`, so OS execve returns ENOEXEC. POSIX-compliant
  runners that go through libc `execvp()` fall back to `/bin/sh` on
  ENOEXEC, which interprets the file via the sh path above (verified on
  WSL Ubuntu 24.04).

### `scripts/test_run_cmd_windows.bat`

- **Test 3 (tightened)**: assert stderr is exactly **0 bytes** (the new
  prologue produces no command-not-found errors at all), instead of
  only checking absence of `-S`.
- **Test 4 (new)**: spawn `run.cmd` via `cmd /c` to match how MCP hosts
  launch it (a fresh cmd.exe with default `@echo on`), capture full
  stdout to a file, and assert (a) the first non-empty line is
  `delegated:stdio` and (b) the total line count is exactly 1. Both
  checks must pass — first-line alone misses cases where extra lines
  appear after the expected output, and line-count alone misses
  reordering.

The `cmd /c` invocation is critical: `call run.cmd` would inherit the
parent test script's `@echo off` and mask the bug.

## Test plan

- [x] `scripts\test_run_cmd_windows.bat` with the fix on Windows 11 →
      **4/4 PASS**
- [x] `scripts\test_run_cmd_windows.bat` after reverting `run.cmd` to
      upstream `main` → **Test 3 FAIL** (93-byte stderr), **Test 4
      FAIL** (5 lines, first line is the prompt-echoed `#!/bin/sh`) —
      confirms the new tests are real regression guards
- [x] `scripts/test_run_cmd.sh` on WSL Ubuntu 24.04 — Unix delegation
      still passes (execvp ENOEXEC → /bin/sh fallback)
- [x] Patched `run.cmd` with CRLF line endings (matches Windows
      checkout under `core.autocrlf=true`) tested on `/bin/sh`,
      `/bin/dash`, and direct execve on Linux — all PASS (POSIX sh
      treats trailing `\r` consistently on the heredoc opener and
      terminator, so they match)
- [x] **End-to-end**: applied the patched `run.cmd` to a local Claude
      Code plugin cache, restarted, `/mcp` reconnected
      `plugin:lumen:lumen` and the `mcp__lumen__semantic_search` tool
      became callable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script structure for cross-platform command execution
  * Enhanced test coverage for Windows command execution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->