### PR TITLE
test(integration): add native-spawn handshake gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,90 @@ jobs:
           echo "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]' \
             || { echo "ERROR: version output does not match semver pattern"; exit 1; }
 
+      - name: Upload binary for integration job
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumen-${{ matrix.os }}
+          path: bin/lumen
+          retention-days: 1
+          if-no-files-found: error
+
+  build-windows-cross:
+    # Delegates to `make build` so the cross-compile recipe (MinGW toolchain,
+    # sqlite3 headers, CC overrides) lives in exactly one place: .goreleaser.yml,
+    # invoked through the xgoreleaser docker image already used by every shipped
+    # release. ci.yml does not duplicate that recipe.
+    name: Build windows-amd64 (xgoreleaser)
+    runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cross-compile via xgoreleaser
+        run: make build
+
+      - name: Stage windows binary for upload
+        run: |
+          # `make build` outputs to dist/<id>_<goos>_<goarch>/lumen[.exe].
+          # Extract the windows artifact into a stable path for upload.
+          mkdir -p bin
+          find dist -type f -name 'lumen.exe' -exec cp {} bin/lumen.exe \;
+          test -x bin/lumen.exe
+
+      - name: Upload binary for integration job
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumen-windows-amd64
+          path: bin/lumen.exe
+          retention-days: 1
+          if-no-files-found: error
+
+  integration:
+    name: Integration (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: github.actor != 'release-please[bot]'
+    timeout-minutes: 10
+    needs: [build, build-windows-cross]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download lumen binary (Unix)
+        if: runner.os != 'Windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: lumen-${{ matrix.os }}
+          path: bin
+
+      - name: Download lumen binary (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: lumen-windows-amd64
+          path: bin
+
+      - name: Restore execute bit (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x bin/lumen
+
+      - name: Integration tests
+        shell: bash
+        run: |
+          go test -tags=integration -timeout=5m -v ./internal/integration/...
+
   scripts:
     name: Script tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+// Package integration hosts native-spawn tests that mirror the consumer
+// invocation path used by Claude Code, Cursor, OpenCode, and Codex.
+// exec.Command on Unix calls posix_spawn(2); on Windows it calls
+// CreateProcessW. No shell is in the loop — any byte-0 / shebang / extension
+// regression in the launcher chain fails these tests deterministically.
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRoot locates the repository root by walking up from this test file
+// until it finds go.mod. Tests live at internal/integration/, so the answer
+// is two levels up — but we walk dynamically to be robust to relocation.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(here)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above test file")
+		}
+		dir = parent
+	}
+}
+
+// launcherPath returns the absolute path to launcher.mjs at the repo root.
+// Skips the test if launcher.mjs is missing — signals an incomplete checkout
+// rather than a real regression.
+func launcherPath(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(repoRoot(t), "launcher.mjs")
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("launcher.mjs not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// lookupBuiltBinary returns the path to a pre-built lumen binary for the
+// current OS/arch. Resolution order:
+//  1. $LUMEN_BIN_PATH (CI integration job sets this to the artifact downloaded
+//     from build / build-windows-cross).
+//  2. <repoRoot>/bin/lumen[.exe] (matches `make build-local` output).
+//
+// Skips the test (rather than failing) when no binary is present, so a fresh
+// checkout without a build doesn't produce confusing test failures.
+func lookupBuiltBinary(t *testing.T) string {
+	t.Helper()
+	if env := os.Getenv("LUMEN_BIN_PATH"); env != "" {
+		if _, err := os.Stat(env); err == nil {
+			return env
+		}
+		t.Fatalf("$LUMEN_BIN_PATH set to %q but file is missing", env)
+	}
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+	p := filepath.Join(repoRoot(t), "bin", "lumen"+ext)
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("no built binary at %s and $LUMEN_BIN_PATH unset; build via `make build-local` or set the env var", p)
+	}
+	return p
+}
+
+// nodePath looks up the Node binary the launcher will be invoked through.
+// Skips the test if Node is not in PATH, since the launcher is JS.
+func nodePath(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("node")
+	if err != nil {
+		t.Skipf("node not in PATH: %v", err)
+	}
+	return p
+}
+
+// sandboxTempDir returns an isolated temp dir whose cleanup tolerates
+// Windows file-locking errors. The SessionStart hook spawns a detached
+// background indexer (cmd/hook_spawn_windows.go) that opens debug.log and
+// index.db; on Windows those files cannot be unlinked while handles are
+// open, which makes t.TempDir() cleanup fail and mark the test FAIL even
+// though the test logic succeeded. Best-effort RemoveAll + log-on-error
+// preserves test correctness; CI runner resets sweep any residue.
+func sandboxTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "lumen-integration-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("sandbox cleanup non-fatal error (likely Windows handle held by background indexer): %v", err)
+		}
+	})
+	return dir
+}
+
+// sandboxEnv returns an env slice that points lumen at temp directories for
+// HOME / XDG_DATA_HOME / CLAUDE_PLUGIN_DATA so the runner's real lumen state
+// is untouched. PATH is preserved so node (and its children) can resolve.
+// LUMEN_BIN_PATH is forwarded so launcher.mjs uses the pre-built binary.
+func sandboxEnv(t *testing.T) []string {
+	t.Helper()
+	tmp := sandboxTempDir(t)
+	env := []string{
+		"HOME=" + tmp,
+		"XDG_DATA_HOME=" + tmp,
+		"XDG_CONFIG_HOME=" + tmp,
+		"XDG_CACHE_HOME=" + tmp,
+		"CLAUDE_PLUGIN_DATA=" + tmp,
+		"PATH=" + os.Getenv("PATH"),
+		"LUMEN_BIN_PATH=" + lookupBuiltBinary(t),
+	}
+	// Windows needs SystemRoot, USERPROFILE, etc. for CreateProcess /
+	// runtime initialization. Forward what the parent has — without these,
+	// node and the spawned binary may fail to start.
+	if runtime.GOOS == "windows" {
+		for _, k := range []string{"SystemRoot", "SYSTEMROOT", "USERPROFILE", "TEMP", "TMP", "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "ProgramFiles", "ComSpec"} {
+			if v := os.Getenv(k); v != "" {
+				env = append(env, k+"="+v)
+			}
+		}
+	}
+	return env
+}

--- a/internal/integration/launcher_spawn_test.go
+++ b/internal/integration/launcher_spawn_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestLauncherSpawnStdioHandshake spawns `node launcher.mjs stdio` via
+// exec.Command (no shell) and runs the MCP initialize handshake. Validates
+// that the launcher chain — Node -> launcher.mjs -> lumen binary -> MCP
+// stdio server — produces a clean JSON-RPC stream with no leading garbage.
+//
+// This is the regression gate the proposal calls for: any byte-0 / shebang /
+// shell-fragment regression that the polyglot kept hitting fails this test
+// deterministically because exec.Command bypasses shell entirely.
+func TestLauncherSpawnStdioHandshake(t *testing.T) {
+	cmd := exec.Command(nodePath(t), launcherPath(t), "stdio")
+	cmd.Env = sandboxEnv(t)
+
+	transport := &mcp.CommandTransport{Command: cmd}
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "integration-spawn-test",
+		Version: "0.1.0",
+	}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("MCP initialize handshake failed: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+}
+
+// TestLauncherSpawnHookSessionStart spawns the SessionStart hook subcommand
+// via the launcher and verifies it produces a valid JSON object on stdout
+// with a clean exit. Mirrors the invocation pattern in hooks/hooks.json and
+// hooks/hooks-cursor.json after Phase 2 migrates them off run.cmd.
+func TestLauncherSpawnHookSessionStart(t *testing.T) {
+	for _, host := range []string{"claude", "cursor"} {
+		t.Run(host, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			cmd := exec.CommandContext(ctx,
+				nodePath(t), launcherPath(t),
+				"hook", "session-start", "lumen", "--host", host,
+			)
+			cmd.Env = sandboxEnv(t)
+			// Hook reads optional JSON from stdin ({"cwd":"..."}); empty input is fine —
+			// the handler falls back to os.Getwd().
+			cmd.Stdin = bytes.NewReader(nil)
+
+			stdout, err := cmd.Output()
+			if err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					t.Fatalf("hook session-start (host=%s) exited %d: stderr=%s", host, ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
+				}
+				t.Fatalf("hook session-start (host=%s) failed: %v", host, err)
+			}
+
+			// Output must be a single, parseable JSON object — proves no shell
+			// echo / shebang noise leaked into stdout.
+			trimmed := bytes.TrimSpace(stdout)
+			var payload map[string]any
+			if err := json.Unmarshal(trimmed, &payload); err != nil {
+				t.Fatalf("hook session-start (host=%s) stdout is not valid JSON: %v\nstdout=%q", host, err, stdout)
+			}
+			if len(payload) == 0 {
+				t.Fatalf("hook session-start (host=%s) returned empty JSON object", host)
+			}
+		})
+	}
+}
+
+// TestLauncherSpawnHookPreToolUse exercises the second hook subcommand wired
+// into hooks/hooks.json. Pre-tool-use exits cleanly without producing JSON
+// when there's nothing to intercept (it reads tool_input from stdin).
+func TestLauncherSpawnHookPreToolUse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		nodePath(t), launcherPath(t),
+		"hook", "pre-tool-use", "lumen",
+	)
+	cmd.Env = sandboxEnv(t)
+	cmd.Stdin = bytes.NewReader(nil)
+
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("hook pre-tool-use exited %d: stderr=%s", ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
+		}
+		t.Fatalf("hook pre-tool-use failed: %v", err)
+	}
+}

--- a/launcher.mjs
+++ b/launcher.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Spawns the lumen native binary matching the host OS/arch and forwards
+// stdin/stdout/stderr + exit code. Replaces the scripts/run.{sh,bat,cmd}
+// polyglot launcher. This Phase 1 file is intentionally minimal: it only
+// resolves a binary already present at <pluginRoot>/bin/ (or via the
+// LUMEN_BIN_PATH env override). Lazy fetch from GitHub Releases, SHA-256
+// checksum verification, file lock, and per-host cache resolution land in
+// Phase 2.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const ext = process.platform === "win32" ? ".exe" : "";
+
+function findBinary() {
+  // Explicit override — used by integration tests and (future) Phase 2 cache
+  // resolution that wants to bypass the search.
+  if (process.env.LUMEN_BIN_PATH) {
+    return process.env.LUMEN_BIN_PATH;
+  }
+  const candidates = [
+    path.join(here, "bin", `lumen${ext}`),
+    path.join(here, "bin", `lumen-${process.platform}-${process.arch}${ext}`),
+  ];
+  for (const c of candidates) {
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {
+      // not present, try next
+    }
+  }
+  return null;
+}
+
+const bin = findBinary();
+if (!bin) {
+  process.stderr.write(
+    `lumen launcher: no binary found. Set LUMEN_BIN_PATH or build with \`make build-local\`.\n`,
+  );
+  process.exit(127);
+}
+
+const child = spawn(bin, process.argv.slice(2), { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});


### PR DESCRIPTION
## Summary

Adds a Go integration test that exercises the same `posix_spawn` (Unix) / `CreateProcessW` (Windows) invocation path Claude Code, Cursor, OpenCode, and Codex use to spawn the lumen MCP server. No shell sits in the loop, so any byte-0 / shebang / extension regression in the launcher chain fails the test deterministically — the bash-fallback masking that lets the existing `scripts/test_run*.sh` tests pass against broken polyglots no longer hides the failure.

This is **Phase 1** of a two-step polyglot elimination effort. It locks the regression gate in place *before* a follow-up PR changes the artifact, so subsequent migrations either pass CI cleanly or surface the specific failure path immediately rather than reaching users. The follow-up Phase 2 PR addresses the regression class behind #152.

## Why a rigorous gate

The polyglot pattern — a single `.cmd` file that is simultaneously a Windows batch script and a POSIX shell script — has cycled through the same byte-0 regression class in multiple Claude Code plugins:

- **obra/superpowers** (the most-watched Claude Code plugin reference implementation) patched the same byte-0 conflict three different ways across v4.3.0 → v4.3.1 → v4.3.2+, with a regression filed at [obra/superpowers#529](https://github.com/obra/superpowers/issues/529).
- **Anthropic's marketplace tracker** acknowledges the pattern is structurally fragile in [anthropics/claude-plugins-official#1692](https://github.com/anthropics/claude-plugins-official/issues/1692), citing superpowers' history as the canonical example.
- **lumen** has hit this regression class twice in two months (#121 era and the v0.0.39 install path that motivated #152), each time trading one OS's regression for another's.

The byte 0 of a single file can be exactly one of `#` (POSIX shebang), `:` (cmd label, no echo), or `@` (cmd `@echo off`). These are mutually exclusive — no polyglot byte 0 satisfies POSIX `posix_spawn`, Windows `cmd.exe` extension dispatch, and shell parsing all at once. Each iteration re-introduces a different regression. A test gate that exercises the actual host-spawn path (no shell mediator) is the smallest reliable backstop until the polyglot is replaced (Phase 2).

## What this adds

- **`launcher.mjs`** at repo root — minimal Node ESM (~50 lines, zero dependencies). Resolves `bin/lumen[.exe]` from the plugin root or `LUMEN_BIN_PATH` and spawns it. Phase 2 enriches this; Phase 1 keeps it minimal so the test gate lands in isolation.
- **`internal/integration/launcher_spawn_test.go`** (build tag `integration`):
  - `TestLauncherSpawnStdioHandshake` drives a real MCP `initialize` handshake via `mcp.CommandTransport`.
  - `TestLauncherSpawnHookSessionStart` (claude + cursor subtests).
  - `TestLauncherSpawnHookPreToolUse`.
- **`internal/integration/helpers_test.go`** — sandboxed env, repo-root resolution, and a Windows-tolerant temp-dir helper that handles the detached background indexer's open-handle-on-exit semantics.
- **`.github/workflows/ci.yml`**:
  - `build` job uploads `bin/lumen` as artifact `lumen-${matrix.os}` for the integration job.
  - `build-windows-cross` (new, ubuntu-latest) delegates to `make build` so the cross-compile recipe lives only in `.goreleaser.yml` (xgoreleaser docker image already used by every release). ci.yml does not duplicate apt-get / cp / CC overrides.
  - `integration` job (matrix `[ubuntu-latest, macos-latest, windows-latest]`) downloads the matching artifact and runs `go test -tags=integration`.

Existing polyglot script-test steps remain in place — defensive coverage during the soak window in case Phase 2 needs revert.

## Verification

### CI

Green on the fork PR mirror across the full matrix: Build (ubuntu / macos / windows-amd64 cross), Test, Lint, E2E, **Integration (ubuntu / macos / windows)**, plus the existing Script-test jobs.

### Local

Tested via `claude --plugin-dir <repo>` on:

- **Windows 11 25H2 26200.7462**
- **macOS Tahoe 26.4.1**
- **Ubuntu 24.04.4 LTS (arm)**

MCP execution worked correctly on all three.

## Related

- Phase 2 follow-up: invokes lumen via the launcher and migrates every host's manifest off the polyglot. Will close #152.
