### PR TITLE
fix(mcp): Revert recent changes and route Claude Code/Cursor manifests through Node launcher

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,8 +19,9 @@
   ],
   "mcpServers": {
     "lumen": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run.cmd",
+      "command": "node",
       "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/run.cjs",
         "stdio"
       ]
     }

--- a/.cursor-plugin/INSTALL.md
+++ b/.cursor-plugin/INSTALL.md
@@ -8,7 +8,8 @@ Lumen ships a native Cursor plugin bundle in this repository.
 - `.cursor/mcp.json` - local `lumen` MCP server wiring
 - `hooks/hooks-cursor.json` - SessionStart hook
 - `skills/` - shared `doctor` and `reindex` skills
-- `scripts/run.cmd` - cross-platform launcher used by the MCP server and hooks
+- `scripts/run.cjs` - Node-based MCP launcher (manifest entry)
+- `scripts/run.cmd` - polyglot launcher used by hooks (and as a backward-compat fallback)
 
 ## Installation
 

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "lumen": {
-      "command": "${CURSOR_PLUGIN_ROOT}/scripts/run.cmd",
+      "command": "node",
       "args": [
+        "${CURSOR_PLUGIN_ROOT}/scripts/run.cjs",
         "stdio"
       ]
     }

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Cross-platform MCP launcher for Lumen.
+//
+// Plugin manifests for Claude Code and Cursor accept a single `command`
+// string with no per-OS dispatch. A shell-script polyglot (scripts/run.cmd)
+// cannot satisfy both POSIX shebang detection (byte 0 == "#!") and cmd.exe
+// stdout cleanliness (line 1 must be "@"-prefixed or a label) at the same
+// byte 0, so a single-file polyglot is fundamentally incompatible with
+// macOS posix_spawn. This launcher routes through Node — guaranteed to be
+// in PATH for Claude Code and Cursor — and dispatches to the platform's
+// shell script.
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const root =
+  process.env.CLAUDE_PLUGIN_ROOT ||
+  process.env.CURSOR_PLUGIN_ROOT ||
+  path.resolve(__dirname, '..');
+
+const isWin = process.platform === 'win32';
+const args = process.argv.slice(2);
+
+const command = isWin ? 'cmd.exe' : path.join(root, 'scripts', 'run.sh');
+const commandArgs = isWin
+  ? ['/c', path.join(root, 'scripts', 'run.bat'), ...args]
+  : args;
+
+const child = spawn(command, commandArgs, { stdio: 'inherit' });
+
+// Forward termination signals from MCP host to child so bin/lumen does not
+// linger as an orphan process when Claude Code / Cursor shuts the launcher
+// down.
+['SIGTERM', 'SIGINT', 'SIGHUP'].forEach((sig) => {
+  process.on(sig, () => {
+    if (!child.killed) child.kill(sig);
+  });
+});
+
+child.on('error', (err) => {
+  console.error(`lumen launcher failed to spawn ${command}:`, err.message);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 1);
+});

--- a/scripts/run.cmd
+++ b/scripts/run.cmd
@@ -1,3 +1,4 @@
+#!/bin/sh
 :<<"::CMDLITERAL"
 @echo off
 goto :batch

--- a/scripts/test_run_cmd_windows.bat
+++ b/scripts/test_run_cmd_windows.bat
@@ -47,53 +47,23 @@ if "!OUTPUT!"=="delegated:hook session-start lumen --host claude" (
   set /a FAIL+=1
 )
 
-:: --- Test 3: run.cmd produces clean stderr ---
-:: The polyglot prologue must not surface command-not-found errors
-:: from cmd.exe trying to execute the shell-only lines.
-:: NOTE: invoke via `cmd /c` to match how MCP hosts spawn run.cmd
-:: (a fresh cmd.exe with default echo state, not inheriting `call`).
+:: --- Test 3: run.cmd produces no unexpected stderr ---
 set "STDERR_FILE=%TMP_DIR%\stderr.txt"
-set "STDOUT_FILE=%TMP_DIR%\stdout.txt"
-cmd /c ""%TMP_DIR%\run.cmd" stdio" 2>"%STDERR_FILE%" >"%STDOUT_FILE%"
+"%TMP_DIR%\run.cmd" stdio 2>"%STDERR_FILE%" >NUL
 
+:: Check stderr is empty or contains only the expected "not recognized" from shebang line
 set "STDERR_SIZE=0"
 for %%A in ("%STDERR_FILE%") do set "STDERR_SIZE=%%~zA"
 
-if "!STDERR_SIZE!"=="0" (
-  echo   PASS: stderr is empty
+:: Stderr should only contain the harmless shebang error (if any)
+:: We check it doesn't contain "-S" which was the old broken error
+findstr /i "\-S" "%STDERR_FILE%" >NUL 2>&1
+if errorlevel 1 (
+  echo   PASS: no '-S' error in stderr
   set /a PASS+=1
 ) else (
-  echo   FAIL: stderr is not empty [size: !STDERR_SIZE! bytes]
+  echo   FAIL: stderr contains '-S' error from old broken polyglot
   type "%STDERR_FILE%"
-  set /a FAIL+=1
-)
-
-:: --- Test 4: run.cmd produces clean stdout (no command-echo pollution) ---
-:: cmd.exe echoes commands to stdout before @echo off takes effect, so a
-:: polyglot whose first line is treated as a command (rather than a label
-:: or @-prefixed line) prepends prompt-prefixed text to stdout. This breaks
-:: MCP stdio JSON-RPC framing on Claude Code, Cursor, and other hosts that
-:: spawn run.cmd directly via .cmd file extension association.
-set "STDOUT_FIRST="
-for /f "usebackq delims=" %%i in ("%STDOUT_FILE%") do (
-  if not defined STDOUT_FIRST set "STDOUT_FIRST=%%i"
-)
-for /f %%i in ('find /c /v "" ^< "%STDOUT_FILE%"') do set "STDOUT_LINES=%%i"
-
-set "TEST4=fail"
-if "!STDOUT_FIRST!"=="delegated:stdio" if "!STDOUT_LINES!"=="1" set "TEST4=pass"
-
-if "!TEST4!"=="pass" (
-  echo   PASS: stdout has no command-echo pollution
-  set /a PASS+=1
-) else (
-  echo   FAIL: stdout polluted before run.bat output
-  echo         expected: 1 line "delegated:stdio"
-  echo         got first line: !STDOUT_FIRST!
-  echo         line count:     !STDOUT_LINES!
-  echo         --- full stdout ---
-  type "%STDOUT_FILE%"
-  echo         --- end ---
   set /a FAIL+=1
 )
 


### PR DESCRIPTION
Fix MacOS MCP. Currently the MCP server won't load on MacOS. POSIX posix_spawn requires byte 0-1 == "#\!" for shebang detection.

PR #145 removed the `#\!/bin/sh` line from `scripts/run.cmd` to enforce strict cmd.exe stdout cleanliness on Windows MCP hosts. That regressed macOS/Linux MCP launches with:

    ENOEXEC: posix_spawn '/path/scripts/run.cmd'

A single byte 0 cannot satisfy both POSIX shebang detection and `cmd.exe` echo suppression (which requires "@" or ":" prefix). The two constraints are mutually exclusive for a polyglot file.

Resolution:

- Add scripts/run.cjs as a small Node dispatcher that invokes run.sh on Unix and `cmd /c run.bat` on Windows. Node is guaranteed in PATH for Claude Code, Cursor, OpenCode, and Codex environments. The launcher forwards SIGTERM/SIGINT/SIGHUP from the MCP host to the child so the lumen binary does not linger as an orphan process when Claude Code or Cursor shuts the launcher down.
- Update `.claude-plugin/plugin.json` and `.cursor/mcp.json` to invoke `node scripts/run.cjs stdio`. Both Claude Code and Cursor now bypass `run.cmd` entirely.
- Restore `#\!/bin/sh` to `scripts/run.cmd` line 1. This re-enables direct posix_spawn invocation on macOS/Linux for backward compatibility with stale plugin manifests, hook commands (`hooks/hooks.json`, `hooks/hooks-cursor.json`), and the OpenCode plugin loader.
- Restore the shebang-tolerant Test 3 in `test_run_cmd_windows.bat` (matches the version at `b66a339` prior to PR #145). PR #145 strengthened Test 3 to enforce empty stderr and added Test 4 to enforce empty stdout under `cmd /c` — both relied on run.cmd being the MCP entry point. Since Claude Code and Cursor now route through `run.cjs`, those invariants no longer apply; reverting to the original tolerant Test 3 keeps the delegation tests intact while accepting the harmless shebang noise that `cmd.exe` emits.

Codex already documents per-OS scripts (`run.sh` on Unix, `run.cmd` on Windows) and never relied on the polyglot being the single MCP entry point.

Compatibility:

- Claude Code (any OS, post-update): node dispatch path
- Cursor (any OS, post-update): node dispatch path
- OpenCode (any OS): existing lumen.js dispatcher; unaffected
- Codex (any OS): unchanged; per-OS install docs continue to work
- Hooks on macOS/Linux: works via restored shebang
- Stale Claude/Cursor manifests pointing at run.cmd on macOS: now works

Constraint: Cannot satisfy POSIX shebang and `cmd.exe` stdout cleanliness at byte 0 of a single file
Constraint: Plugin manifest schema does not support per-OS command dispatch
Rejected: shebang-only restoration | leaves Claude/Cursor still fragile on direct run.cmd invocation
Rejected: `/bin/sh` in manifest | absent on Windows
Rejected: bundle `bin/lumen` directly | requires marketplace per-OS distribution
Confidence: high
Scope-risk: narrow
Directive: do not remove `#\!/bin/sh` from `run.cmd` without restoring per-OS dispatch via the manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with launcher configuration details.

* **Chores**
  * Refactored plugin launcher infrastructure for improved cross-platform support.
  * Expanded test coverage for launcher functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->