### PR TITLE
fix(plugin)!: invoke lumen via node launcher with lazy binary fetch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,8 +19,9 @@
   ],
   "mcpServers": {
     "lumen": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run.cmd",
+      "command": "node",
       "args": [
+        "${CLAUDE_PLUGIN_ROOT}/launcher.mjs",
         "stdio"
       ]
     }

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -7,6 +7,10 @@ server.
 
 - [Codex CLI](https://developers.openai.com/codex/cli)
 - Git
+- **Node.js 22+** (current Active LTS) — Lumen's MCP entry point is
+  `launcher.mjs`, a small Node shim that selects the matching native binary
+  for your OS/arch and fetches it on first use (subsequent runs are cache
+  hits). Check with `node --version`.
 
 ## Installation
 
@@ -22,9 +26,11 @@ server.
    ln -s "$CODEX_HOME/lumen/skills" "$HOME/.agents/skills/lumen"
    ```
 
-3. Register the MCP server:
+3. Register the MCP server with a generous startup timeout (Codex's default
+   is 10 s, which can be tight on a cold-cache first run over a slow link):
    ```bash
-   codex mcp add lumen -- "$CODEX_HOME/lumen/scripts/run.sh" stdio
+   codex mcp add lumen --startup-timeout-sec 60 -- \
+     node "$CODEX_HOME/lumen/launcher.mjs" stdio
    ```
 
 4. Restart Codex.
@@ -36,7 +42,47 @@ $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USER
 git clone https://github.com/ory/lumen.git "$codexHome\lumen"
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills" | Out-Null
 cmd /c mklink /J "$env:USERPROFILE\.agents\skills\lumen" "$codexHome\lumen\skills"
-codex mcp add lumen -- "$codexHome\lumen\scripts\run.cmd" stdio
+codex mcp add lumen --startup-timeout-sec 60 -- `
+  node "$codexHome\lumen\launcher.mjs" stdio
+```
+
+## Troubleshooting
+
+### `node` not found when Codex starts the MCP server
+
+Codex's spawned subprocess inherits a PATH that may not match your interactive
+shell's PATH ([codex#6243](https://github.com/openai/codex/issues/6243)). If
+Codex reports `node not found` while `which node` works in your terminal,
+re-register with the absolute path:
+
+```bash
+codex mcp add lumen --startup-timeout-sec 60 -- \
+  "$(which node)" "$CODEX_HOME/lumen/launcher.mjs" stdio
+```
+
+### MCP startup times out on first run
+
+The launcher fetches a ~30 MB binary from GitHub Releases on first invocation
+(subsequent runs are cache hits in <100 ms). Increase the timeout further
+on slow connections:
+
+```bash
+codex mcp remove lumen
+codex mcp add lumen --startup-timeout-sec 120 -- \
+  node "$CODEX_HOME/lumen/launcher.mjs" stdio
+```
+
+The flag persists into `~/.codex/config.toml` under
+`mcp_servers.lumen.startup_timeout_sec` — preserve that key if you later edit
+the file by hand.
+
+### Pre-warm the cache before first session
+
+The launcher exposes a `prefetch` subcommand that downloads + verifies the
+matching binary and exits — useful in CI or as a manual warm-up:
+
+```bash
+node "$CODEX_HOME/lumen/launcher.mjs" prefetch
 ```
 
 ## Migrating from the old repo-local plugin
@@ -61,6 +107,9 @@ ls -la "$HOME/.agents/skills/lumen"
 cd "${CODEX_HOME:-$HOME/.codex}/lumen" && git pull
 ```
 
+The launcher reads the version from `.release-please-manifest.json` after the
+pull and fetches the matching binary on next invocation.
+
 ## Uninstalling
 
 ```bash
@@ -69,3 +118,7 @@ rm "$HOME/.agents/skills/lumen"
 ```
 
 Optionally delete the clone: `rm -rf "${CODEX_HOME:-$HOME/.codex}/lumen"`.
+
+The cached binaries live under `$XDG_DATA_HOME/lumen/` (Unix) or
+`%LOCALAPPDATA%\lumen\` (Windows); remove that directory if you want a clean
+slate.

--- a/.cursor-plugin/INSTALL.md
+++ b/.cursor-plugin/INSTALL.md
@@ -8,7 +8,7 @@ Lumen ships a native Cursor plugin bundle in this repository.
 - `.cursor/mcp.json` - local `lumen` MCP server wiring
 - `hooks/hooks-cursor.json` - SessionStart hook
 - `skills/` - shared `doctor` and `reindex` skills
-- `scripts/run.cmd` - cross-platform launcher used by the MCP server and hooks
+- `launcher.mjs` - Node-based launcher used by the MCP server and hooks; resolves the matching native lumen binary per OS/arch and lazily fetches it from GitHub Releases on first use
 
 ## Installation
 

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "lumen": {
-      "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.cmd",
+      "command": "node",
       "args": [
+        "${CURSOR_PLUGIN_ROOT}/launcher.mjs",
         "stdio"
       ]
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,90 @@ jobs:
           echo "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]' \
             || { echo "ERROR: version output does not match semver pattern"; exit 1; }
 
+      - name: Upload binary for integration job
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumen-${{ matrix.os }}
+          path: bin/lumen
+          retention-days: 1
+          if-no-files-found: error
+
+  build-windows-cross:
+    # Delegates to `make build` so the cross-compile recipe (MinGW toolchain,
+    # sqlite3 headers, CC overrides) lives in exactly one place: .goreleaser.yml,
+    # invoked through the xgoreleaser docker image already used by every shipped
+    # release. ci.yml does not duplicate that recipe.
+    name: Build windows-amd64 (xgoreleaser)
+    runs-on: ubuntu-latest
+    if: github.actor != 'release-please[bot]'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cross-compile via xgoreleaser
+        run: make build
+
+      - name: Stage windows binary for upload
+        run: |
+          # `make build` outputs to dist/<id>_<goos>_<goarch>/lumen[.exe].
+          # Extract the windows artifact into a stable path for upload.
+          mkdir -p bin
+          find dist -type f -name 'lumen.exe' -exec cp {} bin/lumen.exe \;
+          test -x bin/lumen.exe
+
+      - name: Upload binary for integration job
+        uses: actions/upload-artifact@v4
+        with:
+          name: lumen-windows-amd64
+          path: bin/lumen.exe
+          retention-days: 1
+          if-no-files-found: error
+
+  integration:
+    name: Integration (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: github.actor != 'release-please[bot]'
+    timeout-minutes: 10
+    needs: [build, build-windows-cross]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Download lumen binary (Unix)
+        if: runner.os != 'Windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: lumen-${{ matrix.os }}
+          path: bin
+
+      - name: Download lumen binary (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: lumen-windows-amd64
+          path: bin
+
+      - name: Restore execute bit (Unix)
+        if: runner.os != 'Windows'
+        run: chmod +x bin/lumen
+
+      - name: Integration tests
+        shell: bash
+        run: |
+          go test -tags=integration -timeout=5m -v ./internal/integration/...
+
   scripts:
     name: Script tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,13 @@ jobs:
       - name: Stage windows binary for upload
         run: |
           # `make build` outputs to dist/<id>_<goos>_<goarch>/lumen[.exe].
-          # Extract the windows artifact into a stable path for upload.
+          # Pin to the windows-amd64 build deterministically — if a future
+          # goreleaser config adds another Windows arch, an unfiltered find
+          # would let the last copy win nondeterministically.
           mkdir -p bin
-          find dist -type f -name 'lumen.exe' -exec cp {} bin/lumen.exe \;
+          SRC="$(find dist -type f -path '*windows*amd64*/lumen.exe' | head -n1)"
+          test -n "$SRC" || { echo "windows-amd64 lumen.exe not found in dist/"; exit 1; }
+          cp "$SRC" bin/lumen.exe
           test -x bin/lumen.exe
 
       - name: Upload binary for integration job

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -6,6 +6,7 @@ server automatically.
 ## Prerequisites
 
 - [OpenCode.ai](https://opencode.ai) installed
+- Node.js 22+ (Active LTS; used by the plugin's launcher — OpenCode itself runs on Bun/Node, so this is normally already present)
 
 ## Installation
 
@@ -18,7 +19,9 @@ Add Lumen to the `plugin` array in your `opencode.json`:
 ```
 
 Restart OpenCode. The plugin registers a local `mcp.lumen` server that runs
-`scripts/run.cmd stdio` on all platforms.
+`node launcher.mjs stdio` on all platforms; the launcher resolves the
+matching native lumen binary per OS/arch and lazily fetches it from GitHub
+Releases on first use (subsequent runs are cache hits).
 
 ## Verify
 

--- a/.opencode/plugins/lumen.js
+++ b/.opencode/plugins/lumen.js
@@ -1,21 +1,71 @@
-import path from "path";
-import { fileURLToPath } from "url";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(__dirname, "../..");
-const runCommand = path.join(pluginRoot, "scripts", "run.cmd");
+const launcher = path.join(pluginRoot, "launcher.mjs");
+
+// Warm the binary cache before opencode spawns the MCP command. OpenCode's
+// MCP startup window is documented as 5 s and observed at 15–30 s in the
+// wild — short enough that a cold-cache GitHub Releases fetch can blow it.
+// Running prefetch here (synchronously, before config.mcp.lumen registers)
+// pushes the download into the plugin-load phase, so the eventual MCP
+// command spawn is a cache-hit fast path.
+//
+// Hard timeout cap: 90 s. Larger than the launcher's own 60 s HTTP idle
+// timeout so a legitimate slow download isn't truncated, but bounded so
+// a wedged launcher process can't hang opencode startup indefinitely.
+const PREFETCH_TIMEOUT_MS = 90 * 1000;
+
+async function prefetch() {
+  await new Promise((resolve) => {
+    const child = spawn(process.execPath, [launcher, "prefetch"], {
+      stdio: "inherit",
+    });
+    let resolved = false;
+    let timeoutTimer = null;
+    let escalateTimer = null;
+    const resolveOnce = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+    const onChildSettled = () => {
+      // Child is gone — cancel any pending escalation and resolve if not yet.
+      clearTimeout(timeoutTimer);
+      clearTimeout(escalateTimer);
+      resolveOnce();
+    };
+    timeoutTimer = setTimeout(() => {
+      // Don't block opencode startup waiting for a wedged child to die: send
+      // SIGTERM, schedule SIGKILL after a short window in case SIGTERM is
+      // ignored, and resolve the outer promise immediately so plugin load
+      // proceeds. The escalation continues in the background.
+      try {
+        child.kill("SIGTERM");
+      } catch {}
+      escalateTimer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {}
+      }, 500);
+      resolveOnce();
+    }, PREFETCH_TIMEOUT_MS);
+    child.on("exit", onChildSettled);
+    child.on("error", onChildSettled); // best-effort: don't block opencode startup on fetch failure
+  });
+}
 
 export const LumenPlugin = async () => {
+  await prefetch();
   return {
     config: async (config) => {
       config.mcp = config.mcp || {};
       if (!config.mcp.lumen) {
         config.mcp.lumen = {
           type: "local",
-          command:
-            process.platform === "win32"
-              ? ["cmd", "/c", runCommand, "stdio"]
-              : [runCommand, "stdio"],
+          command: [process.execPath, launcher, "stdio"],
           enabled: true,
         };
       }

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 git clone https://github.com/ory/lumen.git "$CODEX_HOME/lumen"
 mkdir -p "$HOME/.agents/skills"
 ln -s "$CODEX_HOME/lumen/skills" "$HOME/.agents/skills/lumen"
-codex mcp add lumen -- "$CODEX_HOME/lumen/scripts/run.sh" stdio
+codex mcp add lumen --startup-timeout-sec 60 -- node "$CODEX_HOME/lumen/launcher.mjs" stdio
 ```
 
 Detailed docs: [.codex/INSTALL.md](.codex/INSTALL.md)

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -3,7 +3,7 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.cmd hook session-start lumen --host cursor"
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/launcher.mjs\" hook session-start lumen --host cursor"
       }
     ]
   }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.cmd\" hook session-start lumen --host claude"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/launcher.mjs\" prefetch"
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/launcher.mjs\" hook session-start lumen --host claude"
           }
         ]
       }
@@ -17,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run.cmd\" hook pre-tool-use lumen"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/launcher.mjs\" hook pre-tool-use lumen"
           }
         ]
       }

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+// Package integration hosts native-spawn tests that mirror the consumer
+// invocation path used by Claude Code, Cursor, OpenCode, and Codex.
+// exec.Command on Unix calls posix_spawn(2); on Windows it calls
+// CreateProcessW. No shell is in the loop — any byte-0 / shebang / extension
+// regression in the launcher chain fails these tests deterministically.
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRoot locates the repository root by walking up from this test file
+// until it finds go.mod. Tests live at internal/integration/, so the answer
+// is two levels up — but we walk dynamically to be robust to relocation.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(here)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above test file")
+		}
+		dir = parent
+	}
+}
+
+// launcherPath returns the absolute path to launcher.mjs at the repo root.
+// Skips the test if launcher.mjs is missing — signals an incomplete checkout
+// rather than a real regression.
+func launcherPath(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(repoRoot(t), "launcher.mjs")
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("launcher.mjs not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// lookupBuiltBinary returns the path to a pre-built lumen binary for the
+// current OS/arch. Resolution order:
+//  1. $LUMEN_BIN_PATH (CI integration job sets this to the artifact downloaded
+//     from build / build-windows-cross).
+//  2. <repoRoot>/bin/lumen[.exe] (matches `make build-local` output).
+//
+// Skips the test (rather than failing) when no binary is present, so a fresh
+// checkout without a build doesn't produce confusing test failures.
+func lookupBuiltBinary(t *testing.T) string {
+	t.Helper()
+	if env := os.Getenv("LUMEN_BIN_PATH"); env != "" {
+		if _, err := os.Stat(env); err == nil {
+			return env
+		}
+		t.Fatalf("$LUMEN_BIN_PATH set to %q but file is missing", env)
+	}
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+	p := filepath.Join(repoRoot(t), "bin", "lumen"+ext)
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("no built binary at %s and $LUMEN_BIN_PATH unset; build via `make build-local` or set the env var", p)
+	}
+	return p
+}
+
+// nodePath looks up the Node binary the launcher will be invoked through.
+// Skips the test if Node is not in PATH, since the launcher is JS.
+func nodePath(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("node")
+	if err != nil {
+		t.Skipf("node not in PATH: %v", err)
+	}
+	return p
+}
+
+// sandboxTempDir returns an isolated temp dir whose cleanup tolerates
+// Windows file-locking errors. The SessionStart hook spawns a detached
+// background indexer (cmd/hook_spawn_windows.go) that opens debug.log and
+// index.db; on Windows those files cannot be unlinked while handles are
+// open, which makes t.TempDir() cleanup fail and mark the test FAIL even
+// though the test logic succeeded. Best-effort RemoveAll + log-on-error
+// preserves test correctness; CI runner resets sweep any residue.
+func sandboxTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "lumen-integration-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("sandbox cleanup non-fatal error (likely Windows handle held by background indexer): %v", err)
+		}
+	})
+	return dir
+}
+
+// sandboxEnv returns an env slice that points lumen at temp directories for
+// HOME / XDG_DATA_HOME / CLAUDE_PLUGIN_DATA so the runner's real lumen state
+// is untouched. PATH is preserved so node (and its children) can resolve.
+// LUMEN_BIN_PATH is forwarded so launcher.mjs uses the pre-built binary.
+func sandboxEnv(t *testing.T) []string {
+	t.Helper()
+	tmp := sandboxTempDir(t)
+	env := []string{
+		"HOME=" + tmp,
+		"XDG_DATA_HOME=" + tmp,
+		"XDG_CONFIG_HOME=" + tmp,
+		"XDG_CACHE_HOME=" + tmp,
+		"CLAUDE_PLUGIN_DATA=" + tmp,
+		"PATH=" + os.Getenv("PATH"),
+		"LUMEN_BIN_PATH=" + lookupBuiltBinary(t),
+	}
+	// Windows needs SystemRoot, USERPROFILE, etc. for CreateProcess /
+	// runtime initialization. Forward what the parent has — without these,
+	// node and the spawned binary may fail to start.
+	if runtime.GOOS == "windows" {
+		for _, k := range []string{"SystemRoot", "SYSTEMROOT", "USERPROFILE", "TEMP", "TMP", "LOCALAPPDATA", "APPDATA", "PROGRAMFILES", "ProgramFiles", "ComSpec"} {
+			if v := os.Getenv(k); v != "" {
+				env = append(env, k+"="+v)
+			}
+		}
+	}
+	return env
+}

--- a/internal/integration/launcher_prefetch_test.go
+++ b/internal/integration/launcher_prefetch_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ensureNetwork verifies the test runner can reach github.com over HTTPS.
+// Skips the test (with a clear reason) if the network is unavailable, so
+// offline local runs and air-gapped CI shards don't produce false negatives.
+func ensureNetwork(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "HEAD", "https://github.com", nil)
+	if err != nil {
+		t.Fatalf("build network probe request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Skipf("github.com unreachable (offline?): %v", err)
+	}
+	resp.Body.Close()
+}
+
+// isolatedLauncher returns the path to a copy of launcher.mjs in a fresh
+// temp dir whose layout does NOT contain a bin/ subdirectory. The launcher's
+// developer fast path is `<here>/bin/lumen[.exe]`; tests that need to
+// exercise the lazy-fetch + cache path must avoid that fast path. Copying
+// to a clean dir is the most portable way (Windows symlinks need admin).
+func isolatedLauncher(t *testing.T) string {
+	t.Helper()
+	dir := sandboxTempDir(t)
+	root := repoRoot(t)
+	for _, name := range []string{"launcher.mjs", ".release-please-manifest.json"} {
+		src := filepath.Join(root, name)
+		dst := filepath.Join(dir, name)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatalf("read %s: %v", src, err)
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", dst, err)
+		}
+	}
+	return filepath.Join(dir, "launcher.mjs")
+}
+
+// readManifestVersion extracts the pinned version from .release-please-manifest.json
+// the same way launcher.mjs does, so tests stay in lockstep with runtime behavior.
+func readManifestVersion(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), ".release-please-manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	v := m["."]
+	if v == "" {
+		t.Fatalf("manifest has no '.' key: %s", raw)
+	}
+	return v
+}
+
+// expectedAssetName returns the goreleaser-style filename of the binary for
+// the running test runner: lumen-<version>-<goos>-<goarch>[.exe].
+func expectedAssetName(version string) string {
+	ext := ""
+	if runtime.GOOS == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("lumen-%s-%s-%s%s", version, runtime.GOOS, runtime.GOARCH, ext)
+}
+
+// expectedCachedPath mirrors launcher.mjs cachedBinaryPath() under
+// CLAUDE_PLUGIN_DATA = cacheParent.
+func expectedCachedPath(cacheParent, version string) string {
+	return filepath.Join(cacheParent, "lumen", "bin", version, expectedAssetName(version))
+}
+
+// sha256File returns the hex-encoded SHA-256 of the file at p.
+func sha256File(t *testing.T, p string) string {
+	t.Helper()
+	f, err := os.Open(p)
+	if err != nil {
+		t.Fatalf("open %s: %v", p, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatalf("hash %s: %v", p, err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// fetchExpectedChecksum downloads the matching line from the release's
+// checksums.txt. Mirrors launcher.mjs parseChecksum behavior for the
+// runtime's goos/goarch.
+func fetchExpectedChecksum(t *testing.T, version, asset string) string {
+	t.Helper()
+	url := fmt.Sprintf("https://github.com/ory/lumen/releases/download/v%s/checksums.txt", version)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		t.Fatalf("build checksums request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("fetch checksums: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("checksums fetch %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read checksums body: %v", err)
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		f := strings.Fields(strings.TrimSpace(line))
+		if len(f) >= 2 && f[1] == asset {
+			return f[0]
+		}
+	}
+	t.Fatalf("no checksum for %s in %s", asset, url)
+	return ""
+}
+
+// prefetchEnv returns a process env with PATH preserved and CLAUDE_PLUGIN_DATA
+// pointed at the supplied cache parent, but explicitly without LUMEN_BIN_PATH
+// so the launcher's lazy-fetch path is exercised.
+func prefetchEnv(t *testing.T, cacheParent string) []string {
+	t.Helper()
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"CLAUDE_PLUGIN_DATA=" + cacheParent,
+		"LUMEN_LAUNCHER_VERBOSE=1",
+	}
+	if runtime.GOOS == "windows" {
+		for _, k := range []string{"SystemRoot", "SYSTEMROOT", "USERPROFILE", "TEMP", "TMP", "LOCALAPPDATA", "APPDATA", "ProgramFiles", "ComSpec"} {
+			if v := os.Getenv(k); v != "" {
+				env = append(env, k+"="+v)
+			}
+		}
+	}
+	return env
+}
+
+// TestLauncherPrefetch downloads the matching release asset, verifies SHA-256,
+// caches it, and confirms a second invocation is a cache hit (no re-download).
+func TestLauncherPrefetch(t *testing.T) {
+	ensureNetwork(t)
+	launcher := isolatedLauncher(t)
+	cacheParent := sandboxTempDir(t)
+	version := readManifestVersion(t)
+	asset := expectedAssetName(version)
+	binPath := expectedCachedPath(cacheParent, version)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, nodePath(t), launcher, "prefetch")
+	cmd.Env = prefetchEnv(t, cacheParent)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("prefetch failed: %v\noutput: %s", err, out)
+	}
+
+	info, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatalf("binary missing at %s: %v", binPath, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		t.Fatalf("binary at %s is not executable: mode=%v", binPath, info.Mode())
+	}
+
+	expectedSHA := fetchExpectedChecksum(t, version, asset)
+	if got := sha256File(t, binPath); got != expectedSHA {
+		t.Fatalf("checksum mismatch for cached binary: got %s, expected %s", got, expectedSHA)
+	}
+
+	// Lock file should be cleaned up after a successful run.
+	lockPath := filepath.Join(cacheParent, "lumen", ".lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock file lingered at %s after prefetch (err=%v)", lockPath, err)
+	}
+
+	// Re-run: cache hit. Compare mtime to ensure the file was not rewritten.
+	mtimeBefore := info.ModTime()
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+	cmd2 := exec.CommandContext(ctx2, nodePath(t), launcher, "prefetch")
+	cmd2.Env = prefetchEnv(t, cacheParent)
+	if out, err := cmd2.CombinedOutput(); err != nil {
+		t.Fatalf("second prefetch failed: %v\noutput: %s", err, out)
+	}
+	info2, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatalf("binary disappeared after second run: %v", err)
+	}
+	if !info2.ModTime().Equal(mtimeBefore) {
+		t.Fatalf("cache miss on second run (mtime changed: %v → %v)", mtimeBefore, info2.ModTime())
+	}
+}
+
+// TestLauncherConcurrentPrefetch runs three prefetch processes simultaneously
+// against a shared cache dir. The file lock must serialize the download:
+// exactly one process performs the network fetch, the others see a cache hit
+// after the lock releases. All three exit 0; the final file checksum is valid.
+func TestLauncherConcurrentPrefetch(t *testing.T) {
+	ensureNetwork(t)
+	launcher := isolatedLauncher(t)
+	cacheParent := sandboxTempDir(t)
+	version := readManifestVersion(t)
+	asset := expectedAssetName(version)
+	binPath := expectedCachedPath(cacheParent, version)
+
+	const N = 3
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	start := make(chan struct{})
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, nodePath(t), launcher, "prefetch")
+			cmd.Env = prefetchEnv(t, cacheParent)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				errs <- fmt.Errorf("prefetch failed: %v\noutput: %s", err, out)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for e := range errs {
+		t.Fatalf("concurrent prefetch error: %v", e)
+	}
+
+	if _, err := os.Stat(binPath); err != nil {
+		t.Fatalf("binary missing at %s after concurrent prefetch: %v", binPath, err)
+	}
+	expectedSHA := fetchExpectedChecksum(t, version, asset)
+	if got := sha256File(t, binPath); got != expectedSHA {
+		t.Fatalf("checksum mismatch after concurrent prefetch: got %s, expected %s", got, expectedSHA)
+	}
+
+	// Lock should be released; partial files should not linger.
+	lockPath := filepath.Join(cacheParent, "lumen", ".lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock file lingered at %s (err=%v)", lockPath, err)
+	}
+	if _, err := os.Stat(binPath + ".partial"); !os.IsNotExist(err) {
+		t.Fatalf("partial download file lingered (err=%v)", err)
+	}
+}
+
+// TestLauncherChecksumMismatch corrupts a release URL by pointing at a
+// non-matching checksum, asserting the launcher refuses to run and exits
+// non-zero. We can't easily man-in-the-middle the real GitHub Releases, so
+// this test creates a dummy cache entry with a wrong checksum and confirms
+// re-verification on subsequent runs (the prefetch path can't be tampered
+// from outside Node, so we rely on the existing checksum verification
+// being exercised by the happy path tests above).
+//
+// Skipped here as a placeholder; the SHA-256 verification correctness is
+// indirectly verified by TestLauncherPrefetch reading the cached file and
+// checking it against the same checksums.txt the launcher consulted.
+func TestLauncherChecksumVerificationPath(t *testing.T) {
+	t.Skip("checksum-mismatch flow is exercised by reviewing launcher.mjs " +
+		"and cross-verified by TestLauncherPrefetch; an MITM-style negative " +
+		"test requires a local mock server (deferred)")
+}

--- a/internal/integration/launcher_spawn_test.go
+++ b/internal/integration/launcher_spawn_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestLauncherSpawnStdioHandshake spawns `node launcher.mjs stdio` via
+// exec.Command (no shell) and runs the MCP initialize handshake. Validates
+// that the launcher chain — Node -> launcher.mjs -> lumen binary -> MCP
+// stdio server — produces a clean JSON-RPC stream with no leading garbage.
+//
+// This is the regression gate the proposal calls for: any byte-0 / shebang /
+// shell-fragment regression that the polyglot kept hitting fails this test
+// deterministically because exec.Command bypasses shell entirely.
+func TestLauncherSpawnStdioHandshake(t *testing.T) {
+	cmd := exec.Command(nodePath(t), launcherPath(t), "stdio")
+	cmd.Env = sandboxEnv(t)
+
+	transport := &mcp.CommandTransport{Command: cmd}
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "integration-spawn-test",
+		Version: "0.1.0",
+	}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("MCP initialize handshake failed: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+}
+
+// TestLauncherSpawnHookSessionStart spawns the SessionStart hook subcommand
+// via the launcher and verifies it produces a valid JSON object on stdout
+// with a clean exit. Mirrors the invocation pattern in hooks/hooks.json and
+// hooks/hooks-cursor.json after Phase 2 migrates them off run.cmd.
+func TestLauncherSpawnHookSessionStart(t *testing.T) {
+	for _, host := range []string{"claude", "cursor"} {
+		t.Run(host, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			cmd := exec.CommandContext(ctx,
+				nodePath(t), launcherPath(t),
+				"hook", "session-start", "lumen", "--host", host,
+			)
+			cmd.Env = sandboxEnv(t)
+			// Hook reads optional JSON from stdin ({"cwd":"..."}); empty input is fine —
+			// the handler falls back to os.Getwd().
+			cmd.Stdin = bytes.NewReader(nil)
+
+			stdout, err := cmd.Output()
+			if err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					t.Fatalf("hook session-start (host=%s) exited %d: stderr=%s", host, ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
+				}
+				t.Fatalf("hook session-start (host=%s) failed: %v", host, err)
+			}
+
+			// Output must be a single, parseable JSON object — proves no shell
+			// echo / shebang noise leaked into stdout.
+			trimmed := bytes.TrimSpace(stdout)
+			var payload map[string]any
+			if err := json.Unmarshal(trimmed, &payload); err != nil {
+				t.Fatalf("hook session-start (host=%s) stdout is not valid JSON: %v\nstdout=%q", host, err, stdout)
+			}
+			if len(payload) == 0 {
+				t.Fatalf("hook session-start (host=%s) returned empty JSON object", host)
+			}
+		})
+	}
+}
+
+// TestLauncherSpawnHookPreToolUse exercises the second hook subcommand wired
+// into hooks/hooks.json. Pre-tool-use exits cleanly without producing JSON
+// when there's nothing to intercept (it reads tool_input from stdin).
+func TestLauncherSpawnHookPreToolUse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		nodePath(t), launcherPath(t),
+		"hook", "pre-tool-use", "lumen",
+	)
+	cmd.Env = sandboxEnv(t)
+	cmd.Stdin = bytes.NewReader(nil)
+
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("hook pre-tool-use exited %d: stderr=%s", ee.ExitCode(), strings.TrimSpace(string(ee.Stderr)))
+		}
+		t.Fatalf("hook pre-tool-use failed: %v", err)
+	}
+}

--- a/launcher.mjs
+++ b/launcher.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Spawns the lumen native binary matching the host OS/arch and forwards
+// stdin/stdout/stderr + exit code. Replaces the scripts/run.{sh,bat,cmd}
+// polyglot launcher. This Phase 1 file is intentionally minimal: it only
+// resolves a binary already present at <pluginRoot>/bin/ (or via the
+// LUMEN_BIN_PATH env override). Lazy fetch from GitHub Releases, SHA-256
+// checksum verification, file lock, and per-host cache resolution land in
+// Phase 2.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const ext = process.platform === "win32" ? ".exe" : "";
+
+function findBinary() {
+  // Explicit override — used by integration tests and (future) Phase 2 cache
+  // resolution that wants to bypass the search.
+  if (process.env.LUMEN_BIN_PATH) {
+    return process.env.LUMEN_BIN_PATH;
+  }
+  const candidates = [
+    path.join(here, "bin", `lumen${ext}`),
+    path.join(here, "bin", `lumen-${process.platform}-${process.arch}${ext}`),
+  ];
+  for (const c of candidates) {
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {
+      // not present, try next
+    }
+  }
+  return null;
+}
+
+const bin = findBinary();
+if (!bin) {
+  process.stderr.write(
+    `lumen launcher: no binary found. Set LUMEN_BIN_PATH or build with \`make build-local\`.\n`,
+  );
+  process.exit(127);
+}
+
+const child = spawn(bin, process.argv.slice(2), { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});

--- a/launcher.mjs
+++ b/launcher.mjs
@@ -1,54 +1,345 @@
 #!/usr/bin/env node
-// Spawns the lumen native binary matching the host OS/arch and forwards
-// stdin/stdout/stderr + exit code. Replaces the scripts/run.{sh,bat,cmd}
-// polyglot launcher. This Phase 1 file is intentionally minimal: it only
-// resolves a binary already present at <pluginRoot>/bin/ (or via the
-// LUMEN_BIN_PATH env override). Lazy fetch from GitHub Releases, SHA-256
-// checksum verification, file lock, and per-host cache resolution land in
-// Phase 2.
+// Spawns the lumen native binary matching the host OS/arch, lazy-fetching it
+// from GitHub Releases on first use into a per-host cache. Replaces the
+// scripts/run.{sh,bat,cmd} polyglot.
+//
+// Resolution order for the binary:
+//   1. $LUMEN_BIN_PATH                            — explicit override
+//   2. <pluginRoot>/bin/lumen[.exe]               — `make build-local` output
+//   3. <cacheDir>/bin/<version>/lumen-<version>-<os>-<arch>[.exe]
+//                                                 — lazy-fetched + SHA-256-verified
+//
+// Cache dir resolution chain: $CLAUDE_PLUGIN_DATA → $CURSOR_PLUGIN_DATA →
+// $XDG_DATA_HOME (Unix) / $LOCALAPPDATA (Windows) → ~/.local/share / tmpdir.
+//
+// Subcommand `prefetch` runs the cache-population flow then exits 0; used by
+// SessionStart hooks (Claude Code) and the OpenCode plugin entry to warm
+// the cache before the MCP server is invoked, working around tight
+// startup-handshake timeouts on OpenCode (5 s) and Codex (10 s default).
 
 import { spawn } from "node:child_process";
-import fs from "node:fs";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import { readFile } from "node:fs/promises";
+import { request as httpsRequest } from "node:https";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+
+const REPO = "ory/lumen";
+// 15 min covers a 30 MB download even at trickle speeds (~30 KB/s) before
+// another prefetch process treats the lock as stale and races the writer.
+const STALE_LOCK_MS = 15 * 60 * 1000;
+// Per-socket inactivity timeout. Kills the connection if no data has flowed
+// for HTTP_IDLE_MS — guards against hung connections, ISP throttling, and
+// CDN mid-stream stalls. Active downloads keep flowing data so this never
+// fires for healthy fetches.
+const HTTP_IDLE_MS = 60 * 1000;
+const VERBOSE = process.env.LUMEN_LAUNCHER_VERBOSE === "1";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const ext = process.platform === "win32" ? ".exe" : "";
 
-function findBinary() {
-  // Explicit override — used by integration tests and (future) Phase 2 cache
-  // resolution that wants to bypass the search.
-  if (process.env.LUMEN_BIN_PATH) {
-    return process.env.LUMEN_BIN_PATH;
+function log(...args) {
+  if (VERBOSE) process.stderr.write(`[lumen-launcher] ${args.join(" ")}\n`);
+}
+function fatal(msg, code = 1) {
+  process.stderr.write(`lumen launcher: ${msg}\n`);
+  process.exit(code);
+}
+
+async function readVersion() {
+  const manifestPath = path.join(here, ".release-please-manifest.json");
+  const raw = await readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(raw);
+  const version = manifest["."];
+  if (!version || !/^\d/.test(version)) {
+    throw new Error(
+      `unexpected ${manifestPath} content: ${JSON.stringify(manifest)}`,
+    );
   }
-  const candidates = [
-    path.join(here, "bin", `lumen${ext}`),
-    path.join(here, "bin", `lumen-${process.platform}-${process.arch}${ext}`),
-  ];
-  for (const c of candidates) {
-    try {
-      fs.accessSync(c, fs.constants.X_OK);
-      return c;
-    } catch {
-      // not present, try next
+  return version;
+}
+
+function resolveCacheDir() {
+  for (const env of ["CLAUDE_PLUGIN_DATA", "CURSOR_PLUGIN_DATA"]) {
+    if (process.env[env]) return path.join(process.env[env], "lumen");
+  }
+  if (process.platform === "win32") {
+    if (process.env.LOCALAPPDATA) {
+      return path.join(process.env.LOCALAPPDATA, "lumen");
     }
+  } else {
+    if (process.env.XDG_DATA_HOME) {
+      return path.join(process.env.XDG_DATA_HOME, "lumen");
+    }
+    return path.join(homedir(), ".local", "share", "lumen");
+  }
+  return path.join(tmpdir(), "lumen-cache");
+}
+
+// Node's process.platform / process.arch (darwin/win32, x64/arm64) differs
+// from Go's GOOS / GOARCH (darwin/windows, amd64/arm64) used by goreleaser
+// when naming release artifacts. Map between them.
+function goos() {
+  return { darwin: "darwin", linux: "linux", win32: "windows" }[process.platform] ?? process.platform;
+}
+function goarch() {
+  return { x64: "amd64", arm64: "arm64", ia32: "386" }[process.arch] ?? process.arch;
+}
+
+function assetName(version) {
+  return `lumen-${version}-${goos()}-${goarch()}${ext}`;
+}
+
+function cachedBinaryPath(cacheDir, version) {
+  return path.join(cacheDir, "bin", version, assetName(version));
+}
+
+// Follows redirects up to 5 hops; resolves with the IncomingMessage on 200,
+// rejects on error or non-2xx. Per-socket inactivity timeout fires on
+// hung connect, ISP throttling, or CDN mid-stream stalls (no data for
+// HTTP_IDLE_MS).
+function httpsGet(url, hops = 0) {
+  return new Promise((resolve, reject) => {
+    if (hops > 5) return reject(new Error("too many redirects"));
+    const req = httpsRequest(
+      url,
+      {
+        method: "GET",
+        headers: { "User-Agent": "lumen-launcher" },
+        timeout: HTTP_IDLE_MS,
+      },
+      (res) => {
+        const code = res.statusCode || 0;
+        if (code >= 300 && code < 400 && res.headers.location) {
+          res.destroy();
+          resolve(
+            httpsGet(new URL(res.headers.location, url).toString(), hops + 1),
+          );
+          return;
+        }
+        if (code !== 200) {
+          res.destroy();
+          reject(new Error(`HTTP ${code} for ${url}`));
+          return;
+        }
+        // Idle-timeout the response stream too; req.timeout only covers
+        // pre-headers, while a stalled body stream blocks downloadAndVerify.
+        res.setTimeout(HTTP_IDLE_MS, () => {
+          res.destroy(new Error(`response idle timeout for ${url}`));
+        });
+        resolve(res);
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error(`request timeout for ${url}`));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function fetchText(url) {
+  const res = await httpsGet(url);
+  let buf = "";
+  for await (const chunk of res) buf += chunk;
+  return buf;
+}
+
+function parseChecksum(text, fileName) {
+  // goreleaser checksums.txt: "<sha256>  <filename>" per line
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const m = line.match(/^([0-9a-f]{64})\s+(.+)$/);
+    if (m && m[2] === fileName) return m[1];
   }
   return null;
 }
 
-const bin = findBinary();
-if (!bin) {
-  process.stderr.write(
-    `lumen launcher: no binary found. Set LUMEN_BIN_PATH or build with \`make build-local\`.\n`,
-  );
-  process.exit(127);
+async function downloadAndVerify(url, expectedSha256, destPath) {
+  const tmpPath = `${destPath}.partial`;
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  const res = await httpsGet(url);
+  const hash = createHash("sha256");
+  try {
+    await new Promise((resolve, reject) => {
+      const out = fs.createWriteStream(tmpPath);
+      const fail = (err) => {
+        res.destroy();
+        out.destroy();
+        reject(err);
+      };
+      res.on("data", (chunk) => hash.update(chunk));
+      res.on("error", fail);
+      out.on("error", fail);
+      out.on("finish", resolve);
+      res.pipe(out);
+    });
+  } catch (e) {
+    // Mid-stream network reset / idle-timeout / write error — drop the
+    // partial file so the next run starts clean instead of relying on
+    // createWriteStream's truncate-on-open.
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {}
+    throw e;
+  }
+  const actual = hash.digest("hex");
+  if (actual !== expectedSha256) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {}
+    throw new Error(
+      `SHA-256 mismatch for ${path.basename(destPath)}: expected ${expectedSha256}, got ${actual}`,
+    );
+  }
+  fs.chmodSync(tmpPath, 0o755);
+  fs.renameSync(tmpPath, destPath);
 }
 
-const child = spawn(bin, process.argv.slice(2), { stdio: "inherit" });
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-  } else {
-    process.exit(code ?? 0);
+async function withLock(lockPath, fn) {
+  const start = Date.now();
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  while (true) {
+    try {
+      // 'wx' is atomic-create-fail-if-exists on both POSIX and Windows.
+      const fd = fs.openSync(lockPath, "wx");
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } finally {
+        fs.closeSync(fd);
+      }
+      try {
+        return await fn();
+      } finally {
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {}
+      }
+    } catch (e) {
+      if (e.code !== "EEXIST") throw e;
+    }
+    // Held — check staleness, reclaim, or wait briefly and retry.
+    try {
+      const st = fs.statSync(lockPath);
+      if (Date.now() - st.mtimeMs > STALE_LOCK_MS) {
+        log(`reclaiming stale lock at ${lockPath}`);
+        try {
+          fs.unlinkSync(lockPath);
+        } catch {}
+        continue;
+      }
+    } catch (e) {
+      // ENOENT: file disappeared between EEXIST and stat (POSIX race).
+      // EPERM: Windows transient state while another process is unlinking
+      // the lock — Windows file-sharing semantics differ from POSIX and
+      // briefly surface stat as not-permitted. Both mean "lock is gone";
+      // retry the openSync to claim it.
+      if (e.code === "ENOENT" || e.code === "EPERM") continue;
+      throw e;
+    }
+    if (Date.now() - start > STALE_LOCK_MS) {
+      throw new Error(`timeout waiting for lock at ${lockPath}`);
+    }
+    await sleep(200);
   }
-});
+}
+
+async function ensureBinary() {
+  if (process.env.LUMEN_BIN_PATH) return process.env.LUMEN_BIN_PATH;
+
+  // Developer fast path: `make build-local` writes here.
+  const dev = path.join(here, "bin", `lumen${ext}`);
+  try {
+    fs.accessSync(dev, fs.constants.X_OK);
+    return dev;
+  } catch {}
+
+  const version = await readVersion();
+  const cacheDir = resolveCacheDir();
+  const binPath = cachedBinaryPath(cacheDir, version);
+
+  try {
+    fs.accessSync(binPath, fs.constants.X_OK);
+    return binPath;
+  } catch {}
+
+  const lockPath = path.join(cacheDir, ".lock");
+  await withLock(lockPath, async () => {
+    // Re-check under lock — another process may have completed it while we waited.
+    try {
+      fs.accessSync(binPath, fs.constants.X_OK);
+      return;
+    } catch {}
+    log(`fetching lumen ${version} for ${process.platform}-${process.arch}`);
+    const releaseURL = `https://github.com/${REPO}/releases/download/v${version}`;
+    const aName = assetName(version);
+    const checksums = await fetchText(`${releaseURL}/checksums.txt`);
+    const expected = parseChecksum(checksums, aName);
+    if (!expected) {
+      throw new Error(
+        `no SHA-256 for ${aName} in ${releaseURL}/checksums.txt`,
+      );
+    }
+    await downloadAndVerify(`${releaseURL}/${aName}`, expected, binPath);
+    log(`installed lumen at ${binPath}`);
+  });
+  return binPath;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let bin;
+  try {
+    bin = await ensureBinary();
+  } catch (e) {
+    fatal(`failed to locate or fetch lumen binary: ${e.message}`, 2);
+  }
+  if (args[0] === "prefetch") {
+    process.exit(0);
+  }
+  const child = spawn(bin, args, { stdio: "inherit" });
+
+  // Forward SIGINT/SIGTERM/SIGHUP/SIGQUIT to the child so signals delivered
+  // only to the launcher PID (e.g. supervisor SIGTERM, IDE-driven shutdown,
+  // `kill <pid>`) don't orphan the lumen process — which would leak its
+  // sqlite advisory lock and keep its background indexer alive.
+  // Windows process model has no equivalent — only SIGINT/SIGBREAK are
+  // really meaningful and Node treats child.kill on win32 as TerminateProcess.
+  const forwardable =
+    process.platform === "win32" ? [] : ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"];
+  const onSignal = (sig) => {
+    try {
+      child.kill(sig);
+    } catch {}
+  };
+  for (const sig of forwardable) process.on(sig, onSignal);
+
+  // Both 'error' (failed to spawn) and 'exit' (child terminated) can fire;
+  // the previous handlers double-called process.exit / fatal. Settle once.
+  let settled = false;
+  const settle = (fn) => {
+    if (settled) return;
+    settled = true;
+    for (const sig of forwardable) process.off(sig, onSignal);
+    fn();
+  };
+
+  child.on("error", (err) => {
+    settle(() => fatal(`failed to spawn binary: ${err.message}`, 126));
+  });
+  child.on("exit", (code, signal) => {
+    settle(() => {
+      if (signal && process.platform !== "win32") {
+        process.kill(process.pid, signal);
+      } else {
+        process.exit(code ?? (signal ? 1 : 0));
+      }
+    });
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary

Migrates every host's `mcpServers` / hooks command from `scripts/run.cmd` (the polyglot whose byte-0 conflict caused #152 and the same regression class superpowers cycled through three patches for) to `node ${PLUGIN_ROOT}/launcher.mjs`.

This is **Phase 2**, building on the Phase 1 native-spawn integration test gate in #153. After this PR no live code path reaches `scripts/run.cmd`; the polyglot remains in the tree as dead code through the soak window before a separate follow-up PR deletes it.

Fixes #152.

## Why a Node launcher (industry context)

Three data points show the polyglot pattern is structurally fragile:

- **obra/superpowers** — the most-watched Claude Code plugin reference implementation — patched the same byte-0 conflict three different ways across v4.3.0 → v4.3.1 → v4.3.2+ ([obra/superpowers#529](https://github.com/obra/superpowers/issues/529)).
- **Anthropic's marketplace tracker** records the pattern as recurring in [anthropics/claude-plugins-official#1692](https://github.com/anthropics/claude-plugins-official/issues/1692), citing superpowers' history as the canonical example.
- **lumen** has hit this regression class twice in two months (#121 era and #152), each time trading one OS's regression for another's.

The byte 0 of a single file can be exactly one of `#`, `:`, or `@` — mutually exclusive. No polyglot byte 0 satisfies POSIX `posix_spawn`, Windows `cmd.exe` extension dispatch, and shell parsing all at once. Eliminating the polyglot is the only structural fix.

A small Node launcher resolves the OS dispatch in JavaScript and spawns the matching native binary. JS handles platform branching; no shell sits in the loop; the byte-0 conflict goes away. This shares the launcher-resolves-OS-and-spawns-binary shape with `@anthropic-ai/claude-code` itself, which preinstalls per-platform binaries via npm `optionalDependencies` rather than lazy-fetching them at first run — the launcher half is the structural-fix common ground; the distribution mechanism (lazy fetch vs preinstall) is the part lumen could migrate to later if you'd prefer.

## What launcher.mjs does

- **Resolution chain:** `$LUMEN_BIN_PATH` → `<pluginRoot>/bin/lumen[.exe]` (developer fast path from `make build-local`) → `<cacheDir>/bin/<version>/lumen-<version>-<goos>-<goarch>[.exe]` (lazy fetch).
- **Cache dir chain:** `$CLAUDE_PLUGIN_DATA` → `$CURSOR_PLUGIN_DATA` → `$XDG_DATA_HOME` (Unix) / `$LOCALAPPDATA` (Windows) → `~/.local/share` / `os.tmpdir()` last resort.
- **Lazy fetch from GitHub Releases** with redirect-following HTTPS. `checksums.txt` is parsed and SHA-256 verified before atomic rename — non-zero exit on mismatch.
- **File lock at `<cacheDir>/.lock`** (15-min stale recovery) serializes concurrent first-runs. Tolerates Windows `EPERM` transient state during another process's unlink.
- **Per-socket idle timeout (60 s)** on both request and response streams — hung connections / mid-stream stalls error out instead of blocking the launcher and any host waiting on its handshake.
- **Node platform/arch ↔ Go GOOS/GOARCH mapping** (`darwin/x64` → `darwin/amd64` etc.) so asset names match goreleaser.
- **`prefetch` subcommand** for cache-warming hooks.
- **`$LUMEN_LAUNCHER_VERBOSE`** enables stderr diagnostics.
- ~280 lines, Node stdlib only, zero third-party dependencies.

## Per-host migration

| Host | Change |
|---|---|
| Claude Code (`mcpServers` + hooks) | `command: "node"`, args → `[${CLAUDE_PLUGIN_ROOT}/launcher.mjs, …]`. SessionStart hook now runs `prefetch` then `session-start`, warming the cache before the MCP first invocation. |
| Cursor (`mcp.json` + hooks) | `command: "node"`, args → launcher path. |
| OpenCode (`.opencode/plugins/lumen.js`) | spawn target → `[process.execPath, launcher, …]`. New `prefetch()` runs synchronously before `config.mcp.lumen` registration with a 90 s hard timeout cap, sidestepping OpenCode's tight 5 s MCP startup window for cold-cache fetches. |
| Codex (`.codex/INSTALL.md`) | `codex mcp add lumen --startup-timeout-sec 60 -- node "$CODEX_HOME/lumen/launcher.mjs" stdio`. Documents Node 18+ prerequisite, PATH-visibility troubleshooting (codex#6243), config.toml persistence, manual prefetch warm-up, and cache directory location for clean uninstalls. |

`README.md`, `.opencode/INSTALL.md`, `.cursor-plugin/INSTALL.md` updated likewise.

## What this PR does NOT do

- Delete `scripts/run.{cmd,sh,bat}` and their tests — waits for soak window (separate follow-up PR).
- npm `optionalDependencies` migration for `@ory/lumen-opencode` — separate effort, requires distribution-packaging decisions.

## Verification

### CI

Both fork PRs (Phase 1 mirror and this PR's mirror) green across the full matrix: Build (ubuntu / macos / windows-amd64 cross), Test, Lint, E2E, **Integration (ubuntu / macos / windows)**, plus the existing polyglot Script tests as defensive soak coverage.

### Local

Tested via `claude --plugin-dir <repo>` on:

- **Windows 11 25H2 26200.7462**
- **macOS Tahoe 26.4.1**
- **Ubuntu 24.04.4 LTS (arm)**

MCP execution worked correctly on all three; the SessionStart hook ran cleanly, MCP `initialize` handshake completed, and lumen tools were callable.

### Cold-cache lazy-fetch path

Manually verified by removing the developer binary and the existing cache, then running `node launcher.mjs prefetch`. Launcher fetched the v0.0.39 release asset, SHA-256-verified against `checksums.txt`, and placed the binary at `<cacheDir>/bin/0.0.39/...`. Re-invocation was a sub-100 ms cache hit.

## Depends on

- #153 (Phase 1: native-spawn integration test gate). Once #153 lands, this PR rebases to a single-commit diff against `main`. If #153 is merged via *squash-and-merge*, the resulting commit hash differs from `0581c5b` and this PR will conflict on `launcher.mjs` / `internal/integration/` / `.github/workflows/ci.yml` — happy to rebase once that's landed; just flag your preferred merge style and I'll align.

Fixes #152.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a Node-based cross-platform launcher that lazily fetches, caches, verifies, and runs platform-specific binaries with robust spawn and signal handling.
  * Adds a non-blocking "prefetch" step to warm the binary cache.

* **Documentation**
  * Updated install and troubleshooting guidance: required Node version, cache locations, pre-warm step, and recommended startup timeouts.

* **CI**
  * New artifact-based build handoff and integration test stage.

* **Tests**
  * Added integration tests for prefetch, concurrent prefetch, spawn behavior, and hook interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->