### PR TITLE
feat(codex): install session-start hook

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,7 +1,7 @@
 # Installing Lumen for Codex
 
 Enable Lumen in Codex with native skill discovery plus a registered MCP
-server.
+server and Codex startup hooks.
 
 ## Prerequisites
 
@@ -16,56 +16,77 @@ server.
    git clone https://github.com/ory/lumen.git "$CODEX_HOME/lumen"
    ```
 
-2. Create the skills symlink:
+2. Run the Codex installer:
    ```bash
-   mkdir -p "$HOME/.agents/skills"
-   ln -s "$CODEX_HOME/lumen/skills" "$HOME/.agents/skills/lumen"
+   "$CODEX_HOME/lumen/scripts/run" codex install
    ```
 
-3. Register the MCP server:
-   ```bash
-   codex mcp add lumen -- "$CODEX_HOME/lumen/scripts/run" stdio
-   ```
+3. Restart Codex.
 
-4. Restart Codex.
+The installer enables Codex hooks in `config.toml`, registers the `lumen` MCP
+server, links or copies the shared Lumen skills into Codex's user skill
+directory, and installs a user-level Codex `SessionStart` hook. That hook runs
+on startup, resume, and clear events and reuses Lumen's background indexer to
+proactively warm the project index.
 
 ## Windows (PowerShell)
 
 ```powershell
 $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE ".codex" }
 git clone https://github.com/ory/lumen.git "$codexHome\lumen"
-New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills" | Out-Null
-cmd /c mklink /J "$env:USERPROFILE\.agents\skills\lumen" "$codexHome\lumen\skills"
-codex mcp add lumen -- "$codexHome\lumen\scripts\run.cmd" stdio
+cmd /c "$codexHome\lumen\scripts\run.cmd" codex install
 ```
+
+Restart Codex after the installer completes.
 
 ## Migrating from the old repo-local plugin
 
 If you previously used the repo-local Codex marketplace package:
 
 1. Remove the old plugin from Codex's plugin UI.
-2. Register the MCP server with `codex mcp add` as above.
-3. Create the `~/.agents/skills/lumen` symlink.
-4. Restart Codex.
+2. Run `"$CODEX_HOME/lumen/scripts/run" codex install`.
+3. Restart Codex.
+
+If you previously hand-edited Codex MCP or hook configuration, remove stale
+manual entries after confirming the installer-managed configuration works. The
+installer owns the user-level Codex MCP registration, skill link or copy, and
+`hooks.json` `SessionStart` entry for Lumen.
 
 ## Verify
 
 ```bash
+"${CODEX_HOME:-$HOME/.codex}/lumen/scripts/run" codex doctor
 codex mcp get lumen
-ls -la "$HOME/.agents/skills/lumen"
 ```
 
 ## Updating
 
 ```bash
 cd "${CODEX_HOME:-$HOME/.codex}/lumen" && git pull
+"${CODEX_HOME:-$HOME/.codex}/lumen/scripts/run" codex install
 ```
 
 ## Uninstalling
 
 ```bash
 codex mcp remove lumen
-rm "$HOME/.agents/skills/lumen"
+skills="$HOME/.agents/skills/lumen"
+if [ -L "$skills" ]; then
+  target="$(readlink "$skills")"
+  case "$target" in
+    */lumen/skills) rm "$skills" ;;
+    *) echo "Refusing to remove non-Lumen skills link: $skills -> $target" >&2 ;;
+  esac
+elif [ -f "$skills/.lumen-skills-source" ]; then
+  rm -rf "$skills"
+else
+  echo "No installer-managed Lumen skills path found at $skills" >&2
+fi
 ```
 
-Optionally delete the clone: `rm -rf "${CODEX_HOME:-$HOME/.codex}/lumen"`.
+Remove the Lumen `SessionStart` group from
+`${CODEX_HOME:-$HOME/.codex}/hooks.json` if you want to remove the startup hook
+as well. If you no longer use any Codex hooks, you can also remove
+`hooks = true` from the `[features]` table in
+`${CODEX_HOME:-$HOME/.codex}/config.toml`. Optionally delete the clone:
+`rm -rf "${CODEX_HOME:-$HOME/.codex}/lumen"`.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ _Claude Code asking about the
    [OpenCode](https://opencode.ai/)
 
 **Note:** Installation differs by platform. Claude Code is installed from a
-plugin marketplace. Codex uses a local MCP server plus native skill discovery.
-OpenCode installs from npm. Cursor packaging is shipped in this repository and
-is ready for Cursor's plugin distribution workflow.
+plugin marketplace. Codex uses an installer that configures MCP, shared skills,
+and a user-level startup hook. OpenCode installs from npm. Cursor packaging is
+shipped in this repository and is ready for Cursor's plugin distribution
+workflow.
 
 **Install:**
 
@@ -113,29 +114,20 @@ skill or the Lumen `semantic_search` tool.
 
 **Codex**
 
-Quick install:
+Follow the Codex install guide:
 
-```text
-Fetch and follow instructions from https://raw.githubusercontent.com/ory/lumen/refs/heads/main/.codex/INSTALL.md
-```
+[.codex/INSTALL.md](.codex/INSTALL.md)
 
-Manual install:
-
-```bash
-CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
-git clone https://github.com/ory/lumen.git "$CODEX_HOME/lumen"
-mkdir -p "$HOME/.agents/skills"
-ln -s "$CODEX_HOME/lumen/skills" "$HOME/.agents/skills/lumen"
-codex mcp add lumen -- "$CODEX_HOME/lumen/scripts/run" stdio
-```
-
-Detailed docs: [.codex/INSTALL.md](.codex/INSTALL.md)
+The installer enables Codex hooks, registers the Lumen MCP server, links or
+copies the shared Lumen skills, and installs a user-level Codex `SessionStart`
+hook. The hook runs on startup, resume, and clear events and reuses Lumen's
+background indexer for proactive project index warmup.
 
 Verify with:
 
 ```bash
+"${CODEX_HOME:-$HOME/.codex}/lumen/scripts/run" codex doctor
 codex mcp get lumen
-ls -la "$HOME/.agents/skills/lumen"
 ```
 
 **OpenCode**
@@ -161,7 +153,8 @@ opencode mcp list
 - **Claude Code** - update through Claude's plugin marketplace
 - **Cursor** - refresh or reinstall the bundled plugin through Cursor after
   updating this repository or the published package
-- **Codex** - `cd "${CODEX_HOME:-$HOME/.codex}/lumen" && git pull`
+- **Codex** - `cd "${CODEX_HOME:-$HOME/.codex}/lumen" && git pull`, then
+  rerun `./scripts/run codex install`
 - **OpenCode** - update the version pin in `opencode.json` (e.g.
   `@ory/lumen-opencode@0.0.29`) and restart OpenCode
 
@@ -172,8 +165,9 @@ On first Claude Code or Cursor session start, Lumen:
 2. Indexes your project in the background using Merkle tree change detection
 3. Registers a `semantic_search` MCP tool that the host can use automatically
 
-In Codex and OpenCode, the same binary download and index seeding happen on the
-first `semantic_search` call.
+In Codex, the installed `SessionStart` hook warms the index on startup, resume,
+and clear events. In OpenCode, index seeding happens on the first
+`semantic_search` call.
 
 Two shared skills are also available: `doctor` (health check) and `reindex`
 (forced re-indexing). Claude exposes them as `/lumen:doctor` and

--- a/cmd/codex.go
+++ b/cmd/codex.go
@@ -1,0 +1,648 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const codexSkillsSourceMarker = ".lumen-skills-source"
+
+type codexPaths struct {
+	codexHome   string
+	pluginRoot  string
+	launcher    string
+	hookCommand string
+	hooksPath   string
+	configPath  string
+	skillsSrc   string
+	skillsDst   string
+}
+
+type commandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type realCommandRunner struct{}
+
+func (realCommandRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+func init() {
+	rootCmd.AddCommand(codexCmd)
+	codexCmd.AddCommand(codexInstallCmd)
+	codexCmd.AddCommand(codexDoctorCmd)
+}
+
+var codexCmd = &cobra.Command{
+	Use:   "codex",
+	Short: "Manage Codex integration",
+}
+
+var codexInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install or repair Codex MCP, skills, and hooks",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runCodexInstall(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), realCommandRunner{})
+	},
+}
+
+var codexDoctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Report Codex integration status",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runCodexDoctor(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), realCommandRunner{})
+	},
+}
+
+func resolveCodexPaths() (codexPaths, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return codexPaths{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+	codexHome := os.Getenv("CODEX_HOME")
+	if codexHome == "" {
+		codexHome = filepath.Join(home, ".codex")
+	}
+	pluginRoot, err := resolveLumenPluginRoot()
+	if err != nil {
+		return codexPaths{}, err
+	}
+	launcher := codexLauncherPath(pluginRoot)
+	return codexPaths{
+		codexHome:   codexHome,
+		pluginRoot:  pluginRoot,
+		launcher:    launcher,
+		hookCommand: codexSessionStartCommand(launcher),
+		hooksPath:   filepath.Join(codexHome, "hooks.json"),
+		configPath:  filepath.Join(codexHome, "config.toml"),
+		skillsSrc:   filepath.Join(pluginRoot, "skills"),
+		skillsDst:   filepath.Join(home, ".agents", "skills", "lumen"),
+	}, nil
+}
+
+func resolveLumenPluginRoot() (string, error) {
+	for _, name := range []string{"LUMEN_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT", "CURSOR_PLUGIN_ROOT"} {
+		if value := os.Getenv(name); value != "" {
+			return filepath.Abs(value)
+		}
+	}
+	if exe, err := os.Executable(); err == nil {
+		exeDir := filepath.Dir(exe)
+		if filepath.Base(exeDir) == "bin" {
+			root := filepath.Dir(exeDir)
+			if hasLumenLauncher(root) && fileExists(filepath.Join(root, "skills")) {
+				return root, nil
+			}
+		}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if hasLumenLauncher(cwd) && fileExists(filepath.Join(cwd, "skills")) {
+			return cwd, nil
+		}
+	}
+	return "", fmt.Errorf("could not resolve Lumen plugin root")
+}
+
+func hasLumenLauncher(root string) bool {
+	return fileExists(filepath.Join(root, "scripts", "run")) ||
+		fileExists(filepath.Join(root, "scripts", "run.cmd"))
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func installCodexHookFile(path, command string) (bool, error) {
+	var raw []byte
+	if existing, err := os.ReadFile(path); err == nil {
+		raw = existing
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("read hooks file: %w", err)
+	}
+
+	merged, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	targetPath := path
+	if linkTarget, err := os.Readlink(path); err == nil {
+		if filepath.IsAbs(linkTarget) {
+			targetPath = linkTarget
+		} else {
+			targetPath = filepath.Join(filepath.Dir(path), linkTarget)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return false, fmt.Errorf("create hooks directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(targetPath), ".hooks-*.json")
+	if err != nil {
+		return false, fmt.Errorf("create temp hooks file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(merged); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("write temp hooks file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("close temp hooks file: %w", err)
+	}
+	if err := os.Rename(tmpName, targetPath); err != nil {
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("replace hooks file: %w", err)
+	}
+	return true, nil
+}
+
+func ensureCodexHooksFeatureFlag(path string) (bool, error) {
+	var raw []byte
+	if existing, err := os.ReadFile(path); err == nil {
+		raw = existing
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("read Codex config: %w", err)
+	}
+
+	merged, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	return writeFilePreservingSymlink(path, merged, ".config-*.toml")
+}
+
+func codexHooksFeatureEnabled(path string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return codexHooksFeatureEnabledInConfig(raw)
+}
+
+func writeFilePreservingSymlink(path string, data []byte, pattern string) (bool, error) {
+	targetPath := path
+	if linkTarget, err := os.Readlink(path); err == nil {
+		if filepath.IsAbs(linkTarget) {
+			targetPath = linkTarget
+		} else {
+			targetPath = filepath.Join(filepath.Dir(path), linkTarget)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return false, fmt.Errorf("create config directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(targetPath), pattern)
+	if err != nil {
+		return false, fmt.Errorf("create temp config file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("write temp config file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("close temp config file: %w", err)
+	}
+	if err := os.Rename(tmpName, targetPath); err != nil {
+		_ = os.Remove(tmpName)
+		return false, fmt.Errorf("replace config file: %w", err)
+	}
+	return true, nil
+}
+
+func runCodexInstall(ctx context.Context, stdout, stderr io.Writer, runner commandRunner) error {
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		return err
+	}
+	featureChanged, err := ensureCodexHooksFeatureFlag(paths.configPath)
+	if err != nil {
+		return err
+	}
+	if featureChanged {
+		_, _ = fmt.Fprintf(stdout, "Enabled Codex hooks feature in %s\n", paths.configPath)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "Codex hooks feature already enabled in %s\n", paths.configPath)
+	}
+	changed, err := installCodexHookFile(paths.hooksPath, paths.hookCommand)
+	if err != nil {
+		return err
+	}
+	if changed {
+		_, _ = fmt.Fprintf(stdout, "Installed Codex SessionStart hook at %s\n", paths.hooksPath)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "Codex SessionStart hook already installed at %s\n", paths.hooksPath)
+	}
+	if err := ensureCodexSkills(paths, stderr); err != nil {
+		return err
+	}
+	if err := ensureCodexMCP(ctx, paths, runner, stdout, stderr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureCodexSkills(paths codexPaths, _ io.Writer) error {
+	if !fileExists(paths.skillsSrc) {
+		return fmt.Errorf("skills source missing: %s", paths.skillsSrc)
+	}
+	if info, err := os.Lstat(paths.skillsDst); err == nil {
+		if skillsPathMatches(paths.skillsDst, paths.skillsSrc, info) {
+			return nil
+		}
+		if err := removeExistingSkillsPath(paths.skillsDst, info); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.skillsDst), 0o755); err != nil {
+		return fmt.Errorf("create skills directory: %w", err)
+	}
+	if err := os.Symlink(paths.skillsSrc, paths.skillsDst); err != nil {
+		if copyErr := copyCodexSkills(paths.skillsSrc, paths.skillsDst); copyErr != nil {
+			return fmt.Errorf("create skills symlink: %w; copy fallback: %v", err, copyErr)
+		}
+	}
+	return nil
+}
+
+func ensureCodexMCP(ctx context.Context, paths codexPaths, runner commandRunner, stdout, _ io.Writer) error {
+	out, err := runner.Run(ctx, "codex", "mcp", "get", "lumen")
+	if err == nil && codexMCPOutputMatches(out, paths) {
+		_, _ = fmt.Fprintln(stdout, "Codex MCP server lumen already configured")
+		return nil
+	}
+	if err == nil {
+		if _, removeErr := runner.Run(ctx, "codex", "mcp", "remove", "lumen"); removeErr != nil {
+			return fmt.Errorf("remove mismatched Codex MCP server: %w", removeErr)
+		}
+		if _, addErr := runner.Run(ctx, "codex", "mcp", "add", "lumen", "--", paths.launcher, "stdio"); addErr != nil {
+			return fmt.Errorf("add Codex MCP server: %w", addErr)
+		}
+		_, _ = fmt.Fprintln(stdout, "Updated Codex MCP server lumen")
+		return nil
+	}
+	if _, addErr := runner.Run(ctx, "codex", "mcp", "add", "lumen", "--", paths.launcher, "stdio"); addErr != nil {
+		return fmt.Errorf("add Codex MCP server: %w", addErr)
+	}
+	_, _ = fmt.Fprintln(stdout, "Added Codex MCP server lumen")
+	return nil
+}
+
+func codexMCPOutputMatches(out []byte, paths codexPaths) bool {
+	command, args := parseCodexMCPOutput(out)
+	launcher := strings.ReplaceAll(paths.launcher, `\`, "/")
+	return command == launcher && len(args) == 1 && args[0] == "stdio"
+}
+
+func runCodexDoctor(ctx context.Context, stdout, _ io.Writer, runner commandRunner) error {
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(stdout, "Codex home: %s\n", paths.codexHome)
+	_, _ = fmt.Fprintf(stdout, "Lumen root: %s\n", paths.pluginRoot)
+
+	out, err := runner.Run(ctx, "codex", "mcp", "get", "lumen")
+	switch {
+	case err != nil && errors.Is(err, exec.ErrNotFound):
+		_, _ = fmt.Fprintln(stdout, "MCP lumen: unavailable: codex command not found")
+	case err != nil && codexMCPGetOutputReportsMissing(out):
+		_, _ = fmt.Fprintln(stdout, "MCP lumen: missing")
+	case err != nil:
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			_, _ = fmt.Fprintf(stdout, "MCP lumen: error: %v: %s\n", err, oneLine(trimmed))
+		} else {
+			_, _ = fmt.Fprintf(stdout, "MCP lumen: error: %v\n", err)
+		}
+	case codexMCPOutputMatches(out, paths):
+		_, _ = fmt.Fprintln(stdout, "MCP lumen: ok")
+	default:
+		_, _ = fmt.Fprintln(stdout, "MCP lumen: mismatch")
+	}
+
+	featureEnabled, featureErr := codexHooksFeatureEnabled(paths.configPath)
+	switch {
+	case featureErr != nil:
+		_, _ = fmt.Fprintf(stdout, "Codex hooks feature: error: %v\n", featureErr)
+	case featureEnabled:
+		_, _ = fmt.Fprintln(stdout, "Codex hooks feature: ok")
+	default:
+		_, _ = fmt.Fprintln(stdout, "Codex hooks feature: disabled")
+	}
+
+	hookStatus, hookErr := codexHookStatus(paths.hooksPath, paths.hookCommand)
+	switch {
+	case hookErr != nil:
+		_, _ = fmt.Fprintf(stdout, "SessionStart hook: error: %v\n", hookErr)
+	case hookStatus.exact == 1 && hookStatus.total == 1 && featureEnabled:
+		_, _ = fmt.Fprintln(stdout, "SessionStart hook: ok")
+	case hookStatus.exact == 1 && hookStatus.total == 1:
+		_, _ = fmt.Fprintln(stdout, "SessionStart hook: installed but disabled")
+	case hookStatus.total > 1:
+		_, _ = fmt.Fprintf(stdout, "SessionStart hook: duplicate (%d)\n", hookStatus.total)
+	case hookStatus.total == 1:
+		_, _ = fmt.Fprintln(stdout, "SessionStart hook: mismatch")
+	default:
+		_, _ = fmt.Fprintln(stdout, "SessionStart hook: missing")
+	}
+
+	if skillsLinkOK(paths) {
+		_, _ = fmt.Fprintln(stdout, "Skills: ok")
+	} else {
+		_, _ = fmt.Fprintln(stdout, "Skills: missing")
+	}
+	return nil
+}
+
+type codexHookStatusResult struct {
+	exact int
+	total int
+}
+
+func codexHookStatus(path, expectedCommand string) (codexHookStatusResult, error) {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return codexHookStatusResult{}, nil
+	}
+	if err != nil {
+		return codexHookStatusResult{}, err
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return codexHookStatusResult{}, err
+	}
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		if _, exists := doc["hooks"]; exists {
+			return codexHookStatusResult{}, fmt.Errorf("codex hooks document field %q must be an object", "hooks")
+		}
+		return codexHookStatusResult{}, nil
+	}
+	rawGroups, ok := hooks["SessionStart"].([]any)
+	if !ok {
+		if _, exists := hooks["SessionStart"]; exists {
+			return codexHookStatusResult{}, fmt.Errorf("codex hooks document field %q must be an array", "hooks.SessionStart")
+		}
+		return codexHookStatusResult{}, nil
+	}
+	status := codexHookStatusResult{}
+	for _, rawGroup := range rawGroups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok {
+			return codexHookStatusResult{}, fmt.Errorf("codex hooks document field %q must contain objects", "hooks.SessionStart")
+		}
+		groupStatus, err := countLumenCodexHooks(group, expectedCommand)
+		if err != nil {
+			return codexHookStatusResult{}, err
+		}
+		status.exact += groupStatus.exact
+		status.total += groupStatus.total
+	}
+	return status, nil
+}
+
+func countLumenCodexHooks(group map[string]any, expectedCommand string) (codexHookStatusResult, error) {
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return codexHookStatusResult{}, fmt.Errorf("codex hooks document field %q must contain hook arrays", "hooks.SessionStart")
+	}
+	status := codexHookStatusResult{}
+	for _, rawHook := range hooks {
+		hook, ok := rawHook.(map[string]any)
+		if !ok {
+			return codexHookStatusResult{}, fmt.Errorf("codex hooks document field %q must contain hook objects", "hooks.SessionStart.hooks")
+		}
+		command, _ := hook["command"].(string)
+		if command != "" && isOwnedLumenCodexSessionStartCommand(command, hook, expectedCommand) {
+			status.total++
+			if expectedCommand != "" && command == expectedCommand {
+				status.exact++
+			}
+		}
+	}
+	return status, nil
+}
+
+func codexMCPGetOutputReportsMissing(out []byte) bool {
+	lower := strings.ToLower(string(out))
+	return strings.Contains(lower, "no mcp server named")
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func skillsLinkOK(paths codexPaths) bool {
+	info, err := os.Lstat(paths.skillsDst)
+	if err != nil {
+		return false
+	}
+	return skillsPathMatches(paths.skillsDst, paths.skillsSrc, info)
+}
+
+func skillsPathMatches(path, want string, info os.FileInfo) bool {
+	if info.Mode()&os.ModeSymlink == 0 {
+		return sameFileTree(path, want) || copiedSkillsMarkerMatches(path, want)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	return target == want || sameFileTree(resolveRelativeLink(path, target), want)
+}
+
+func resolveRelativeLink(path, target string) string {
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(path), target))
+}
+
+func sameFileTree(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	realA, errA := filepath.EvalSymlinks(absA)
+	realB, errB := filepath.EvalSymlinks(absB)
+	if errA != nil || errB != nil {
+		return absA == absB
+	}
+	return realA == realB
+}
+
+func removeExistingSkillsPath(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return fmt.Errorf("read existing skills link: %w", err)
+		}
+		targetPath := resolveRelativeLink(path, target)
+		if !lumenSkillsDirLooksOwned(targetPath) && !danglingLumenSkillsLinkTarget(targetPath) {
+			return fmt.Errorf("%s exists and is not an installer-managed Lumen skills link", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove stale skills link: %w", err)
+		}
+		return nil
+	}
+
+	if info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+		if copiedSkillsMarkerPresent(path) {
+			return os.RemoveAll(path)
+		}
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return fmt.Errorf("read existing skills directory: %w", err)
+		}
+		if len(entries) != 0 {
+			return fmt.Errorf("%s exists and is not the Lumen skills directory", path)
+		}
+		return os.Remove(path)
+	}
+	return fmt.Errorf("%s exists and is not an installer-managed Lumen skills path", path)
+}
+
+func danglingLumenSkillsLinkTarget(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return false
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	cleaned := filepath.Clean(path)
+	return filepath.Base(cleaned) == "skills" && filepath.Base(filepath.Dir(cleaned)) == "lumen"
+}
+
+func copyCodexSkills(src, dst string) error {
+	if err := filepath.WalkDir(src, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if rel == codexSkillsSourceMarker {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	}); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dst, codexSkillsSourceMarker), []byte(src+"\n"), 0o644)
+}
+
+func copiedSkillsMarkerMatches(path, want string) bool {
+	raw, err := os.ReadFile(filepath.Join(path, codexSkillsSourceMarker))
+	return err == nil &&
+		strings.TrimSpace(string(raw)) == want &&
+		lumenSkillsDirLooksOwned(path)
+}
+
+func copiedSkillsMarkerPresent(path string) bool {
+	raw, err := os.ReadFile(filepath.Join(path, codexSkillsSourceMarker))
+	return err == nil && strings.TrimSpace(string(raw)) != "" && lumenSkillsDirLooksOwned(path)
+}
+
+func lumenSkillsDirLooksOwned(path string) bool {
+	return fileContains(filepath.Join(path, "doctor", "SKILL.md"), "# Lumen Doctor") &&
+		fileContains(filepath.Join(path, "reindex", "SKILL.md"), "# Lumen Reindex")
+}
+
+func fileContains(path, want string) bool {
+	raw, err := os.ReadFile(path)
+	return err == nil && strings.Contains(string(raw), want)
+}
+
+func parseCodexMCPOutput(out []byte) (string, []string) {
+	var parsed struct {
+		Command string   `json:"command"`
+		Args    []string `json:"args"`
+	}
+	if err := json.Unmarshal(out, &parsed); err == nil && parsed.Command != "" {
+		return strings.ReplaceAll(parsed.Command, `\`, "/"), parsed.Args
+	}
+
+	var command string
+	var args []string
+	for _, line := range strings.Split(string(out), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "command":
+			command = strings.ReplaceAll(strings.Trim(strings.TrimSpace(value), `"`), `\`, "/")
+		case "args":
+			args = parseCodexMCPArgs(strings.TrimSpace(value))
+		}
+	}
+	return command, args
+}
+
+func parseCodexMCPArgs(value string) []string {
+	if value == "" {
+		return nil
+	}
+	var parsed []string
+	if strings.HasPrefix(value, "[") && json.Unmarshal([]byte(value), &parsed) == nil {
+		return parsed
+	}
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}

--- a/cmd/codex_hooks.go
+++ b/cmd/codex_hooks.go
@@ -1,0 +1,418 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const codexSessionStartMatcher = "startup|resume|clear"
+const codexHookStatusMessage = "Starting Lumen background indexing"
+const codexHooksFeatureKey = "hooks"
+const deprecatedCodexHooksFeatureKey = "codex_hooks"
+
+func codexLauncherPath(pluginRoot string) string {
+	return codexLauncherPathForGOOS(pluginRoot, runtime.GOOS)
+}
+
+func codexLauncherPathForGOOS(pluginRoot, goos string) string {
+	if goos == "windows" {
+		return strings.TrimRight(pluginRoot, `\/`) + `\scripts\run.cmd`
+	}
+	return filepath.Join(pluginRoot, "scripts", "run")
+}
+
+func codexSessionStartCommand(launcher string) string {
+	return shellQuoteCommandPath(launcher) + " hook session-start lumen --host codex"
+}
+
+func mergeCodexSessionStartHook(raw []byte, command string) ([]byte, bool, error) {
+	doc := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, false, err
+		}
+		if doc == nil {
+			return nil, false, fmt.Errorf("codex hooks document must be an object")
+		}
+	}
+
+	hooks := map[string]any{}
+	if rawHooks, ok := doc["hooks"]; ok {
+		var hooksOK bool
+		hooks, hooksOK = rawHooks.(map[string]any)
+		if !hooksOK {
+			return nil, false, fmt.Errorf("codex hooks document field %q must be an object", "hooks")
+		}
+	}
+
+	sessionStart := []any{}
+	if rawSessionStart, ok := hooks["SessionStart"]; ok {
+		groups, groupsOK := rawSessionStart.([]any)
+		if !groupsOK {
+			return nil, false, fmt.Errorf("codex hooks document field %q must be an array", "hooks.SessionStart")
+		}
+		for _, rawGroup := range groups {
+			group, ok := rawGroup.(map[string]any)
+			if !ok {
+				return nil, false, fmt.Errorf("codex hooks document field %q must contain objects", "hooks.SessionStart")
+			}
+			preservedGroup, keep, err := removeLumenCodexHooksFromGroup(group, command)
+			if err != nil {
+				return nil, false, err
+			}
+			if !keep {
+				continue
+			}
+			sessionStart = append(sessionStart, preservedGroup)
+		}
+	}
+
+	hooks["SessionStart"] = append(sessionStart, map[string]any{
+		"matcher": codexSessionStartMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       command,
+				"statusMessage": codexHookStatusMessage,
+			},
+		},
+	})
+	doc["hooks"] = hooks
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, false, err
+	}
+	out = append(out, '\n')
+	return out, !bytes.Equal(bytes.TrimSpace(raw), bytes.TrimSpace(out)), nil
+}
+
+func mergeCodexHooksFeatureFlag(raw []byte) ([]byte, bool, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return []byte("[features]\nhooks = true\n"), true, nil
+	}
+
+	text := string(raw)
+	lines := strings.Split(text, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	inFeatures := false
+	featuresLine := -1
+	hooksLine := -1
+	legacyLine := -1
+	for i, line := range lines {
+		if table, ok := codexConfigTableName(line); ok {
+			if inFeatures {
+				break
+			}
+			inFeatures = table == "features"
+			if inFeatures {
+				featuresLine = i
+			}
+			continue
+		}
+		if !inFeatures {
+			continue
+		}
+		key, value, ok := codexConfigKeyValue(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case codexHooksFeatureKey:
+			hooksLine = i
+			switch strings.ToLower(value) {
+			case "true":
+			case "false":
+				lines[i] = setCodexHooksFeatureLine(line)
+			default:
+				return nil, false, fmt.Errorf("codex config [features].hooks must be true or false")
+			}
+		case deprecatedCodexHooksFeatureKey:
+			if legacyLine < 0 {
+				legacyLine = i
+			}
+		}
+	}
+
+	switch {
+	case hooksLine >= 0:
+		lines = removeFeatureLines(lines, deprecatedCodexHooksFeatureKey, hooksLine)
+		return codexConfigOutput(raw, lines)
+	case legacyLine >= 0:
+		lines[legacyLine] = setCodexHooksFeatureLine(lines[legacyLine])
+		lines = removeFeatureLines(lines, deprecatedCodexHooksFeatureKey, legacyLine)
+		return codexConfigOutput(raw, lines)
+	case featuresLine >= 0:
+		lines = append(lines[:featuresLine+1], append([]string{"hooks = true"}, lines[featuresLine+1:]...)...)
+		return codexConfigOutput(raw, lines)
+	default:
+		trimmed := strings.TrimRight(text, "\n")
+		if strings.TrimSpace(trimmed) == "" {
+			return []byte("[features]\nhooks = true\n"), true, nil
+		}
+		return []byte(trimmed + "\n\n[features]\nhooks = true\n"), true, nil
+	}
+}
+
+func codexHooksFeatureEnabledInConfig(raw []byte) (bool, error) {
+	lines := strings.Split(string(raw), "\n")
+	inFeatures := false
+	for _, line := range lines {
+		if table, ok := codexConfigTableName(line); ok {
+			inFeatures = table == "features"
+			continue
+		}
+		if !inFeatures {
+			continue
+		}
+		if key, value, ok := codexConfigKeyValue(line); ok && key == codexHooksFeatureKey {
+			switch strings.ToLower(value) {
+			case "true":
+				return true, nil
+			case "false":
+				return false, nil
+			default:
+				return false, fmt.Errorf("codex config [features].hooks must be true or false")
+			}
+		}
+	}
+	return false, nil
+}
+
+func codexConfigTableName(line string) (string, bool) {
+	body, _ := splitTomlLineComment(line)
+	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") || strings.HasPrefix(trimmed, "[[") {
+		return "", false
+	}
+	name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	return name, name != ""
+}
+
+func codexConfigKeyValue(line string) (string, string, bool) {
+	body, _ := splitTomlLineComment(line)
+	key, value, ok := strings.Cut(body, "=")
+	if !ok {
+		return "", "", false
+	}
+	normalizedKey, ok := normalizeTomlKey(strings.TrimSpace(key))
+	if !ok {
+		return "", "", false
+	}
+	return normalizedKey, strings.TrimSpace(value), true
+}
+
+func normalizeTomlKey(key string) (string, bool) {
+	if key == codexHooksFeatureKey || key == deprecatedCodexHooksFeatureKey {
+		return key, true
+	}
+	if len(key) >= 2 && ((key[0] == '"' && key[len(key)-1] == '"') || (key[0] == '\'' && key[len(key)-1] == '\'')) {
+		unquoted := key[1 : len(key)-1]
+		if unquoted == codexHooksFeatureKey || unquoted == deprecatedCodexHooksFeatureKey {
+			return unquoted, true
+		}
+	}
+	return "", false
+}
+
+func setCodexHooksFeatureLine(line string) string {
+	_, comment := splitTomlLineComment(line)
+	indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+	if comment != "" {
+		return indent + "hooks = true " + strings.TrimSpace(comment)
+	}
+	return indent + "hooks = true"
+}
+
+func removeFeatureLines(lines []string, key string, keep int) []string {
+	out := lines[:0]
+	inFeatures := false
+	for i, line := range lines {
+		if table, ok := codexConfigTableName(line); ok {
+			inFeatures = table == "features"
+		}
+		if inFeatures && i != keep {
+			if lineKey, _, ok := codexConfigKeyValue(line); ok && lineKey == key {
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func codexConfigOutput(raw []byte, lines []string) ([]byte, bool, error) {
+	out := []byte(strings.Join(lines, "\n") + "\n")
+	return out, !bytes.Equal(bytes.TrimSpace(raw), bytes.TrimSpace(out)), nil
+}
+
+func splitTomlLineComment(line string) (string, string) {
+	inSingle := false
+	inDouble := false
+	escaped := false
+	for i, r := range line {
+		switch {
+		case escaped:
+			escaped = false
+		case inDouble && r == '\\':
+			escaped = true
+		case !inDouble && r == '\'':
+			inSingle = !inSingle
+		case !inSingle && r == '"':
+			inDouble = !inDouble
+		case !inSingle && !inDouble && r == '#':
+			return line[:i], line[i:]
+		}
+	}
+	return line, ""
+}
+
+func codexHookGroupRunsLumenSessionStart(group map[string]any) bool {
+	return codexHookGroupRunsLumenSessionStartCommand(group, "")
+}
+
+func codexHookGroupRunsLumenSessionStartCommand(group map[string]any, expectedCommand string) bool {
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawHook := range hooks {
+		hook, ok := rawHook.(map[string]any)
+		if !ok {
+			continue
+		}
+		command, ok := hook["command"].(string)
+		if !ok {
+			continue
+		}
+		if isOwnedLumenCodexSessionStartCommand(command, hook, expectedCommand) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeLumenCodexHooksFromGroup(group map[string]any, expectedCommand string) (map[string]any, bool, error) {
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return nil, false, fmt.Errorf("codex hooks document field %q must contain hook arrays", "hooks.SessionStart")
+	}
+
+	preservedHooks := make([]any, 0, len(hooks))
+	changed := false
+	for _, rawHook := range hooks {
+		hook, ok := rawHook.(map[string]any)
+		if !ok {
+			return nil, false, fmt.Errorf("codex hooks document field %q must contain hook objects", "hooks.SessionStart.hooks")
+		}
+		command, _ := hook["command"].(string)
+		if command != "" && isOwnedLumenCodexSessionStartCommand(command, hook, expectedCommand) {
+			changed = true
+			continue
+		}
+		preservedHooks = append(preservedHooks, rawHook)
+	}
+	if len(preservedHooks) == 0 {
+		return nil, false, nil
+	}
+	if !changed {
+		return group, true, nil
+	}
+
+	preservedGroup := make(map[string]any, len(group))
+	for key, value := range group {
+		preservedGroup[key] = value
+	}
+	preservedGroup["hooks"] = preservedHooks
+	return preservedGroup, true, nil
+}
+
+func isLumenCodexSessionStartCommand(command string) bool {
+	normalized := strings.ReplaceAll(command, `\`, "/")
+	if !strings.Contains(normalized, "hook session-start lumen") {
+		return false
+	}
+	root, ok := lumenLauncherRoot(normalized, "/scripts/run")
+	if !ok {
+		root, ok = lumenLauncherRoot(normalized, "/scripts/run.sh")
+	}
+	if !ok {
+		root, ok = lumenLauncherRoot(normalized, "/scripts/run.cmd")
+	}
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(filepath.Base(root)), "lumen")
+}
+
+func isOwnedLumenCodexSessionStartCommand(command string, hook map[string]any, expectedCommand string) bool {
+	if expectedCommand != "" && command == expectedCommand {
+		return true
+	}
+	if hook["statusMessage"] == codexHookStatusMessage &&
+		strings.Contains(command, "hook session-start lumen") {
+		return true
+	}
+	return isLumenCodexSessionStartCommand(command)
+}
+
+func lumenLauncherRoot(command, suffix string) (string, bool) {
+	idx := strings.Index(command, suffix)
+	if idx < 0 {
+		return "", false
+	}
+	root := strings.Trim(command[:idx], `"' `)
+	if root == "" {
+		return "", false
+	}
+	return root, true
+}
+
+func shellQuoteCommandPath(path string) string {
+	if looksLikeWindowsPath(path) {
+		return windowsCommandQuote(path)
+	}
+	return posixShellQuote(path)
+}
+
+func looksLikeWindowsPath(path string) bool {
+	return strings.Contains(path, `\`) || (len(path) >= 2 && path[1] == ':')
+}
+
+func posixShellQuote(path string) string {
+	if path == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}
+
+func windowsCommandQuote(path string) string {
+	replacer := strings.NewReplacer(
+		`^`, `^^`,
+		`%`, `^%`,
+		`!`, `^^!`,
+		`"`, `^"`,
+	)
+	return `"` + replacer.Replace(path) + `"`
+}

--- a/cmd/codex_hooks_test.go
+++ b/cmd/codex_hooks_test.go
@@ -1,0 +1,695 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMergeCodexSessionStartHook_MissingDocument(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+
+	out, changed, err := mergeCodexSessionStartHook(nil, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	doc := decodeCodexHooksDocument(t, out)
+	groups := codexHookGroups(t, doc, "SessionStart")
+	if len(groups) != 1 {
+		t.Fatalf("SessionStart groups = %d, want 1", len(groups))
+	}
+	if got := codexHookCommand(t, groups[0]); got != command {
+		t.Fatalf("command = %q, want %q", got, command)
+	}
+	if strings.Contains(string(out), "compact") {
+		t.Fatalf("output contains compact: %s", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_EmptyDocument(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+
+	out, changed, err := mergeCodexSessionStartHook([]byte("{}"), command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	doc := decodeCodexHooksDocument(t, out)
+	groups := codexHookGroups(t, doc, "SessionStart")
+	if len(groups) != 1 {
+		t.Fatalf("SessionStart groups = %d, want 1", len(groups))
+	}
+	if got := groups[0]["matcher"]; got != codexSessionStartMatcher {
+		t.Fatalf("matcher = %v, want %q", got, codexSessionStartMatcher)
+	}
+	if _, ok := groups[0]["statusMessage"]; ok {
+		t.Fatalf("statusMessage should be on command hook, got group-level value %v", groups[0]["statusMessage"])
+	}
+	if got := codexHookStatusMessageForGroup(t, groups[0]); got != codexHookStatusMessage {
+		t.Fatalf("statusMessage = %q, want %q", got, codexHookStatusMessage)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_MissingDocument(t *testing.T) {
+	out, changed, err := mergeCodexHooksFeatureFlag(nil)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "[features]\nhooks = true\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_AppendsFeaturesSection(t *testing.T) {
+	raw := []byte("model = \"gpt-5-codex\"\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "model = \"gpt-5-codex\"\n\n[features]\nhooks = true\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_InsertsIntoExistingFeatures(t *testing.T) {
+	raw := []byte("[features]\nexperimental = true\n\n[mcp_servers]\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "[features]\nhooks = true\nexperimental = true\n\n[mcp_servers]\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_EnablesDisabledFlag(t *testing.T) {
+	raw := []byte("[features]\n  hooks = false # keep hooks enabled for Lumen\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "[features]\n  hooks = true # keep hooks enabled for Lumen\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_Idempotent(t *testing.T) {
+	raw := []byte("[features]\nhooks = true\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if string(out) != string(raw) {
+		t.Fatalf("config = %q, want original %q", out, raw)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_RejectsInvalidValue(t *testing.T) {
+	out, changed, err := mergeCodexHooksFeatureFlag([]byte("[features]\nhooks = \"yes\"\n"))
+	if err == nil {
+		t.Fatal("error = nil, want invalid value error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_MigratesDeprecatedCodexHooksFlag(t *testing.T) {
+	raw := []byte("[features]\n  codex_hooks = true # keep hooks enabled for Lumen\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "[features]\n  hooks = true # keep hooks enabled for Lumen\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexHooksFeatureFlag_RemovesDeprecatedCodexHooksWhenHooksExists(t *testing.T) {
+	raw := []byte("[features]\nhooks = true\ncodex_hooks = true\n")
+
+	out, changed, err := mergeCodexHooksFeatureFlag(raw)
+	if err != nil {
+		t.Fatalf("mergeCodexHooksFeatureFlag: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got, want := string(out), "[features]\nhooks = true\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+}
+
+func TestCodexHooksFeatureEnabledInConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		raw     string
+		want    bool
+		wantErr bool
+	}{
+		{name: "missing", raw: "[features]\n", want: false},
+		{name: "disabled", raw: "[features]\nhooks = false\n", want: false},
+		{name: "enabled", raw: "[features]\nhooks = true\n", want: true},
+		{name: "commented", raw: "[features]\nhooks = true # enabled\n", want: true},
+		{name: "deprecated only", raw: "[features]\ncodex_hooks = true\n", want: false},
+		{name: "wrong table", raw: "[other]\nhooks = true\n", want: false},
+		{name: "invalid", raw: "[features]\nhooks = \"yes\"\n", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := codexHooksFeatureEnabledInConfig([]byte(tc.raw))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("enabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexLauncherPathForGOOS(t *testing.T) {
+	pluginRoot := filepath.Join("tmp", "lumen")
+
+	if got, want := codexLauncherPathForGOOS(pluginRoot, "darwin"), filepath.Join(pluginRoot, "scripts", "run"); got != want {
+		t.Fatalf("darwin launcher = %q, want %q", got, want)
+	}
+	if got, want := codexLauncherPathForGOOS(`C:\Users\franz\lumen`, "windows"), `C:\Users\franz\lumen\scripts\run.cmd`; got != want {
+		t.Fatalf("windows launcher = %q, want %q", got, want)
+	}
+}
+
+func TestCodexSessionStartCommandQuotesLauncher(t *testing.T) {
+	launcher := "/Users/franz/Code/lumen plugin/scripts/run"
+
+	got := codexSessionStartCommand(launcher)
+	if !strings.HasPrefix(got, `'`+launcher+`'`) {
+		t.Fatalf("command = %q, want quoted launcher prefix", got)
+	}
+	if !strings.Contains(got, " hook session-start lumen --host codex") {
+		t.Fatalf("command = %q, want session-start invocation", got)
+	}
+}
+
+func TestCodexSessionStartCommandEscapesShellExpansion(t *testing.T) {
+	launcher := "/Users/franz/Code/lumen $(touch nope)/scripts/run"
+
+	got := codexSessionStartCommand(launcher)
+	if !strings.HasPrefix(got, `'`+launcher+`'`) {
+		t.Fatalf("command = %q, want single-quoted launcher prefix", got)
+	}
+	if strings.Contains(got, `"`) {
+		t.Fatalf("command = %q, want no double-quoted shell interpolation", got)
+	}
+}
+
+func TestCodexSessionStartCommandEscapesSingleQuotes(t *testing.T) {
+	launcher := "/Users/franz/Code/lumen's fork/scripts/run"
+
+	got := codexSessionStartCommand(launcher)
+	if want := `'/Users/franz/Code/lumen'\''s fork/scripts/run' hook session-start lumen --host codex`; got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestCodexSessionStartCommandEscapesWindowsExpansion(t *testing.T) {
+	launcher := `C:\Users\%USERNAME%\lumen\scripts\run.cmd`
+
+	got := codexSessionStartCommand(launcher)
+	if want := `"C:\Users\^%USERNAME^%\lumen\scripts\run.cmd" hook session-start lumen --host codex`; got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesUnrelatedHooks(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	raw := []byte(`{
+		"hooks": {
+			"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "\"/repo/lumen/scripts/run\" hook session-start lumen --host claude"}]}],
+			"SessionStart": [{"matcher": "startup", "hooks": [{"type": "command", "command": "echo foreign"}]}]
+		}
+	}`)
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	doc := decodeCodexHooksDocument(t, out)
+	if got := codexHookCommand(t, codexHookGroups(t, doc, "PreToolUse")[0]); got != `"/repo/lumen/scripts/run" hook session-start lumen --host claude` {
+		t.Fatalf("PreToolUse command = %q, want preserved command", got)
+	}
+	sessionStart := codexHookGroups(t, doc, "SessionStart")
+	if len(sessionStart) != 2 {
+		t.Fatalf("SessionStart groups = %d, want 2", len(sessionStart))
+	}
+	if got := codexHookCommand(t, sessionStart[0]); got != "echo foreign" {
+		t.Fatalf("foreign command = %q, want preserved command", got)
+	}
+	if got := codexHookCommand(t, sessionStart[1]); got != command {
+		t.Fatalf("Lumen command = %q, want %q", got, command)
+	}
+}
+
+func TestMergeCodexSessionStartHook_ReplacesStaleLumenHook(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	raw := []byte(`{
+		"hooks": {
+			"SessionStart": [
+				{"matcher": "startup|resume|clear|compact", "hooks": [{"type": "command", "command": "\"/repo/lumen/scripts/run.sh\" hook session-start lumen --host claude"}]},
+				{"matcher": "startup", "hooks": [{"type": "command", "command": "echo foreign"}]}
+			]
+		}
+	}`)
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	groups := codexHookGroups(t, decodeCodexHooksDocument(t, out), "SessionStart")
+	if len(groups) != 2 {
+		t.Fatalf("SessionStart groups = %d, want 2", len(groups))
+	}
+	lumenCount := 0
+	for _, group := range groups {
+		if codexHookGroupRunsLumenSessionStart(group) {
+			lumenCount++
+			if got := group["matcher"]; got != codexSessionStartMatcher {
+				t.Fatalf("Lumen matcher = %v, want %q", got, codexSessionStartMatcher)
+			}
+		}
+	}
+	if lumenCount != 1 {
+		t.Fatalf("Lumen hook groups = %d, want 1", lumenCount)
+	}
+	if strings.Contains(string(out), "compact") {
+		t.Fatalf("output contains compact: %s", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_DeduplicatesLumenHooks(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	raw := []byte(`{
+		"hooks": {
+			"SessionStart": [
+				{"matcher": "startup", "hooks": [{"type": "command", "command": "\"/repo/lumen/scripts/run.sh\" hook session-start lumen --host claude"}]},
+				{"matcher": "resume", "hooks": [{"type": "command", "command": "\"/repo/lumen/scripts/run\" hook session-start lumen --host claude"}]}
+			]
+		}
+	}`)
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	groups := codexHookGroups(t, decodeCodexHooksDocument(t, out), "SessionStart")
+	if len(groups) != 1 {
+		t.Fatalf("SessionStart groups = %d, want 1", len(groups))
+	}
+	if got := codexHookCommand(t, groups[0]); got != command {
+		t.Fatalf("command = %q, want %q", got, command)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesForeignSessionStartCommands(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	foreign := `"/tmp/not-lumen/scripts/run" hook session-start lumen --host claude`
+	raw, err := json.Marshal(map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "startup",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": foreign},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	groups := codexHookGroups(t, decodeCodexHooksDocument(t, out), "SessionStart")
+	if len(groups) != 2 {
+		t.Fatalf("SessionStart groups = %d, want 2", len(groups))
+	}
+	if got := codexHookCommand(t, groups[0]); got != foreign {
+		t.Fatalf("foreign command = %q, want %q", got, foreign)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesForeignHookInMixedGroup(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	raw := []byte(`{
+		"hooks": {
+			"SessionStart": [
+				{
+					"matcher": "startup",
+					"hooks": [
+						{"type": "command", "command": "\"/repo/lumen/scripts/run\" hook session-start lumen --host claude"},
+						{"type": "command", "command": "echo foreign"}
+					]
+				}
+			]
+		}
+	}`)
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	groups := codexHookGroups(t, decodeCodexHooksDocument(t, out), "SessionStart")
+	if len(groups) != 2 {
+		t.Fatalf("SessionStart groups = %d, want 2", len(groups))
+	}
+	if got := codexHookCommands(t, groups[0]); len(got) != 1 || got[0] != "echo foreign" {
+		t.Fatalf("first group commands = %#v, want preserved foreign hook only", got)
+	}
+	if got := codexHookCommand(t, groups[1]); got != command {
+		t.Fatalf("Lumen command = %q, want %q", got, command)
+	}
+}
+
+func TestMergeCodexSessionStartHook_ReplacesMovedUnmarkedLumenHook(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+	raw := []byte(`{
+		"hooks": {
+			"SessionStart": [
+				{"matcher": "startup", "hooks": [{"type": "command", "command": "\"/repo/lumen fork/scripts/run.sh\" hook session-start lumen --host claude"}]}
+			]
+		}
+	}`)
+
+	out, changed, err := mergeCodexSessionStartHook(raw, command)
+	if err != nil {
+		t.Fatalf("mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	groups := codexHookGroups(t, decodeCodexHooksDocument(t, out), "SessionStart")
+	if len(groups) != 1 {
+		t.Fatalf("SessionStart groups = %d, want 1", len(groups))
+	}
+	if got := codexHookCommand(t, groups[0]); got != command {
+		t.Fatalf("command = %q, want %q", got, command)
+	}
+}
+
+func TestMergeCodexSessionStartHook_MalformedJSON(t *testing.T) {
+	out, changed, err := mergeCodexSessionStartHook([]byte(`{"hooks":`), "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_NullDocument(t *testing.T) {
+	out, changed, err := mergeCodexSessionStartHook([]byte(`null`), "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_Idempotent(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+
+	first, changed, err := mergeCodexSessionStartHook(nil, command)
+	if err != nil {
+		t.Fatalf("first mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("first changed = false, want true")
+	}
+
+	second, changed, err := mergeCodexSessionStartHook(first, command)
+	if err != nil {
+		t.Fatalf("second mergeCodexSessionStartHook: %v", err)
+	}
+	if changed {
+		t.Fatal("second changed = true, want false")
+	}
+	if string(second) != string(first) {
+		t.Fatalf("second output changed:\n%s\nwant:\n%s", second, first)
+	}
+}
+
+func TestMergeCodexSessionStartHook_IdempotentOutsideLumenDirectory(t *testing.T) {
+	command := codexSessionStartCommand("/repo/lumen fork/scripts/run")
+
+	first, changed, err := mergeCodexSessionStartHook(nil, command)
+	if err != nil {
+		t.Fatalf("first mergeCodexSessionStartHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("first changed = false, want true")
+	}
+
+	second, changed, err := mergeCodexSessionStartHook(first, command)
+	if err != nil {
+		t.Fatalf("second mergeCodexSessionStartHook: %v", err)
+	}
+	if changed {
+		t.Fatal("second changed = true, want false")
+	}
+	if string(second) != string(first) {
+		t.Fatalf("second output changed:\n%s\nwant:\n%s", second, first)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesMalformedHooksShape(t *testing.T) {
+	raw := []byte(`{"hooks": []}`)
+	out, changed, err := mergeCodexSessionStartHook(raw, "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesMalformedSessionStartShape(t *testing.T) {
+	raw := []byte(`{"hooks": {"SessionStart": {}}}`)
+	out, changed, err := mergeCodexSessionStartHook(raw, "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesMalformedSessionStartGroup(t *testing.T) {
+	raw := []byte(`{"hooks": {"SessionStart": ["bad"]}}`)
+	out, changed, err := mergeCodexSessionStartHook(raw, "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesMalformedSessionStartGroupHooks(t *testing.T) {
+	raw := []byte(`{"hooks": {"SessionStart": [{"hooks": {}}]}}`)
+	out, changed, err := mergeCodexSessionStartHook(raw, "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func TestMergeCodexSessionStartHook_PreservesMalformedSessionStartHook(t *testing.T) {
+	raw := []byte(`{"hooks": {"SessionStart": [{"hooks": ["bad"]}]}}`)
+	out, changed, err := mergeCodexSessionStartHook(raw, "command")
+	if err == nil {
+		t.Fatal("error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if out != nil {
+		t.Fatalf("out = %q, want nil", out)
+	}
+}
+
+func decodeCodexHooksDocument(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, raw)
+	}
+	return doc
+}
+
+func codexHookGroups(t *testing.T, doc map[string]any, event string) []map[string]any {
+	t.Helper()
+	hooks, ok := doc["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks missing or wrong type: %#v", doc["hooks"])
+	}
+	rawGroups, ok := hooks[event].([]any)
+	if !ok {
+		t.Fatalf("%s hooks missing or wrong type: %#v", event, hooks[event])
+	}
+	groups := make([]map[string]any, 0, len(rawGroups))
+	for _, rawGroup := range rawGroups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok {
+			t.Fatalf("hook group wrong type: %#v", rawGroup)
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func codexHookCommand(t *testing.T, group map[string]any) string {
+	t.Helper()
+	hook := codexSingleHook(t, group)
+	command, ok := hook["command"].(string)
+	if !ok {
+		t.Fatalf("command missing or wrong type: %#v", hook["command"])
+	}
+	return command
+}
+
+func codexHookCommands(t *testing.T, group map[string]any) []string {
+	t.Helper()
+	rawHooks, ok := group["hooks"].([]any)
+	if !ok {
+		t.Fatalf("hooks = %#v, want hook array", group["hooks"])
+	}
+	commands := make([]string, 0, len(rawHooks))
+	for _, rawHook := range rawHooks {
+		hook, ok := rawHook.(map[string]any)
+		if !ok {
+			t.Fatalf("hook wrong type: %#v", rawHook)
+		}
+		command, ok := hook["command"].(string)
+		if !ok {
+			t.Fatalf("command missing or wrong type: %#v", hook["command"])
+		}
+		commands = append(commands, command)
+	}
+	return commands
+}
+
+func codexHookStatusMessageForGroup(t *testing.T, group map[string]any) string {
+	t.Helper()
+	hook := codexSingleHook(t, group)
+	statusMessage, ok := hook["statusMessage"].(string)
+	if !ok {
+		t.Fatalf("statusMessage missing or wrong type: %#v", hook["statusMessage"])
+	}
+	return statusMessage
+}
+
+func codexSingleHook(t *testing.T, group map[string]any) map[string]any {
+	t.Helper()
+	rawHooks, ok := group["hooks"].([]any)
+	if !ok || len(rawHooks) != 1 {
+		t.Fatalf("hooks = %#v, want one hook", group["hooks"])
+	}
+	hook, ok := rawHooks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("hook wrong type: %#v", rawHooks[0])
+	}
+	return hook
+}

--- a/cmd/codex_test.go
+++ b/cmd/codex_test.go
@@ -1,0 +1,798 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeRunner struct {
+	calls     []string
+	getOutput []byte
+	getErr    error
+	runErrs   map[string]error
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	call := name + " " + strings.Join(args, " ")
+	f.calls = append(f.calls, call)
+	if f.runErrs != nil {
+		if err := f.runErrs[call]; err != nil {
+			return nil, err
+		}
+	}
+	if call == "codex mcp get lumen" {
+		return f.getOutput, f.getErr
+	}
+	return []byte("ok\n"), nil
+}
+
+func TestCodexPathsFromEnv(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	codexHome := filepath.Join(home, "codex-home")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+
+	if paths.codexHome != codexHome {
+		t.Fatalf("codexHome = %q, want %q", paths.codexHome, codexHome)
+	}
+	if paths.pluginRoot != pluginRoot {
+		t.Fatalf("pluginRoot = %q, want %q", paths.pluginRoot, pluginRoot)
+	}
+	if paths.launcher != filepath.Join(pluginRoot, "scripts", "run") {
+		t.Fatalf("launcher = %q, want run under plugin root", paths.launcher)
+	}
+	if paths.hooksPath != filepath.Join(codexHome, "hooks.json") {
+		t.Fatalf("hooksPath = %q, want hooks.json under CODEX_HOME", paths.hooksPath)
+	}
+	if paths.configPath != filepath.Join(codexHome, "config.toml") {
+		t.Fatalf("configPath = %q, want config.toml under CODEX_HOME", paths.configPath)
+	}
+	if paths.skillsSrc != filepath.Join(pluginRoot, "skills") {
+		t.Fatalf("skillsSrc = %q, want skills under plugin root", paths.skillsSrc)
+	}
+	if paths.skillsDst != filepath.Join(home, ".agents", "skills", "lumen") {
+		t.Fatalf("skillsDst = %q, want ~/.agents/skills/lumen", paths.skillsDst)
+	}
+	if !strings.Contains(paths.hookCommand, " hook session-start lumen --host codex") {
+		t.Fatalf("hookCommand = %q, want Lumen session-start command", paths.hookCommand)
+	}
+}
+
+func TestInstallCodexHookFile_Idempotent(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), "hooks.json")
+	command := codexSessionStartCommand("/repo/lumen/scripts/run")
+
+	changed, err := installCodexHookFile(hooksPath, command)
+	if err != nil {
+		t.Fatalf("first installCodexHookFile: %v", err)
+	}
+	if !changed {
+		t.Fatal("first changed = false, want true")
+	}
+	first, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read first hooks file: %v", err)
+	}
+
+	changed, err = installCodexHookFile(hooksPath, command)
+	if err != nil {
+		t.Fatalf("second installCodexHookFile: %v", err)
+	}
+	if changed {
+		t.Fatal("second changed = true, want false")
+	}
+	second, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read second hooks file: %v", err)
+	}
+	if string(second) != string(first) {
+		t.Fatalf("hooks file changed on idempotent install:\n%s\nwant:\n%s", second, first)
+	}
+}
+
+func TestInstallCodexHookFile_MalformedJSONLeavesFileUntouched(t *testing.T) {
+	hooksPath := filepath.Join(t.TempDir(), "hooks.json")
+	original := []byte(`{"hooks":`)
+	if err := os.WriteFile(hooksPath, original, 0o644); err != nil {
+		t.Fatalf("write malformed hooks file: %v", err)
+	}
+
+	changed, err := installCodexHookFile(hooksPath, "command")
+	if err == nil {
+		t.Fatal("installCodexHookFile error = nil, want error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("hooks file = %q, want original %q", got, original)
+	}
+}
+
+func TestRunCodexInstall_WritesHookAndAddsMCPWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	runner := &fakeRunner{getErr: exec.ErrNotFound}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	if err := runCodexInstall(context.Background(), stdout, stderr, runner); err != nil {
+		t.Fatalf("runCodexInstall: %v", err)
+	}
+
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	if !strings.Contains(string(raw), "hook session-start lumen --host codex") {
+		t.Fatalf("hooks file missing session-start command:\n%s", raw)
+	}
+	config, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	if !strings.Contains(string(config), "[features]\n") || !strings.Contains(string(config), "hooks = true") {
+		t.Fatalf("config file missing hooks feature flag:\n%s", config)
+	}
+	if strings.Contains(string(config), "codex_hooks") {
+		t.Fatalf("config file contains deprecated codex_hooks feature flag:\n%s", config)
+	}
+	if !isSymlinkTo(t, filepath.Join(home, ".agents", "skills", "lumen"), filepath.Join(pluginRoot, "skills")) {
+		t.Fatalf("skills link was not installed")
+	}
+	wantAdd := fmt.Sprintf("codex mcp add lumen -- %s stdio", filepath.Join(pluginRoot, "scripts", "run"))
+	if !containsCall(runner.calls, "codex mcp get lumen") || !containsCall(runner.calls, wantAdd) {
+		t.Fatalf("calls = %#v, want get and add", runner.calls)
+	}
+	if !strings.Contains(stdout.String(), "Installed Codex SessionStart hook") {
+		t.Fatalf("stdout = %q, want installed hook message", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunCodexInstall_IdempotentEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	runner := &fakeRunner{getErr: exec.ErrNotFound}
+
+	if err := runCodexInstall(context.Background(), new(bytes.Buffer), new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("first runCodexInstall: %v", err)
+	}
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	firstHooks, err := os.ReadFile(paths.hooksPath)
+	if err != nil {
+		t.Fatalf("read first hooks file: %v", err)
+	}
+	firstCallCount := len(runner.calls)
+
+	runner.getErr = nil
+	runner.getOutput = []byte(fmt.Sprintf("command: %s\nargs: stdio\n", paths.launcher))
+	stdout := new(bytes.Buffer)
+	if err := runCodexInstall(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("second runCodexInstall: %v", err)
+	}
+
+	secondHooks, err := os.ReadFile(paths.hooksPath)
+	if err != nil {
+		t.Fatalf("read second hooks file: %v", err)
+	}
+	if string(secondHooks) != string(firstHooks) {
+		t.Fatalf("hooks changed on second install:\n%s\nwant:\n%s", secondHooks, firstHooks)
+	}
+	if !isSymlinkTo(t, paths.skillsDst, paths.skillsSrc) {
+		t.Fatalf("skills link was not preserved")
+	}
+	if !strings.Contains(stdout.String(), "Codex SessionStart hook already installed") ||
+		!strings.Contains(stdout.String(), "Codex MCP server lumen already configured") {
+		t.Fatalf("second stdout = %q, want idempotent messages", stdout.String())
+	}
+	for _, call := range runner.calls[firstCallCount:] {
+		if strings.Contains(call, " mcp add ") || strings.Contains(call, " mcp remove ") {
+			t.Fatalf("second run should not add/remove MCP, calls = %#v", runner.calls[firstCallCount:])
+		}
+	}
+	status, err := codexHookStatus(paths.hooksPath, paths.hookCommand)
+	if err != nil {
+		t.Fatalf("codexHookStatus: %v", err)
+	}
+	if status.exact != 1 || status.total != 1 {
+		t.Fatalf("hook status = %+v, want exactly one Lumen hook", status)
+	}
+}
+
+func TestRunCodexInstall_FailsWhenMCPAddFails(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	addCall := fmt.Sprintf("codex mcp add lumen -- %s stdio", filepath.Join(pluginRoot, "scripts", "run"))
+	runner := &fakeRunner{
+		getErr:  exec.ErrNotFound,
+		runErrs: map[string]error{addCall: errors.New("add failed")},
+	}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	if err := runCodexInstall(context.Background(), stdout, stderr, runner); err == nil {
+		t.Fatal("runCodexInstall error = nil, want MCP add error")
+	}
+	if strings.Contains(stderr.String(), "Warning: MCP setup incomplete") {
+		t.Fatalf("stderr = %q, want no swallowed MCP warning", stderr.String())
+	}
+}
+
+func TestRunCodexInstall_FailsWhenSkillsSetupFails(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	skillsDst := filepath.Join(home, ".agents", "skills", "lumen")
+	if err := os.MkdirAll(skillsDst, 0o755); err != nil {
+		t.Fatalf("create skills dst: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDst, "custom.md"), []byte("custom"), 0o644); err != nil {
+		t.Fatalf("write custom skills file: %v", err)
+	}
+	runner := &fakeRunner{getErr: exec.ErrNotFound}
+	stderr := new(bytes.Buffer)
+
+	if err := runCodexInstall(context.Background(), new(bytes.Buffer), stderr, runner); err == nil {
+		t.Fatal("runCodexInstall error = nil, want skills setup error")
+	}
+	if strings.Contains(stderr.String(), "Warning: skills setup incomplete") {
+		t.Fatalf("stderr = %q, want no swallowed skills warning", stderr.String())
+	}
+}
+
+func TestRunCodexInstall_ReplacesMismatchedMCP(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	runner := &fakeRunner{getOutput: []byte("command: /other/lumen\nargs: stdio\n")}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	if err := runCodexInstall(context.Background(), stdout, stderr, runner); err != nil {
+		t.Fatalf("runCodexInstall: %v", err)
+	}
+
+	wantRemove := "codex mcp remove lumen"
+	wantAdd := fmt.Sprintf("codex mcp add lumen -- %s stdio", filepath.Join(pluginRoot, "scripts", "run"))
+	if !containsCall(runner.calls, "codex mcp get lumen") || !containsCall(runner.calls, wantRemove) || !containsCall(runner.calls, wantAdd) {
+		t.Fatalf("calls = %#v, want get, remove, add", runner.calls)
+	}
+	if !strings.Contains(stdout.String(), "Updated Codex MCP server lumen") {
+		t.Fatalf("stdout = %q, want updated MCP message", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestCodexMCPOutputMatchesRequiresCommandAndArgs(t *testing.T) {
+	paths := codexPaths{launcher: "/repo/lumen/scripts/run"}
+	if !codexMCPOutputMatches([]byte("transport: stdio\ncommand: /repo/lumen/scripts/run\nargs: stdio\n"), paths) {
+		t.Fatal("expected command and args output to match")
+	}
+	if !codexMCPOutputMatches([]byte(`{"command":"/repo/lumen/scripts/run","args":["stdio"]}`), paths) {
+		t.Fatal("expected JSON command and args output to match")
+	}
+	if codexMCPOutputMatches([]byte("transport: stdio\nnote: /repo/lumen/scripts/run\n"), paths) {
+		t.Fatal("matched output without command field")
+	}
+	if codexMCPOutputMatches([]byte("command: /repo/lumen/scripts/run\nnote: stdio\n"), paths) {
+		t.Fatal("matched output without args field")
+	}
+	if codexMCPOutputMatches([]byte("command: /repo/lumen/scripts/run.bak\nargs: stdio\n"), paths) {
+		t.Fatal("matched command prefix false positive")
+	}
+	if codexMCPOutputMatches([]byte("command: /repo/lumen/scripts/run\nargs: stdio-extra\n"), paths) {
+		t.Fatal("matched args prefix false positive")
+	}
+}
+
+func TestRunCodexDoctorReportsHookStatus(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	if _, err := installCodexHookFile(paths.hooksPath, paths.hookCommand); err != nil {
+		t.Fatalf("installCodexHookFile: %v", err)
+	}
+	if _, err := ensureCodexHooksFeatureFlag(paths.configPath); err != nil {
+		t.Fatalf("ensureCodexHooksFeatureFlag: %v", err)
+	}
+	runner := &fakeRunner{getOutput: []byte(fmt.Sprintf("command: %s\nargs: stdio\n", paths.launcher))}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, stderr, runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Codex home: " + paths.codexHome,
+		"Lumen root: " + paths.pluginRoot,
+		"MCP lumen: ok",
+		"Codex hooks feature: ok",
+		"SessionStart hook: ok",
+		"Skills: missing",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunCodexDoctorReportsMissingStatuses(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	runner := &fakeRunner{
+		getOutput: []byte("Error: No MCP server named 'lumen' found."),
+		getErr:    errors.New("exit status 1"),
+	}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"MCP lumen: missing", "Codex hooks feature: disabled", "SessionStart hook: missing", "Skills: missing"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestRunCodexDoctorReportsInstalledHookDisabledByFeatureFlag(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	if _, err := installCodexHookFile(paths.hooksPath, paths.hookCommand); err != nil {
+		t.Fatalf("installCodexHookFile: %v", err)
+	}
+	runner := &fakeRunner{getOutput: []byte(fmt.Sprintf("command: %s\nargs: stdio\n", paths.launcher))}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"Codex hooks feature: disabled", "SessionStart hook: installed but disabled"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestRunCodexDoctorReportsUnavailableMCPCommand(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), &fakeRunner{getErr: exec.ErrNotFound}); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "MCP lumen: unavailable: codex command not found") {
+		t.Fatalf("stdout = %q, want unavailable MCP command", stdout.String())
+	}
+}
+
+func TestRunCodexDoctorReportsMismatchedMCP(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	runner := &fakeRunner{getOutput: []byte("command: /other/lumen\nargs: stdio\n")}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "MCP lumen: mismatch") {
+		t.Fatalf("stdout = %q, want MCP mismatch", stdout.String())
+	}
+}
+
+func TestRunCodexDoctorReportsStaleHookMismatch(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	staleCommand := codexSessionStartCommand(filepath.Join(home, "old-lumen", "scripts", "run"))
+	if _, err := installCodexHookFile(paths.hooksPath, staleCommand); err != nil {
+		t.Fatalf("installCodexHookFile: %v", err)
+	}
+	runner := &fakeRunner{getOutput: []byte(fmt.Sprintf("command: %s\nargs: stdio\n", paths.launcher))}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "SessionStart hook: mismatch") {
+		t.Fatalf("stdout = %q, want stale hook mismatch", out)
+	}
+	if strings.Contains(out, "SessionStart hook: ok") {
+		t.Fatalf("stdout = %q, did not want stale hook ok", out)
+	}
+}
+
+func TestRunCodexDoctorReportsDuplicateHooksAndSkillsOK(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	if _, err := installCodexHookFile(paths.hooksPath, paths.hookCommand); err != nil {
+		t.Fatalf("installCodexHookFile first: %v", err)
+	}
+	raw, err := os.ReadFile(paths.hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks file: %v", err)
+	}
+	duplicate := strings.Replace(string(raw), `"SessionStart": [`, `"SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "\"/repo/lumen/scripts/run.sh\" hook session-start lumen --host claude",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup"
+      },`, 1)
+	if err := os.WriteFile(paths.hooksPath, []byte(duplicate), 0o644); err != nil {
+		t.Fatalf("write duplicate hooks file: %v", err)
+	}
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err != nil {
+		t.Fatalf("ensureCodexSkills: %v", err)
+	}
+	runner := &fakeRunner{getOutput: []byte(fmt.Sprintf("command: %s\nargs: stdio\n", paths.launcher))}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), runner); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"SessionStart hook: duplicate (2)", "Skills: ok"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestRunCodexDoctorReportsMalformedHooks(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("LUMEN_PLUGIN_ROOT", pluginRoot)
+	paths, err := resolveCodexPaths()
+	if err != nil {
+		t.Fatalf("resolveCodexPaths: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.hooksPath), 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+	if err := os.WriteFile(paths.hooksPath, []byte(`{"hooks":`), 0o644); err != nil {
+		t.Fatalf("write malformed hooks: %v", err)
+	}
+	stdout := new(bytes.Buffer)
+
+	if err := runCodexDoctor(context.Background(), stdout, new(bytes.Buffer), &fakeRunner{getErr: exec.ErrNotFound}); err != nil {
+		t.Fatalf("runCodexDoctor: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "SessionStart hook: error:") {
+		t.Fatalf("stdout = %q, want hook error", stdout.String())
+	}
+}
+
+func TestInstallCodexHookFile_PreservesHooksSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "actual-hooks.json")
+	link := filepath.Join(dir, "hooks.json")
+	if err := os.WriteFile(target, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := installCodexHookFile(link, codexSessionStartCommand("/repo/lumen/scripts/run")); err != nil {
+		t.Fatalf("installCodexHookFile: %v", err)
+	}
+	if info, err := os.Lstat(link); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("link was not preserved; info=%v err=%v", info, err)
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(raw), "hook session-start lumen") {
+		t.Fatalf("target not updated:\n%s", raw)
+	}
+}
+
+func TestEnsureCodexSkills_CopiedSkillsAreIdempotent(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	paths := codexPaths{
+		skillsSrc: filepath.Join(pluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	if err := copyCodexSkills(paths.skillsSrc, paths.skillsDst); err != nil {
+		t.Fatalf("copyCodexSkills: %v", err)
+	}
+	info, err := os.Lstat(paths.skillsDst)
+	if err != nil {
+		t.Fatalf("lstat copied skills: %v", err)
+	}
+	if !skillsPathMatches(paths.skillsDst, paths.skillsSrc, info) {
+		t.Fatal("copied skills should match marker")
+	}
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err != nil {
+		t.Fatalf("ensureCodexSkills should accept copied skills: %v", err)
+	}
+	if !skillsLinkOK(paths) {
+		t.Fatal("skillsLinkOK should accept copied skills")
+	}
+}
+
+func TestEnsureCodexSkills_RejectsMarkerOnlyCopy(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	paths := codexPaths{
+		skillsSrc: filepath.Join(pluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	if err := os.MkdirAll(paths.skillsDst, 0o755); err != nil {
+		t.Fatalf("create skills dst: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(paths.skillsDst, codexSkillsSourceMarker), []byte(paths.skillsSrc+"\n"), 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	info, err := os.Lstat(paths.skillsDst)
+	if err != nil {
+		t.Fatalf("lstat marker-only skills: %v", err)
+	}
+	if skillsPathMatches(paths.skillsDst, paths.skillsSrc, info) {
+		t.Fatal("marker-only skills directory should not match")
+	}
+	if skillsLinkOK(paths) {
+		t.Fatal("skillsLinkOK should reject marker-only skills")
+	}
+}
+
+func TestEnsureCodexSkills_RefusesExistingFile(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	paths := codexPaths{
+		skillsSrc: filepath.Join(pluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.skillsDst), 0o755); err != nil {
+		t.Fatalf("create skills parent: %v", err)
+	}
+	if err := os.WriteFile(paths.skillsDst, []byte("user-owned"), 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err == nil {
+		t.Fatal("ensureCodexSkills error = nil, want refusal for existing file")
+	}
+	if got, err := os.ReadFile(paths.skillsDst); err != nil || string(got) != "user-owned" {
+		t.Fatalf("existing file changed: got=%q err=%v", got, err)
+	}
+}
+
+func TestEnsureCodexSkills_RefusesNonLumenSymlink(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := makeCodexPluginRoot(t, home)
+	paths := codexPaths{
+		skillsSrc: filepath.Join(pluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	customTarget := filepath.Join(home, "custom-skills")
+	if err := os.MkdirAll(customTarget, 0o755); err != nil {
+		t.Fatalf("create custom target: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.skillsDst), 0o755); err != nil {
+		t.Fatalf("create skills parent: %v", err)
+	}
+	if err := os.Symlink(customTarget, paths.skillsDst); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err == nil {
+		t.Fatal("ensureCodexSkills error = nil, want refusal for non-Lumen symlink")
+	}
+	if !isSymlinkTo(t, paths.skillsDst, customTarget) {
+		t.Fatalf("non-Lumen symlink was changed")
+	}
+}
+
+func TestEnsureCodexSkills_ReplacesStaleLumenSymlink(t *testing.T) {
+	home := t.TempDir()
+	oldPluginRoot := makeCodexPluginRoot(t, filepath.Join(home, "old"))
+	newPluginRoot := makeCodexPluginRoot(t, filepath.Join(home, "new"))
+	paths := codexPaths{
+		skillsSrc: filepath.Join(newPluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.skillsDst), 0o755); err != nil {
+		t.Fatalf("create skills parent: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(oldPluginRoot, "skills"), paths.skillsDst); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err != nil {
+		t.Fatalf("ensureCodexSkills: %v", err)
+	}
+	if !isSymlinkTo(t, paths.skillsDst, paths.skillsSrc) {
+		t.Fatalf("stale Lumen symlink was not replaced")
+	}
+}
+
+func TestEnsureCodexSkills_ReplacesDanglingLumenSymlink(t *testing.T) {
+	home := t.TempDir()
+	oldPluginRoot := makeCodexPluginRoot(t, filepath.Join(home, "old", "lumen"))
+	newPluginRoot := makeCodexPluginRoot(t, filepath.Join(home, "new"))
+	paths := codexPaths{
+		skillsSrc: filepath.Join(newPluginRoot, "skills"),
+		skillsDst: filepath.Join(home, ".agents", "skills", "lumen"),
+	}
+	oldSkills := filepath.Join(oldPluginRoot, "skills")
+	if err := os.MkdirAll(filepath.Dir(paths.skillsDst), 0o755); err != nil {
+		t.Fatalf("create skills parent: %v", err)
+	}
+	if err := os.Symlink(oldSkills, paths.skillsDst); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.RemoveAll(oldPluginRoot); err != nil {
+		t.Fatalf("remove old plugin root: %v", err)
+	}
+
+	if err := ensureCodexSkills(paths, new(bytes.Buffer)); err != nil {
+		t.Fatalf("ensureCodexSkills: %v", err)
+	}
+	if !isSymlinkTo(t, paths.skillsDst, paths.skillsSrc) {
+		t.Fatalf("dangling Lumen symlink was not replaced")
+	}
+}
+
+func makeCodexPluginRoot(t *testing.T, home string) string {
+	t.Helper()
+	pluginRoot := filepath.Join(home, "lumen")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "scripts"), 0o755); err != nil {
+		t.Fatalf("create scripts dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "skills"), 0o755); err != nil {
+		t.Fatalf("create skills dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "skills", "doctor"), 0o755); err != nil {
+		t.Fatalf("create doctor skill dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pluginRoot, "skills", "reindex"), 0o755); err != nil {
+		t.Fatalf("create reindex skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "scripts", "run"), []byte("#!/usr/bin/env bash\n"), 0o755); err != nil {
+		t.Fatalf("write run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "skills", "doctor", "SKILL.md"), []byte("---\nname: doctor\n---\n\n# Lumen Doctor\n"), 0o644); err != nil {
+		t.Fatalf("write doctor skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "skills", "reindex", "SKILL.md"), []byte("---\nname: reindex\n---\n\n# Lumen Reindex\n"), 0o644); err != nil {
+		t.Fatalf("write reindex skill: %v", err)
+	}
+	return pluginRoot
+}
+
+func containsCall(calls []string, want string) bool {
+	for _, call := range calls {
+		if call == want {
+			return true
+		}
+	}
+	return false
+}
+
+func isSymlinkTo(t *testing.T, path, wantTarget string) bool {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatalf("read symlink: %v", err)
+	}
+	return target == wantTarget
+}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -36,6 +36,7 @@ const backgroundIndexStaleness = 5 * time.Minute
 
 const (
 	hookHostClaude = "claude"
+	hookHostCodex  = "codex"
 	hookHostCursor = "cursor"
 )
 
@@ -59,7 +60,7 @@ var hookSessionStartHost string
 
 var hookSessionStartCmd = &cobra.Command{
 	Use:   "session-start [mcp-name]",
-	Short: "Output SessionStart hook JSON for Claude Code or Cursor",
+	Short: "Output SessionStart hook JSON for Claude Code, Codex, or Cursor",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  runHookSessionStart,
 }
@@ -195,7 +196,7 @@ func generateSessionContextInternal(cwd string, findDonor func(string, string) s
 
 func normalizeHookHost(host string) (string, error) {
 	switch strings.ToLower(host) {
-	case "", hookHostClaude:
+	case "", hookHostClaude, hookHostCodex:
 		return hookHostClaude, nil
 	case hookHostCursor:
 		return hookHostCursor, nil

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -493,6 +493,37 @@ func TestSessionStartOutputCursorJSON(t *testing.T) {
 	}
 }
 
+func TestNormalizeHookHostCodexUsesClaudeCompatibleOutput(t *testing.T) {
+	host, err := normalizeHookHost("codex")
+	if err != nil {
+		t.Fatalf("normalizeHookHost: %v", err)
+	}
+
+	directive := sessionStartDirective(host, "lumen")
+	if !strings.Contains(directive, "mcp__lumen__semantic_search") {
+		t.Fatalf("codex directive = %q, want MCP tool reference", directive)
+	}
+
+	data, err := json.Marshal(sessionStartOutput(host, "context"))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if _, exists := parsed["additional_context"]; exists {
+		t.Fatal("codex output should not use Cursor additional_context payloads")
+	}
+	hso, ok := parsed["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatal("codex output should use hookSpecificOutput payloads")
+	}
+	if hso["hookEventName"] != "SessionStart" || hso["additionalContext"] != "context" {
+		t.Fatalf("hookSpecificOutput = %#v, want SessionStart additionalContext", hso)
+	}
+}
+
 // TestSpawnBackgroundIndexer_DoesNotPanic verifies that spawnBackgroundIndexer
 // does not panic or block on a path that contains no indexable files.
 // The spawned process will acquire the lock, find nothing to index, and exit.


### PR DESCRIPTION
## Summary

Add a Codex-specific installer that configures the Lumen MCP server, shared skills, Codex hooks feature flag, and a user-level SessionStart hook for proactive project index warmup.

- Add `lumen codex install` to install or repair Codex MCP, skills, and hooks.
- Enable `[features] hooks = true` in Codex `config.toml` so installed hooks run without the deprecated `codex_hooks` warning.
- Migrate existing `[features] codex_hooks` entries to `[features] hooks` during install.
- Add `lumen codex doctor` to report missing, disabled, stale, duplicate, or malformed Codex integration state.
- Merge Lumen SessionStart hooks into Codex `hooks.json` without clobbering unrelated user hooks.
- Deduplicate and replace stale Lumen-owned hook entries.
- Refuse to overwrite user-owned skill files or non-Lumen symlinks.
- Update Codex documentation from manual setup to the installer flow.

## Test Plan

- `env CGO_ENABLED=1 go test -tags=fts5 -count=1 ./...`
- `make build-local`
- `git diff --check upstream/main...HEAD`
- local install + doctor smoke test with `./bin/lumen codex install` and `./bin/lumen codex doctor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI commands to install/verify Codex integration, configure hooks feature, register the Lumen MCP, and install/link shared skills
  * SessionStart hook that proactively warms the project index on startup/resume/clear
  * Hook host "codex" supported for session-start workflows

* **Documentation**
  * Updated Quick Start/INSTALL/README with installer workflow, verification, update, and uninstall steps (including Windows)

* **Tests**
  * Extensive test coverage for installer, hooks, MCP handling, skills management, and doctor reporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/lumen/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->