### PR TITLE
fix(scripts): resolve release artifacts from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Coveralls
+        if: ${{ github.repository == 'ory/lumen' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'ory/lumen') }}
         uses: coverallsapp/github-action@v2
         with:
           file: coverage.out

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.repository == 'ory/lumen'
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -29,7 +30,7 @@ jobs:
     container:
       image: oryd/xgoreleaser:1.26.0-2.14.1
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' && github.repository == 'ory/lumen' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +49,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' && github.repository == 'ory/lumen' }}
     permissions:
       contents: read
       id-token: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,8 +78,3 @@ archives:
 
 checksum:
   name_template: checksums.txt
-
-release:
-  github:
-    owner: ory
-    name: lumen

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -27,7 +27,7 @@ set "TMP_BINARY=%BINARY%.tmp"
 if not exist "%BINARY%" (
   if defined LUMEN_RELEASE_REPO (
     set "REPO=%LUMEN_RELEASE_REPO%"
-    echo(!REPO!| findstr /r "^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$" >nul 2>&1
+    powershell -NoProfile -Command "if ($env:REPO -match '^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$' -and $env:REPO -notmatch '\.git$') { exit 0 } else { exit 1 }" >nul 2>&1
     if errorlevel 1 (
       echo Error: LUMEN_RELEASE_REPO must be in owner/repo form >&2
       exit /b 1
@@ -64,7 +64,7 @@ if not exist "%BINARY%" (
       if defined CANDIDATE (
         if "!CANDIDATE:~-4!"==".git" set "CANDIDATE=!CANDIDATE:~0,-4!"
         set "CANDIDATE_OK=0"
-        echo(!CANDIDATE!| findstr /r "^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$" >nul 2>&1
+        powershell -NoProfile -Command "if ($env:CANDIDATE -match '^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$' -and $env:CANDIDATE -notmatch '\.git$') { exit 0 } else { exit 1 }" >nul 2>&1
         if not errorlevel 1 set "CANDIDATE_OK=1"
         if "!CANDIDATE_OK!"=="1" (
           for /f "tokens=1 delims=/" %%o in ("!CANDIDATE!") do set "CANDIDATE_OWNER=%%o"

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -21,10 +21,62 @@ if not defined LUMEN_EMBED_MODEL set "LUMEN_EMBED_MODEL=ordis/jina-embeddings-v2
 
 :: Binary path
 set "BINARY=%PLUGIN_ROOT%\bin\lumen-windows-%ARCH%.exe"
+set "TMP_BINARY=%BINARY%.tmp"
 
 :: Download on first run if binary is missing
 if not exist "%BINARY%" (
-  set "REPO=ory/lumen"
+  if defined LUMEN_RELEASE_REPO (
+    set "REPO=%LUMEN_RELEASE_REPO%"
+    echo(!REPO!| findstr /r "^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$" >nul 2>&1
+    if errorlevel 1 (
+      echo Error: LUMEN_RELEASE_REPO must be in owner/repo form >&2
+      exit /b 1
+    )
+    for /f "tokens=1 delims=/" %%o in ("!REPO!") do set "REPO_OWNER=%%o"
+    if "!REPO_OWNER:~-1!"=="-" (
+      echo Error: LUMEN_RELEASE_REPO must be in owner/repo form >&2
+      exit /b 1
+    )
+    if not "!REPO_OWNER:~39,1!"=="" (
+      echo Error: LUMEN_RELEASE_REPO must be in owner/repo form >&2
+      exit /b 1
+    )
+    if not "!REPO_OWNER:--=!"=="!REPO_OWNER!" (
+      echo Error: LUMEN_RELEASE_REPO must be in owner/repo form >&2
+      exit /b 1
+    )
+  ) else (
+    set "REPO="
+    set "ORIGIN_URL="
+    for /f "delims=" %%u in ('git -C "%PLUGIN_ROOT%" remote get-url origin 2^>nul') do (
+      if not defined ORIGIN_URL set "ORIGIN_URL=%%u"
+    )
+    if defined ORIGIN_URL (
+      set "CANDIDATE="
+      set "_TMP=!ORIGIN_URL!"
+      if /I "!_TMP:~0,19!"=="https://github.com/" (
+        set "CANDIDATE=!_TMP:~19!"
+      ) else if /I "!_TMP:~0,15!"=="git@github.com:" (
+        set "CANDIDATE=!_TMP:~15!"
+      ) else if /I "!_TMP:~0,21!"=="ssh://git@github.com/" (
+        set "CANDIDATE=!_TMP:~21!"
+      )
+      if defined CANDIDATE (
+        if "!CANDIDATE:~-4!"==".git" set "CANDIDATE=!CANDIDATE:~0,-4!"
+        set "CANDIDATE_OK=0"
+        echo(!CANDIDATE!| findstr /r "^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-][A-Za-z0-9_.-]*$" >nul 2>&1
+        if not errorlevel 1 set "CANDIDATE_OK=1"
+        if "!CANDIDATE_OK!"=="1" (
+          for /f "tokens=1 delims=/" %%o in ("!CANDIDATE!") do set "CANDIDATE_OWNER=%%o"
+          if "!CANDIDATE_OWNER:~-1!"=="-" set "CANDIDATE_OK=0"
+          if not "!CANDIDATE_OWNER:~39,1!"=="" set "CANDIDATE_OK=0"
+          if not "!CANDIDATE_OWNER:--=!"=="!CANDIDATE_OWNER!" set "CANDIDATE_OK=0"
+        )
+        if "!CANDIDATE_OK!"=="1" set "REPO=!CANDIDATE!"
+      )
+    )
+    if not defined REPO set "REPO=ory/lumen"
+  )
 
   :: Always use the version pinned in the manifest — keeps plugin and binary in sync
   set "MANIFEST=%PLUGIN_ROOT%\.release-please-manifest.json"
@@ -52,8 +104,10 @@ if not exist "%BINARY%" (
   echo Downloading lumen !VERSION! for windows/!ARCH!... >&2
   if not exist "%PLUGIN_ROOT%\bin" mkdir "%PLUGIN_ROOT%\bin"
 
-  call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
+  if exist "%TMP_BINARY%" del "%TMP_BINARY%" 2>nul
+  call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%TMP_BINARY%"
   if errorlevel 1 (
+    if exist "%TMP_BINARY%" del "%TMP_BINARY%" 2>nul
     :: Fallback: manifest version not released yet — resolve latest from GitHub API
     echo Version !VERSION! not found, resolving latest release... >&2
 
@@ -88,14 +142,23 @@ if not exist "%BINARY%" (
     set "ASSET=lumen-!VERSION:~1!-windows-!ARCH!.exe"
     set "URL=https://github.com/!REPO!/releases/download/!VERSION!/!ASSET!"
 
-    call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%BINARY%"
+    if exist "%TMP_BINARY%" del "%TMP_BINARY%" 2>nul
+    call curl -sfL --max-time 300 --retry 3 --retry-delay 2 "!URL!" -o "%TMP_BINARY%"
     if errorlevel 1 (
+      if exist "%TMP_BINARY%" del "%TMP_BINARY%" 2>nul
       echo Error: fallback download also failed >&2
       exit /b 1
     )
   )
 
+  move /Y "%TMP_BINARY%" "%BINARY%" >nul
+  if errorlevel 1 (
+    if exist "%TMP_BINARY%" del "%TMP_BINARY%" 2>nul
+    echo Error: could not install downloaded lumen binary >&2
+    exit /b 1
+  )
   echo Installed lumen to %BINARY% >&2
 )
 
+set "LUMEN_PLUGIN_ROOT=%PLUGIN_ROOT%"
 "%BINARY%" %*

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,6 +6,59 @@ set -euo pipefail
 # OpenCode, and direct local invocation.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 
+release_repo_from_remote_url() {
+  local url="$1" repo
+  case "$url" in
+    https://github.com/*/*.git) repo="${url#https://github.com/}"; repo="${repo%.git}" ;;
+    https://github.com/*/*) repo="${url#https://github.com/}" ;;
+    git@github.com:*/*.git) repo="${url#git@github.com:}"; repo="${repo%.git}" ;;
+    git@github.com:*/*) repo="${url#git@github.com:}" ;;
+    ssh://git@github.com/*/*.git) repo="${url#ssh://git@github.com/}"; repo="${repo%.git}" ;;
+    ssh://git@github.com/*/*) repo="${url#ssh://git@github.com/}" ;;
+    *) repo="" ;;
+  esac
+  if valid_release_repo "$repo"; then
+    echo "$repo"
+  else
+    echo ""
+  fi
+}
+
+valid_release_repo() {
+  local repo="$1" owner name
+  case "$repo" in
+    */*/* | /* | */) return 1 ;;
+    */*) ;;
+    *) return 1 ;;
+  esac
+  owner="${repo%%/*}"
+  name="${repo#*/}"
+  [[ "$owner" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
+  [[ "$owner" != *--* ]] || return 1
+  [[ "$name" =~ ^[A-Za-z0-9_.-]+$ ]]
+}
+
+resolve_release_repo() {
+  if [ -n "${LUMEN_RELEASE_REPO:-}" ]; then
+    if ! valid_release_repo "$LUMEN_RELEASE_REPO"; then
+      echo "Error: LUMEN_RELEASE_REPO must be in owner/repo form" >&2
+      return 1
+    fi
+    echo "$LUMEN_RELEASE_REPO"
+    return
+  fi
+
+  local remote_url repo
+  remote_url="$(git -C "$PLUGIN_ROOT" remote get-url origin 2>/dev/null || true)"
+  repo="$(release_repo_from_remote_url "$remote_url")"
+  if [ -n "$repo" ]; then
+    echo "$repo"
+    return
+  fi
+
+  echo "ory/lumen"
+}
+
 # Platform detection
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -29,7 +82,7 @@ done
 if [ -z "$BINARY" ]; then
   BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
 
-  REPO="ory/lumen"
+  REPO="$(resolve_release_repo)"
 
   # Always use the version pinned in the manifest — keeps plugin and binary in sync
   MANIFEST="${PLUGIN_ROOT}/.release-please-manifest.json"
@@ -80,4 +133,5 @@ if [ -z "$BINARY" ]; then
   echo "Installed lumen to ${BINARY}" >&2
 fi
 
+export LUMEN_PLUGIN_ROOT="${PLUGIN_ROOT}"
 exec "$BINARY" "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -35,6 +35,7 @@ valid_release_repo() {
   name="${repo#*/}"
   [[ "$owner" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
   [[ "$owner" != *--* ]] || return 1
+  [[ "$name" != *.git ]] || return 1
   [[ "$name" =~ ^[A-Za-z0-9_.-]+$ ]]
 }
 

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -129,6 +129,7 @@ valid_release_repo() {
   name="${repo#*/}"
   [[ "$owner" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
   [[ "$owner" != *--* ]] || return 1
+  [[ "$name" != *.git ]] || return 1
   [[ "$name" =~ ^[A-Za-z0-9_.-]+$ ]]
 }
 
@@ -152,6 +153,8 @@ assert_eq "ignore GitHub origin with invalid repo characters" "" \
   "$(release_repo_from_remote_url "https://github.com/def324/lumen?download=1")"
 assert_eq "reject release repo with no slash" "reject" \
   "$(valid_release_repo "ory" && echo accept || echo reject)"
+assert_eq "reject release repo with .git suffix" "reject" \
+  "$(valid_release_repo "def324/lumen.git" && echo accept || echo reject)"
 assert_eq "ignore GitHub origin with invalid owner underscore" "" \
   "$(release_repo_from_remote_url "https://github.com/def_324/lumen.git")"
 assert_eq "ignore GitHub origin with owner leading hyphen" "" \

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -98,6 +98,72 @@ assert_eq "Windows amd64 URL" \
   "$(download_url "$REPO" "$VERSION" "windows" "amd64")"
 
 echo ""
+echo "=== release repository resolution tests ==="
+
+release_repo_from_remote_url() {
+  local url="$1" repo
+  case "$url" in
+    https://github.com/*/*.git) repo="${url#https://github.com/}"; repo="${repo%.git}" ;;
+    https://github.com/*/*) repo="${url#https://github.com/}" ;;
+    git@github.com:*/*.git) repo="${url#git@github.com:}"; repo="${repo%.git}" ;;
+    git@github.com:*/*) repo="${url#git@github.com:}" ;;
+    ssh://git@github.com/*/*.git) repo="${url#ssh://git@github.com/}"; repo="${repo%.git}" ;;
+    ssh://git@github.com/*/*) repo="${url#ssh://git@github.com/}" ;;
+    *) repo="" ;;
+  esac
+  if valid_release_repo "$repo"; then
+    echo "$repo"
+  else
+    echo ""
+  fi
+}
+
+valid_release_repo() {
+  local repo="$1" owner name
+  case "$repo" in
+    */*/* | /* | */) return 1 ;;
+    */*) ;;
+    *) return 1 ;;
+  esac
+  owner="${repo%%/*}"
+  name="${repo#*/}"
+  [[ "$owner" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] || return 1
+  [[ "$owner" != *--* ]] || return 1
+  [[ "$name" =~ ^[A-Za-z0-9_.-]+$ ]]
+}
+
+assert_eq "parse HTTPS origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen.git")"
+assert_eq "parse HTTPS origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen")"
+assert_eq "parse SSH origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "git@github.com:def324/lumen.git")"
+assert_eq "parse ssh:// origin with .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "ssh://git@github.com/def324/lumen.git")"
+assert_eq "parse SSH origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "git@github.com:def324/lumen")"
+assert_eq "parse ssh:// origin without .git" "def324/lumen" \
+  "$(release_repo_from_remote_url "ssh://git@github.com/def324/lumen")"
+assert_eq "ignore non-GitHub origin" "" \
+  "$(release_repo_from_remote_url "git@example.com:def324/lumen.git")"
+assert_eq "ignore GitHub origin with extra path" "" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen/archive/main.tar.gz")"
+assert_eq "ignore GitHub origin with invalid repo characters" "" \
+  "$(release_repo_from_remote_url "https://github.com/def324/lumen?download=1")"
+assert_eq "reject release repo with no slash" "reject" \
+  "$(valid_release_repo "ory" && echo accept || echo reject)"
+assert_eq "ignore GitHub origin with invalid owner underscore" "" \
+  "$(release_repo_from_remote_url "https://github.com/def_324/lumen.git")"
+assert_eq "ignore GitHub origin with owner leading hyphen" "" \
+  "$(release_repo_from_remote_url "https://github.com/-def324/lumen.git")"
+assert_eq "ignore GitHub origin with owner trailing hyphen" "" \
+  "$(release_repo_from_remote_url "https://github.com/def324-/lumen.git")"
+assert_eq "ignore GitHub origin with owner double hyphen" "" \
+  "$(release_repo_from_remote_url "https://github.com/de--f324/lumen.git")"
+assert_eq "ignore GitHub origin with owner over 39 characters" "" \
+  "$(release_repo_from_remote_url "https://github.com/abcdefghijklmnopqrstuvwxyzabcdefghijklmn/lumen.git")"
+
+echo ""
 echo "=== arch normalisation tests ==="
 assert_eq "x86_64 → amd64"  "amd64" "$(normalise_arch "x86_64")"
 assert_eq "aarch64 → arm64" "arm64" "$(normalise_arch "aarch64")"
@@ -165,6 +231,7 @@ echo "=== stdio download-on-first-run integration test ==="
   _SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
+  _URL_LOG="${_TMPROOT}/curl-urls.txt"
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
 
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -181,6 +248,7 @@ echo "=== stdio download-on-first-run integration test ==="
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) mkdir -p "$(dirname "$2")"; printf '#!/usr/bin/env bash\nexit 0\n' > "$2"; chmod +x "$2"; shift 2 ;;
+    https://*) printf '%s\n' "$1" >> "$LUMEN_CURL_URL_LOG"; shift ;;
     *)  shift ;;
   esac
 done
@@ -189,7 +257,10 @@ FAKECURL
   chmod +x "${_FAKE_CURL_DIR}/curl"
 
   EXIT_CODE=0
-  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" PATH="${_FAKE_CURL_DIR}:${PATH}" \
+  CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
+    LUMEN_RELEASE_REPO="def324/lumen" \
+    LUMEN_CURL_URL_LOG="${_URL_LOG}" \
+    PATH="${_FAKE_CURL_DIR}:${PATH}" \
     bash "${_SCRIPT_DIR}/run.sh" stdio >/dev/null 2>&1 || EXIT_CODE=$?
 
   if [ "$EXIT_CODE" -ne 0 ]; then
@@ -198,6 +269,12 @@ FAKECURL
   fi
   if [ ! -x "$_EXPECTED_BINARY" ]; then
     echo "  FAIL: run.sh stdio should have downloaded binary to ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  if ! grep -q "https://github.com/def324/lumen/releases/download/v0.0.1/" "${_URL_LOG}"; then
+    echo "  FAIL: run.sh stdio should use LUMEN_RELEASE_REPO for download URL"
+    echo "        URLs:"
+    sed 's/^/          /' "${_URL_LOG}"
     exit 1
   fi
   echo "  PASS: run.sh stdio downloads binary and execs it on first install"
@@ -301,6 +378,7 @@ echo "=== stdio first-install MCP handshake test ==="
   _TMPROOT="$(mktemp -d)"
   _FAKE_CURL_DIR="$(mktemp -d)"
   _MOCK_BIN_DIR="$(mktemp -d)"
+  _URL_LOG="${_TMPROOT}/curl-urls.txt"
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR" "$_MOCK_BIN_DIR"' EXIT
 
   _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -321,6 +399,8 @@ echo "=== stdio first-install MCP handshake test ==="
 
   printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
   mkdir -p "${_TMPROOT}/bin"
+  git -C "${_TMPROOT}" init -q
+  git -C "${_TMPROOT}" remote add origin git@github.com:def324/lumen.git
 
   # Stub curl: parse -o <target> and copy the prebuilt mock into place.
   cat > "${_FAKE_CURL_DIR}/curl" <<'FAKECURL'
@@ -328,6 +408,7 @@ echo "=== stdio first-install MCP handshake test ==="
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) mkdir -p "$(dirname "$2")"; cp "$LUMEN_MOCK_BINARY" "$2"; chmod +x "$2"; shift 2 ;;
+    https://*) printf '%s\n' "$1" >> "$LUMEN_CURL_URL_LOG"; shift ;;
     *)  shift ;;
   esac
 done
@@ -343,6 +424,7 @@ FAKECURL
   printf '%s\n' "$_INIT_REQ" | \
     CLAUDE_PLUGIN_ROOT="${_TMPROOT}" \
     PATH="${_FAKE_CURL_DIR}:${PATH}" \
+    LUMEN_CURL_URL_LOG="${_URL_LOG}" \
     LUMEN_MOCK_BINARY="${_MOCK_BIN}" \
     bash "${_SCRIPT_DIR}/run.sh" stdio >"${_STDOUT}" 2>"${_STDERR}" \
     || EXIT_CODE=$?
@@ -355,6 +437,12 @@ FAKECURL
   fi
   if [ ! -x "$_EXPECTED_BINARY" ]; then
     echo "  FAIL: run.sh stdio did not place artefact at ${_EXPECTED_BINARY}"
+    exit 1
+  fi
+  if ! grep -q "https://github.com/def324/lumen/releases/download/v0.0.1/" "${_URL_LOG}"; then
+    echo "  FAIL: run.sh stdio should derive release repo from plugin root origin"
+    echo "        URLs:"
+    sed 's/^/          /' "${_URL_LOG}"
     exit 1
   fi
   if ! grep -q '"jsonrpc":"2.0"' "${_STDOUT}"; then

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -28,7 +28,6 @@ $proc     = $null
 
 try {
     $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'amd64' }
-    $expectedBinary = Join-Path $TmpRoot "bin\lumen-windows-$arch.exe"
 
     # Build the mock MCP server — pure Go, no CGO.
     $mockBin = Join-Path $MockBinDir 'mock_lumen.exe'
@@ -59,6 +58,7 @@ try {
         $curlStub = @'
 @echo off
 setlocal enabledelayedexpansion
+echo %*>>"%LUMEN_CURL_ARGS_LOG%"
 :loop
 if "%~1"=="" goto done
 if "%~1"=="-o" (
@@ -74,64 +74,141 @@ exit /b 0
 '@
         [IO.File]::WriteAllText((Join-Path $FakeCurlDir 'curl.bat'), $curlStub, [Text.Encoding]::ASCII)
 
-        # Launch run.bat via System.Diagnostics.Process for reliable exit-code
-        # propagation and explicit stdin/stdout/stderr wiring. Start-Process
-        # with -RedirectStandardInput is unreliable here.
-        $runBat  = Join-Path $ScriptDir 'run.bat'
-        $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+        function Invoke-RunBatScenario {
+            param(
+                [string] $Name,
+                [string] $ExpectedRepo,
+                [string] $PassMessage,
+                [string] $ReleaseRepoOverride = '',
+                [string] $OriginUrl = ''
+            )
 
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = 'cmd.exe'
-        $psi.Arguments = "/c `"$runBat`" stdio"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput  = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError  = $true
-        $psi.CreateNoWindow = $true
-        $psi.WorkingDirectory = $RepoRoot
-        $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $TmpRoot
-        $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
-        $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
+            $pluginRoot = (New-Item -ItemType Directory -Path (Join-Path $TmpRoot $Name)).FullName
+            $curlArgsLog = Join-Path $pluginRoot 'curl-args.txt'
+            $expectedBinary = Join-Path $pluginRoot "bin\lumen-windows-$arch.exe"
 
-        $proc = [System.Diagnostics.Process]::Start($psi)
+            # Minimal plugin root: manifest only.
+            $manifest = '{' + "`n" + '  ".": "0.0.1"' + "`n" + '}' + "`n"
+            [IO.File]::WriteAllText((Join-Path $pluginRoot '.release-please-manifest.json'), $manifest, [Text.Encoding]::ASCII)
+            New-Item -ItemType Directory -Path (Join-Path $pluginRoot 'bin') | Out-Null
 
-        # If run.bat fast-exits in stdio mode, its stdin pipe is already
-        # closed by the time we try to write — that IS the #125 symptom,
-        # so swallow the broken-pipe exception and let the exit-code check
-        # below produce the real diagnostic.
-        try { $proc.StandardInput.WriteLine($initReq) } catch { }
-        try { $proc.StandardInput.Close() } catch { }
+            if ($OriginUrl) {
+                $gitOutput = & git -C $pluginRoot init 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Fail "could not initialise plugin root git repo for $Name"
+                    $gitOutput | ForEach-Object { Write-Host "          $_" }
+                    return
+                }
 
-        $stdout = $proc.StandardOutput.ReadToEnd()
-        $stderr = $proc.StandardError.ReadToEnd()
-        if (-not $proc.WaitForExit(60000)) {
-            $proc.Kill()
-            Fail "run.bat stdio did not exit within 60s"
-        } else {
-            $exitCode = $proc.ExitCode
-
-            Write-Host "    launcher exit code: $exitCode"
-            if ($stderr) {
-                Write-Host "    launcher stderr:"
-                ($stderr -split "`r?`n") | ForEach-Object { if ($_) { Write-Host "      $_" } }
+                $gitOutput = & git -C $pluginRoot remote add origin $OriginUrl 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Fail "could not add origin remote for $Name"
+                    $gitOutput | ForEach-Object { Write-Host "          $_" }
+                    return
+                }
             }
 
-            if ($exitCode -ne 0) {
-                Fail "run.bat stdio exited $exitCode — MCP server would be dead for the session"
-            } elseif (-not (Test-Path $expectedBinary)) {
-                Fail "run.bat stdio did not place artefact at $expectedBinary"
-            } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
-                Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout"
-                Write-Host "        stdout:"
-                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
-            } elseif ($stdout -notmatch '"name":"mock-lumen"') {
-                Fail "MCP response did not come from the exec'd mock — run.bat may be swallowing stdout"
-                Write-Host "        stdout:"
-                ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+            # Launch run.bat via System.Diagnostics.Process for reliable exit-code
+            # propagation and explicit stdin/stdout/stderr wiring. Start-Process
+            # with -RedirectStandardInput is unreliable here.
+            $runBat  = Join-Path $ScriptDir 'run.bat'
+            $initReq = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"launcher-e2e","version":"1.0"}}}'
+
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = 'cmd.exe'
+            $psi.Arguments = "/c `"$runBat`" stdio"
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardInput  = $true
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError  = $true
+            $psi.CreateNoWindow = $true
+            $psi.WorkingDirectory = $RepoRoot
+            $psi.Environment['CLAUDE_PLUGIN_ROOT'] = $pluginRoot
+            $psi.Environment['LUMEN_MOCK_BINARY']  = $mockBin
+            $psi.Environment['LUMEN_CURL_ARGS_LOG'] = $curlArgsLog
+            $psi.Environment['PATH'] = "$FakeCurlDir;$origPath"
+            $psi.Environment.Remove('LUMEN_RELEASE_REPO') | Out-Null
+            if ($ReleaseRepoOverride) {
+                $psi.Environment['LUMEN_RELEASE_REPO'] = $ReleaseRepoOverride
+            }
+
+            $script:proc = [System.Diagnostics.Process]::Start($psi)
+
+            # If run.bat fast-exits in stdio mode, its stdin pipe is already
+            # closed by the time we try to write — that IS the #125 symptom,
+            # so swallow the broken-pipe exception and let the exit-code check
+            # below produce the real diagnostic.
+            try { $script:proc.StandardInput.WriteLine($initReq) } catch { }
+            try { $script:proc.StandardInput.Close() } catch { }
+
+            $stdout = $script:proc.StandardOutput.ReadToEnd()
+            $stderr = $script:proc.StandardError.ReadToEnd()
+            if (-not $script:proc.WaitForExit(60000)) {
+                $script:proc.Kill()
+                Fail "run.bat stdio did not exit within 60s for $Name"
             } else {
-                Pass "run.bat stdio downloads, execs, and brokers MCP initialize on first install"
+                $exitCode = $script:proc.ExitCode
+
+                Write-Host "    launcher exit code ($Name): $exitCode"
+                if ($stderr) {
+                    Write-Host "    launcher stderr ($Name):"
+                    ($stderr -split "`r?`n") | ForEach-Object { if ($_) { Write-Host "      $_" } }
+                }
+
+                $expectedUrl = [regex]::Escape("https://github.com/$ExpectedRepo/releases/download/")
+                if ($exitCode -ne 0) {
+                    Fail "run.bat stdio exited $exitCode for $Name - MCP server would be dead for the session"
+                } elseif (-not (Test-Path $expectedBinary)) {
+                    Fail "run.bat stdio did not place artefact at $expectedBinary"
+                } elseif (-not (Test-Path $curlArgsLog)) {
+                    Fail "fake curl did not capture launcher download arguments for $Name"
+                } elseif ((Get-Content -Raw $curlArgsLog) -notmatch $expectedUrl) {
+                    Fail "run.bat stdio should use $ExpectedRepo for download URL in $Name"
+                    Write-Host "        curl args:"
+                    (Get-Content $curlArgsLog) | ForEach-Object { Write-Host "          $_" }
+                } elseif ($stdout -notmatch '"jsonrpc":"2\.0"') {
+                    Fail "MCP initialize produced no JSON-RPC 2.0 response on stdout for $Name"
+                    Write-Host "        stdout:"
+                    ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+                } elseif ($stdout -notmatch '"name":"mock-lumen"') {
+                    Fail "MCP response did not come from the exec'd mock for $Name - run.bat may be swallowing stdout"
+                    Write-Host "        stdout:"
+                    ($stdout -split "`r?`n") | ForEach-Object { Write-Host "          $_" }
+                } else {
+                    Pass $PassMessage
+                }
             }
         }
+
+        Invoke-RunBatScenario `
+            -Name 'env-override' `
+            -ExpectedRepo 'def324/lumen' `
+            -ReleaseRepoOverride 'def324/lumen' `
+            -PassMessage 'run.bat stdio uses LUMEN_RELEASE_REPO for first-install download'
+
+        Invoke-RunBatScenario `
+            -Name 'origin-remote' `
+            -ExpectedRepo 'def324/lumen' `
+            -OriginUrl 'https://github.com/def324/lumen.git' `
+            -PassMessage 'run.bat stdio derives first-install download repo from git origin'
+
+        Invoke-RunBatScenario `
+            -Name 'invalid-origin-fallback' `
+            -ExpectedRepo 'ory/lumen' `
+            -OriginUrl 'https://github.com/def324/lumen/archive/main.tar.gz' `
+            -PassMessage 'run.bat stdio ignores invalid GitHub origin shapes'
+
+        Invoke-RunBatScenario `
+            -Name 'invalid-owner-fallback' `
+            -ExpectedRepo 'ory/lumen' `
+            -OriginUrl 'https://github.com/def_324/lumen.git' `
+            -PassMessage 'run.bat stdio ignores invalid GitHub origin owners'
+
+        Invoke-RunBatScenario `
+            -Name 'long-owner-fallback' `
+            -ExpectedRepo 'ory/lumen' `
+            -OriginUrl 'https://github.com/abcdefghijklmnopqrstuvwxyzabcdefghijklmn/lumen.git' `
+            -PassMessage 'run.bat stdio ignores GitHub origin owners over 39 characters'
     }
 } finally {
     $env:PATH = $origPath

--- a/scripts/test_run_windows.ps1
+++ b/scripts/test_run_windows.ps1
@@ -193,6 +193,12 @@ exit /b 0
             -PassMessage 'run.bat stdio derives first-install download repo from git origin'
 
         Invoke-RunBatScenario `
+            -Name 'ssh-origin-remote' `
+            -ExpectedRepo 'def324/lumen' `
+            -OriginUrl 'git@github.com:def324/lumen.git' `
+            -PassMessage 'run.bat stdio derives first-install download repo from SSH origin'
+
+        Invoke-RunBatScenario `
             -Name 'invalid-origin-fallback' `
             -ExpectedRepo 'ory/lumen' `
             -OriginUrl 'https://github.com/def324/lumen/archive/main.tar.gz' `


### PR DESCRIPTION
## Summary

Make Lumen launcher release downloads work from fork checkouts and keep fork workflow runs away from upstream-only publishing paths.

- Resolve release artifacts from LUMEN_RELEASE_REPO, then a valid GitHub origin remote, then ory/lumen.
- Validate owner/repo values before constructing GitHub release URLs.
- Remove hardcoded GoReleaser release repository metadata so release artifacts attach to the repository running the workflow.
- Gate Coveralls and release publishing paths to avoid requiring upstream-only credentials from fork contexts.
- Add Unix and Windows launcher coverage for fork-derived release URLs and invalid-origin fallback behavior.

## Test Plan

- bash scripts/test_run.sh
- bash scripts/test_run_cmd.sh
- actionlint -shellcheck=
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security with repository guards to prevent unauthorized workflow execution.
  * Improved release process with validation checks and atomic binary downloads.
  * Added support for custom release repositories via `LUMEN_RELEASE_REPO` environment variable; scripts now automatically derive release location from local Git configuration with fallback to default.
  * Expanded test coverage for release repository resolution across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->