### PR TITLE
fix(scripts): resolve release downloads from fork remotes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,8 +78,3 @@ archives:
 
 checksum:
   name_template: checksums.txt
-
-release:
-  github:
-    owner: ory
-    name: lumen

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -24,7 +24,11 @@ set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
-  set "REPO=ory/lumen"
+  if defined LUMEN_RELEASE_REPO (
+    set "REPO=%LUMEN_RELEASE_REPO%"
+  ) else (
+    set "REPO=ory/lumen"
+  )
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync
   set "MANIFEST=%PLUGIN_ROOT%\.release-please-manifest.json"

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -27,7 +27,28 @@ if not exist "%BINARY%" (
   if defined LUMEN_RELEASE_REPO (
     set "REPO=%LUMEN_RELEASE_REPO%"
   ) else (
-    set "REPO=ory/lumen"
+    set "REPO="
+    set "ORIGIN_URL="
+    for /f "delims=" %%u in ('git -C "%PLUGIN_ROOT%" remote get-url origin 2^>nul') do (
+      if not defined ORIGIN_URL set "ORIGIN_URL=%%u"
+    )
+    if defined ORIGIN_URL (
+      set "CANDIDATE="
+      set "_TMP=!ORIGIN_URL!"
+      if /I "!_TMP:~0,19!"=="https://github.com/" (
+        set "CANDIDATE=!_TMP:~19!"
+      ) else if /I "!_TMP:~0,15!"=="git@github.com:" (
+        set "CANDIDATE=!_TMP:~15!"
+      ) else if /I "!_TMP:~0,21!"=="ssh://git@github.com/" (
+        set "CANDIDATE=!_TMP:~21!"
+      )
+      if defined CANDIDATE (
+        if "!CANDIDATE:~-4!"==".git" set "CANDIDATE=!CANDIDATE:~0,-4!"
+        echo !CANDIDATE! | findstr /r "^[^/][^/]*/[^/][^/]*$" >nul 2>&1
+        if not errorlevel 1 set "REPO=!CANDIDATE!"
+      )
+    )
+    if not defined REPO set "REPO=ory/lumen"
   )
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,13 +7,13 @@ set -euo pipefail
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 
 release_repo_from_remote_url() {
-  local url="$1"
+  local url="$1" repo
   case "$url" in
-    https://github.com/*/*.git) echo "${url#https://github.com/}" | sed 's/[.]git$//' ;;
+    https://github.com/*/*.git) repo="${url#https://github.com/}"; echo "${repo%.git}" ;;
     https://github.com/*/*) echo "${url#https://github.com/}" ;;
-    git@github.com:*/*.git) echo "${url#git@github.com:}" | sed 's/[.]git$//' ;;
+    git@github.com:*/*.git) repo="${url#git@github.com:}"; echo "${repo%.git}" ;;
     git@github.com:*/*) echo "${url#git@github.com:}" ;;
-    ssh://git@github.com/*/*.git) echo "${url#ssh://git@github.com/}" | sed 's/[.]git$//' ;;
+    ssh://git@github.com/*/*.git) repo="${url#ssh://git@github.com/}"; echo "${repo%.git}" ;;
     ssh://git@github.com/*/*) echo "${url#ssh://git@github.com/}" ;;
     *) echo "" ;;
   esac

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,6 +6,36 @@ set -euo pipefail
 # OpenCode, and direct local invocation.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 
+release_repo_from_remote_url() {
+  local url="$1"
+  case "$url" in
+    https://github.com/*/*.git) echo "${url#https://github.com/}" | sed 's/[.]git$//' ;;
+    https://github.com/*/*) echo "${url#https://github.com/}" ;;
+    git@github.com:*/*.git) echo "${url#git@github.com:}" | sed 's/[.]git$//' ;;
+    git@github.com:*/*) echo "${url#git@github.com:}" ;;
+    ssh://git@github.com/*/*.git) echo "${url#ssh://git@github.com/}" | sed 's/[.]git$//' ;;
+    ssh://git@github.com/*/*) echo "${url#ssh://git@github.com/}" ;;
+    *) echo "" ;;
+  esac
+}
+
+resolve_release_repo() {
+  if [ -n "${LUMEN_RELEASE_REPO:-}" ]; then
+    echo "$LUMEN_RELEASE_REPO"
+    return
+  fi
+
+  local remote_url repo
+  remote_url="$(git -C "$PLUGIN_ROOT" remote get-url origin 2>/dev/null || true)"
+  repo="$(release_repo_from_remote_url "$remote_url")"
+  if [ -n "$repo" ]; then
+    echo "$repo"
+    return
+  fi
+
+  echo "ory/lumen"
+}
+
 # Platform detection
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -29,7 +59,7 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 
-  REPO="ory/lumen"
+  REPO="$(resolve_release_repo)"
 
   # Always use the version pinned in the manifest — keeps plugin and binary in sync
   MANIFEST="${PLUGIN_ROOT}/.release-please-manifest.json"

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -101,13 +101,13 @@ echo ""
 echo "=== release repository resolution tests ==="
 
 release_repo_from_remote_url() {
-  local url="$1"
+  local url="$1" repo
   case "$url" in
-    https://github.com/*/*.git) echo "${url#https://github.com/}" | sed 's/[.]git$//' ;;
+    https://github.com/*/*.git) repo="${url#https://github.com/}"; echo "${repo%.git}" ;;
     https://github.com/*/*) echo "${url#https://github.com/}" ;;
-    git@github.com:*/*.git) echo "${url#git@github.com:}" | sed 's/[.]git$//' ;;
+    git@github.com:*/*.git) repo="${url#git@github.com:}"; echo "${repo%.git}" ;;
     git@github.com:*/*) echo "${url#git@github.com:}" ;;
-    ssh://git@github.com/*/*.git) echo "${url#ssh://git@github.com/}" | sed 's/[.]git$//' ;;
+    ssh://git@github.com/*/*.git) repo="${url#ssh://git@github.com/}"; echo "${repo%.git}" ;;
     ssh://git@github.com/*/*) echo "${url#ssh://git@github.com/}" ;;
     *) echo "" ;;
   esac
@@ -121,6 +121,10 @@ assert_eq "parse SSH origin with .git" "def324/lumen" \
   "$(release_repo_from_remote_url "git@github.com:def324/lumen.git")"
 assert_eq "parse ssh:// origin with .git" "def324/lumen" \
   "$(release_repo_from_remote_url "ssh://git@github.com/def324/lumen.git")"
+assert_eq "parse SSH origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "git@github.com:def324/lumen")"
+assert_eq "parse ssh:// origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "ssh://git@github.com/def324/lumen")"
 assert_eq "ignore non-GitHub origin" "" \
   "$(release_repo_from_remote_url "git@example.com:def324/lumen.git")"
 

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -98,6 +98,33 @@ assert_eq "Windows amd64 URL" \
   "$(download_url "$REPO" "$VERSION" "windows" "amd64")"
 
 echo ""
+echo "=== release repository resolution tests ==="
+
+release_repo_from_remote_url() {
+  local url="$1"
+  case "$url" in
+    https://github.com/*/*.git) echo "${url#https://github.com/}" | sed 's/[.]git$//' ;;
+    https://github.com/*/*) echo "${url#https://github.com/}" ;;
+    git@github.com:*/*.git) echo "${url#git@github.com:}" | sed 's/[.]git$//' ;;
+    git@github.com:*/*) echo "${url#git@github.com:}" ;;
+    ssh://git@github.com/*/*.git) echo "${url#ssh://git@github.com/}" | sed 's/[.]git$//' ;;
+    ssh://git@github.com/*/*) echo "${url#ssh://git@github.com/}" ;;
+    *) echo "" ;;
+  esac
+}
+
+assert_eq "parse HTTPS origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen.git")"
+assert_eq "parse HTTPS origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen")"
+assert_eq "parse SSH origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "git@github.com:def324/lumen.git")"
+assert_eq "parse ssh:// origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "ssh://git@github.com/def324/lumen.git")"
+assert_eq "ignore non-GitHub origin" "" \
+  "$(release_repo_from_remote_url "git@example.com:def324/lumen.git")"
+
+echo ""
 echo "=== arch normalisation tests ==="
 assert_eq "x86_64 → amd64"  "amd64" "$(normalise_arch "x86_64")"
 assert_eq "aarch64 → arm64" "arm64" "$(normalise_arch "aarch64")"
@@ -165,6 +192,7 @@ echo "=== stdio download-on-first-run integration test ==="
   _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
+  _URL_LOG="${_TMPROOT}/curl-urls.txt"
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
 
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -181,6 +209,7 @@ echo "=== stdio download-on-first-run integration test ==="
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    https://*) printf '%s\n' "$1" >> "$LUMEN_CURL_URL_LOG"; shift ;;
     *)  shift ;;
   esac
 done
@@ -189,7 +218,10 @@ FAKECURL
   chmod +x "${_FAKE_CURL_DIR}/curl"
 
   EXIT_CODE=0
-  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
+    LUMEN_RELEASE_REPO="def324/lumen" \
+    LUMEN_CURL_URL_LOG="${_URL_LOG}" \
+    PATH="${_FAKE_CURL_DIR}:${PATH}" \
     bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
 
   if [ "$EXIT_CODE" -ne 0 ]; then
@@ -198,6 +230,12 @@ FAKECURL
   fi
   if [ ! -x "$_EXPECTED_BINARY" ]; then
     echo "  FAIL: run.sh stdio should have downloaded binary to ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  if ! grep -q "https://github.com/def324/lumen/releases/download/v0.0.1/" "${_URL_LOG}"; then
+    echo "  FAIL: run.sh stdio should use LUMEN_RELEASE_REPO for download URL"
+    echo "        URLs:"
+    sed 's/^/          /' "${_URL_LOG}"
     exit 1
   fi
   echo "  PASS: run.sh stdio downloads binary and execs it on first install"
@@ -301,6 +339,7 @@ echo "=== stdio first-install MCP handshake test ==="
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
   _MOCK_BIN_DIR="$(mktemp -d)"
+  _URL_LOG="${_TMPROOT}/curl-urls.txt"
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR" "$_MOCK_BIN_DIR"' EXIT
 
   _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -321,6 +360,8 @@ echo "=== stdio first-install MCP handshake test ==="
 
   printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
   mkdir -p "${_TMPROOT}/bin"
+  git -C "${_TMPROOT}" init -q
+  git -C "${_TMPROOT}" remote add origin git@github.com:def324/lumen.git
 
   # Stub curl: parse -o <target> and copy the prebuilt mock into place.
   cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
@@ -328,6 +369,7 @@ echo "=== stdio first-install MCP handshake test ==="
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) mkdir -p "$(dirname "$2")"; cp "$LUMEN_MOCK_BINARY" "$2"; chmod +x "$2"; shift 2 ;;
+    https://*) printf '%s\n' "$1" >> "$LUMEN_CURL_URL_LOG"; shift ;;
     *)  shift ;;
   esac
 done
@@ -343,6 +385,7 @@ FAKECURL
   printf '%s\n' "$_INIT_REQ" | \
     CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
     PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    LUMEN_CURL_URL_LOG="${_URL_LOG}" \
     LUMEN_MOCK_BINARY="${_MOCK_BIN}" \
     bash "${_SCRIPT_DIR}/run.sh" stdio >"${_STDOUT}" 2>"${_STDERR}" \
     || EXIT_CODE=$?
@@ -355,6 +398,12 @@ FAKECURL
   fi
   if [ ! -x "$_EXPECTED_BINARY" ]; then
     echo "  FAIL: run.sh stdio did not place artefact at ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  if ! grep -q "https://github.com/def324/lumen/releases/download/v0.0.1/" "${_URL_LOG}"; then
+    echo "  FAIL: run.sh stdio should derive release repo from plugin root origin"
+    echo "        URLs:"
+    sed 's/^/          /' "${_URL_LOG}"
     exit 1
   fi
   if ! grep -q '"jsonrpc":"2.0"' "${_STDOUT}"; then

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -21,15 +21,12 @@ $RepoRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
 $TmpRoot     = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "lumen-stdio-$([guid]::NewGuid().ToString('N'))")).FullName
 $FakeCurlDir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "fakecurl-$([guid]::NewGuid().ToString('N'))")).FullName
 $MockBinDir  = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "mockbin-$([guid]::NewGuid().ToString('N'))")).FullName
-$CurlArgsLog = Join-Path $TmpRoot 'curl-args.txt'
-
 $origPath = $env:PATH
 $buildOK  = $false
 $proc     = $null
 
 try {
     $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'amd64' }
-    $expectedBinary = Join-Path $TmpRoot "bin\lumen-windows-$arch.exe"
 
     # Build the mock MCP server — pure Go, no CGO.
     $mockBin = Join-Path $MockBinDir 'mock_lumen.exe'
@@ -48,11 +45,6 @@ try {
     }
 
     if ($buildOK) {
-        # Minimal plugin root: manifest only.
-        $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
-        [IO.File]::WriteAllText((Join-Path $TmpRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
-        New-Item -ItemType Directory -Path (Join-Path $TmpRoot 'bin') | Out-Null
-
         # Stub curl: curl.bat parses -o <target> and copies the prebuilt mock in.
         # cmd.exe's PATHEXT search is per-directory: our fake dir is prepended
         # to PATH and contains only curl.bat, so it wins regardless of PATHEXT
@@ -76,71 +68,123 @@ exit /b 0
 '@
         [IO.File]::WriteAllText((Join-Path $FakeCurlDir 'curl.bat'), $curlStub, [Text.Encoding]::ASCII)
 
-        # Launch run.bat via System.Diagnostics.Process for reliable exit-code
-        # propagation and explicit stdin/stdout/stderr wiring. Start-Process
-        # with -RedirectStandardInput is unreliable here.
-        $runBat  = Join-Path $ScriptDir 'run.bat'
-        $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+        function Invoke-RunBatScenario {
+            param(
+                [string] $Name,
+                [string] $ExpectedRepo,
+                [string] $PassMessage,
+                [string] $ReleaseRepoOverride = '',
+                [string] $OriginUrl = ''
+            )
 
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = 'cmd.exe'
-        $psi.Arguments = "/c `"$runBat`" stdio"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput  = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError  = $true
-        $psi.CreateNoWindow = $true
-        $psi.WorkingDirectory = $RepoRoot
-        $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $TmpRoot
-        $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
-        $psi.Environment['LUMEN_RELEASE_REPO'] = 'def324/lumen'
-        $psi.Environment['LUMEN_CURL_ARGS_LOG'] = $CurlArgsLog
-        $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
+            $pluginRoot = (New-Item -ItemType Directory -Path (Join-Path $TmpRoot $Name)).FullName
+            $curlArgsLog = Join-Path $pluginRoot 'curl-args.txt'
+            $expectedBinary = Join-Path $pluginRoot "bin\lumen-windows-$arch.exe"
 
-        $proc = [System.Diagnostics.Process]::Start($psi)
+            # Minimal plugin root: manifest only.
+            $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
+            [IO.File]::WriteAllText((Join-Path $pluginRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
+            New-Item -ItemType Directory -Path (Join-Path $pluginRoot 'bin') | Out-Null
 
-        # If run.bat fast-exits in stdio mode, its stdin pipe is already
-        # closed by the time we try to write — that IS the #125 symptom,
-        # so swallow the broken-pipe exception and let the exit-code check
-        # below produce the real diagnostic.
-        try { $proc.StandardInput.WriteLine($initReq) } catch { }
-        try { $proc.StandardInput.Close() } catch { }
+            if ($OriginUrl) {
+                $gitOutput = & git -C $pluginRoot init 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Fail "could not initialise plugin root git repo for $Name"
+                    $gitOutput | ForEach-Object { Write-Host "          $_" }
+                    return
+                }
 
-        $stdout = $proc.StandardOutput.ReadToEnd()
-        $stderr = $proc.StandardError.ReadToEnd()
-        if (-not $proc.WaitForExit(60000)) {
-            $proc.Kill()
-            Fail "run.bat stdio did not exit within 60s"
-        } else {
-            $exitCode = $proc.ExitCode
-
-            Write-Host "    launcher exit code: $exitCode"
-            if ($stderr) {
-                Write-Host "    launcher stderr:"
-                ($stderr -split "`r?`n") | ForEach-Object { if ($_) { Write-Host "      $_" } }
+                $gitOutput = & git -C $pluginRoot remote add origin $OriginUrl 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Fail "could not add origin remote for $Name"
+                    $gitOutput | ForEach-Object { Write-Host "          $_" }
+                    return
+                }
             }
 
-            if ($exitCode -ne 0) {
-                Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
-            } elseif (-not (Test-Path $expectedBinary)) {
-                Fail "run.bat stdio did not place artefact at $expectedBinary"
-            } elseif (-not (Test-Path $CurlArgsLog)) {
-                Fail "fake curl did not capture launcher download arguments"
-            } elseif ((Get-Content -Raw $CurlArgsLog) -notmatch 'https://github\.com/def324/lumen/releases/download/') {
-                Fail "run.bat stdio should use LUMEN_RELEASE_REPO for download URL"
-                Write-Host "        curl args:"
-                (Get-Content $CurlArgsLog) | ForEach-Object { Write-Host "          $_" }
-            } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
-                Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
-                Write-Host "        stdout:"
-                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
-            } elseif ($stdout -notmatch '"name":"mock-lumen"') {
-                Fail "MCP response did not come from the exec'd mock — run.bat may be swallowing stdout"
-                Write-Host "        stdout:"
-                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+            # Launch run.bat via System.Diagnostics.Process for reliable exit-code
+            # propagation and explicit stdin/stdout/stderr wiring. Start-Process
+            # with -RedirectStandardInput is unreliable here.
+            $runBat  = Join-Path $ScriptDir 'run.bat'
+            $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = 'cmd.exe'
+            $psi.Arguments = "/c `"$runBat`" stdio"
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardInput  = $true
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError  = $true
+            $psi.CreateNoWindow = $true
+            $psi.WorkingDirectory = $RepoRoot
+            $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $pluginRoot
+            $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
+            $psi.Environment['LUMEN_CURL_ARGS_LOG'] = $curlArgsLog
+            $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
+            $psi.Environment.Remove('LUMEN_RELEASE_REPO') | Out-Null
+            if ($ReleaseRepoOverride) {
+                $psi.Environment['LUMEN_RELEASE_REPO'] = $ReleaseRepoOverride
+            }
+
+            $script:proc = [System.Diagnostics.Process]::Start($psi)
+
+            # If run.bat fast-exits in stdio mode, its stdin pipe is already
+            # closed by the time we try to write — that IS the #125 symptom,
+            # so swallow the broken-pipe exception and let the exit-code check
+            # below produce the real diagnostic.
+            try { $script:proc.StandardInput.WriteLine($initReq) } catch { }
+            try { $script:proc.StandardInput.Close() } catch { }
+
+            $stdout = $script:proc.StandardOutput.ReadToEnd()
+            $stderr = $script:proc.StandardError.ReadToEnd()
+            if (-not $script:proc.WaitForExit(60000)) {
+                $script:proc.Kill()
+                Fail "run.bat stdio did not exit within 60s for $Name"
             } else {
-                Pass "run.bat stdio downloads, execs, and brokers MCP initialize on first install"
+                $exitCode = $script:proc.ExitCode
+
+                Write-Host "    launcher exit code ($Name): $exitCode"
+                if ($stderr) {
+                    Write-Host "    launcher stderr ($Name):"
+                    ($stderr -split "`r?`n") | ForEach-Object { if ($_) { Write-Host "      $_" } }
+                }
+
+                $expectedUrl = [regex]::Escape("https://github.com/$ExpectedRepo/releases/download/")
+                if ($exitCode -ne 0) {
+                    Fail "run.bat stdio exited $exitCode for $Name - MCP server would be dead for the session"
+                } elseif (-not (Test-Path $expectedBinary)) {
+                    Fail "run.bat stdio did not place artefact at $expectedBinary"
+                } elseif (-not (Test-Path $curlArgsLog)) {
+                    Fail "fake curl did not capture launcher download arguments for $Name"
+                } elseif ((Get-Content -Raw $curlArgsLog) -notmatch $expectedUrl) {
+                    Fail "run.bat stdio should use $ExpectedRepo for download URL in $Name"
+                    Write-Host "        curl args:"
+                    (Get-Content $curlArgsLog) | ForEach-Object { Write-Host "          $_" }
+                } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
+                    Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout for $Name"
+                    Write-Host "        stdout:"
+                    ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+                } elseif ($stdout -notmatch '"name":"mock-lumen"') {
+                    Fail "MCP response did not come from the exec'd mock for $Name - run.bat may be swallowing stdout"
+                    Write-Host "        stdout:"
+                    ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+                } else {
+                    Pass $PassMessage
+                }
             }
+        }
+
+        Invoke-RunBatScenario `
+            -Name 'env-override' `
+            -ExpectedRepo 'def324/lumen' `
+            -ReleaseRepoOverride 'def324/lumen' `
+            -PassMessage 'run.bat stdio uses LUMEN_RELEASE_REPO for first-install download'
+
+        Invoke-RunBatScenario `
+            -Name 'origin-remote' `
+            -ExpectedRepo 'def324/lumen' `
+            -OriginUrl 'https://github.com/def324/lumen.git' `
+            -PassMessage 'run.bat stdio derives first-install download repo from git origin'
         }
     }
 } finally {

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -185,6 +185,12 @@ exit /b 0
             -ExpectedRepo 'def324/lumen' `
             -OriginUrl 'https://github.com/def324/lumen.git' `
             -PassMessage 'run.bat stdio derives first-install download repo from git origin'
+
+        Invoke-RunBatScenario `
+            -Name 'origin-remote-ssh' `
+            -ExpectedRepo 'def324/lumen' `
+            -OriginUrl 'git@github.com:def324/lumen.git' `
+            -PassMessage 'run.bat stdio derives first-install download repo from git origin (ssh)'
         }
 } finally {
     $env:PATH = $origPath

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -21,6 +21,7 @@ $RepoRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
 $TmpRoot     = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "lumen-stdio-$([guid]::NewGuid().ToString('N'))")).FullName
 $FakeCurlDir = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "fakecurl-$([guid]::NewGuid().ToString('N'))")).FullName
 $MockBinDir  = (New-Item -ItemType Directory -Path (Join-Path $env:TEMP "mockbin-$([guid]::NewGuid().ToString('N'))")).FullName
+$CurlArgsLog = Join-Path $TmpRoot 'curl-args.txt'
 
 $origPath = $env:PATH
 $buildOK  = $false
@@ -59,6 +60,7 @@ try {
         $curlStub = @'
 @echo off
 setlocal enabledelayedexpansion
+echo %*>>"%LUMEN_CURL_ARGS_LOG%"
 :loop
 if "%~1"=="" goto done
 if "%~1"=="-o" (
@@ -91,6 +93,8 @@ exit /b 0
         $psi.WorkingDirectory = $RepoRoot
         $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $TmpRoot
         $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
+        $psi.Environment['LUMEN_RELEASE_REPO'] = 'def324/lumen'
+        $psi.Environment['LUMEN_CURL_ARGS_LOG'] = $CurlArgsLog
         $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
 
         $proc = [System.Diagnostics.Process]::Start($psi)
@@ -120,6 +124,12 @@ exit /b 0
                 Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
             } elseif (-not (Test-Path $expectedBinary)) {
                 Fail "run.bat stdio did not place artefact at $expectedBinary"
+            } elseif (-not (Test-Path $CurlArgsLog)) {
+                Fail "fake curl did not capture launcher download arguments"
+            } elseif ((Get-Content -Raw $CurlArgsLog) -notmatch 'https://github\.com/def324/lumen/releases/download/') {
+                Fail "run.bat stdio should use LUMEN_RELEASE_REPO for download URL"
+                Write-Host "        curl args:"
+                (Get-Content $CurlArgsLog) | ForEach-Object { Write-Host "          $_" }
             } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
                 Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
                 Write-Host "        stdout:"

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -186,7 +186,6 @@ exit /b 0
             -OriginUrl 'https://github.com/def324/lumen.git' `
             -PassMessage 'run.bat stdio derives first-install download repo from git origin'
         }
-    }
 } finally {
     $env:PATH = $origPath
     if ($proc -and -not $proc.HasExited) { try { $proc.Kill() } catch {} }

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -132,8 +132,8 @@ exit /b 0
             # closed by the time we try to write — that IS the #125 symptom,
             # so swallow the broken-pipe exception and let the exit-code check
             # below produce the real diagnostic.
-            try { $script:proc.StandardInput.WriteLine($initReq) } catch { }
-            try { $script:proc.StandardInput.Close() } catch { }
+            try { $script:proc.StandardInput.WriteLine($initReq) } catch { $null = $_ }
+            try { $script:proc.StandardInput.Close() } catch { $null = $_ }
 
             $stdout = $script:proc.StandardOutput.ReadToEnd()
             $stderr = $script:proc.StandardError.ReadToEnd()
@@ -191,6 +191,17 @@ exit /b 0
             -ExpectedRepo 'def324/lumen' `
             -OriginUrl 'git@github.com:def324/lumen.git' `
             -PassMessage 'run.bat stdio derives first-install download repo from git origin (ssh)'
+
+        Invoke-RunBatScenario `
+            -Name 'origin-remote-ssh-url' `
+            -ExpectedRepo 'def324/lumen' `
+            -OriginUrl 'ssh://git@github.com/def324/lumen.git' `
+            -PassMessage 'run.bat stdio derives first-install download repo from git origin (ssh://)'
+
+        Invoke-RunBatScenario `
+            -Name 'fallback-ory-lumen' `
+            -ExpectedRepo 'ory/lumen' `
+            -PassMessage 'run.bat stdio falls back to ory/lumen when no origin or env override is set'
         }
 } finally {
     $env:PATH = $origPath


### PR DESCRIPTION
## Summary
- resolve launcher release downloads from LUMEN_RELEASE_REPO, then the installed checkout origin, then upstream fallback
- let GoReleaser target the current repository instead of hardcoding ory/lumen
- cover Unix fork URL resolution and Windows LUMEN_RELEASE_REPO behavior in launcher tests

## Verification
- bash scripts/test_run.sh
- bash scripts/test_run_cmd.sh
- make test

Draft PR for CI verification and separate review from the stdio lifecycle fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-run binary download now derives the GitHub release repository dynamically or via env var override, enabling forks/custom distributions on Windows and Unix.

* **Tests**
  * Expanded cross-platform tests and Windows harnesses to verify release-repo resolution and expected download URLs across multiple remote URL formats and scenarios.

* **Chores**
  * Release configuration updated to produce a named checksum output file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->