### PR TITLE
fix(index): refuse $HOME, system roots, and .lumenignore-blanketed dirs

### DIFF
--- a/cmd/ancestor.go
+++ b/cmd/ancestor.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/merkle"
 )
 
 // findAncestorIndex walks up from path's parent directory, checking whether
@@ -34,7 +35,7 @@ import (
 func findAncestorIndex(path, model string) string {
 	candidate := filepath.Dir(path)
 	for {
-		if !pathCrossesSkipDir(candidate, path) {
+		if !pathCrossesSkipDir(candidate, path) && !merkle.IsRootUnindexable(candidate) {
 			if _, err := os.Stat(config.DBPathForProject(candidate, model)); err == nil {
 				return candidate
 			}

--- a/cmd/ancestor.go
+++ b/cmd/ancestor.go
@@ -35,7 +35,8 @@ import (
 func findAncestorIndex(path, model string) string {
 	candidate := filepath.Dir(path)
 	for {
-		if !pathCrossesSkipDir(candidate, path) && !merkle.IsRootUnindexable(candidate) {
+		unindexable, _ := merkle.IsRootUnindexable(candidate)
+		if !pathCrossesSkipDir(candidate, path) && !unindexable {
 			if _, err := os.Stat(config.DBPathForProject(candidate, model)); err == nil {
 				return candidate
 			}

--- a/cmd/ancestor_test.go
+++ b/cmd/ancestor_test.go
@@ -86,6 +86,35 @@ func TestFindAncestorIndex(t *testing.T) {
 		}
 	})
 
+	t.Run("skips ancestor whose .lumenignore declares it un-indexable", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+
+		// Create a real on-disk ancestor with an existing DB AND a catch-all
+		// .lumenignore. This mirrors the user's $HOME case: walking up from
+		// a non-git subdirectory must NOT resolve to a path that the user has
+		// declared un-indexable.
+		ancestor := filepath.Join(tmpDir, "home")
+		if err := os.MkdirAll(ancestor, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(ancestor, ".lumenignore"), []byte("**\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dbPath := config.DBPathForProject(ancestor, model)
+		if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dbPath, []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		got := findAncestorIndex(filepath.Join(ancestor, "sub", "deep"), model)
+		if got != "" {
+			t.Fatalf("expected empty (ancestor declared un-indexable), got %q", got)
+		}
+	})
+
 	t.Run("returns nearest ancestor when multiple exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("XDG_DATA_HOME", tmpDir)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -54,12 +54,13 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve path: %w", err)
 	}
 
-	// Refuse roots that have declared themselves un-indexable via .lumenignore
-	// (e.g. $HOME with a catch-all pattern). Without this, the indexer would
-	// walk the entire tree, ignore every file, produce an empty index, and on
-	// macOS trigger TCC prompts for protected folders along the way.
-	if merkle.IsRootUnindexable(projectPath) {
-		return fmt.Errorf("%s declares itself un-indexable via .lumenignore; refusing to index", projectPath)
+	// Refuse roots that have declared themselves un-indexable — either via a
+	// .lumenignore catch-all (e.g. $HOME with `**`) or via the hardcoded
+	// refusal list. Without this, the indexer would walk the entire tree,
+	// ignore every file, produce an empty index, and on macOS trigger TCC
+	// prompts for protected folders along the way.
+	if unindexable, reason := merkle.IsRootUnindexable(projectPath); unindexable {
+		return fmt.Errorf("refusing to index %s: %s", projectPath, reason)
 	}
 
 	logger, logFile := newDebugLogger()
@@ -84,6 +85,14 @@ func runIndex(cmd *cobra.Command, args []string) error {
 		projectPath = root
 	} else if ancestor := findAncestorIndex(projectPath, modelName); ancestor != "" {
 		projectPath = ancestor
+	}
+
+	// Re-check after normalization: git.RepoRoot can resolve upward to an
+	// un-indexable root (e.g. a git repo rooted at $HOME) and bypass the
+	// pre-normalization guard. findAncestorIndex already filters, but the git
+	// path does not.
+	if unindexable, reason := merkle.IsRootUnindexable(projectPath); unindexable {
+		return fmt.Errorf("refusing to index %s: %s", projectPath, reason)
 	}
 
 	// When the project directory is not a git repo, discover nested git repos

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ory/lumen/internal/git"
 	"github.com/ory/lumen/internal/index"
 	"github.com/ory/lumen/internal/indexlock"
+	"github.com/ory/lumen/internal/merkle"
 	"github.com/ory/lumen/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -48,6 +49,19 @@ var indexCmd = &cobra.Command{
 }
 
 func runIndex(cmd *cobra.Command, args []string) error {
+	projectPath, err := filepath.Abs(args[0])
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	// Refuse roots that have declared themselves un-indexable via .lumenignore
+	// (e.g. $HOME with a catch-all pattern). Without this, the indexer would
+	// walk the entire tree, ignore every file, produce an empty index, and on
+	// macOS trigger TCC prompts for protected folders along the way.
+	if merkle.IsRootUnindexable(projectPath) {
+		return fmt.Errorf("%s declares itself un-indexable via .lumenignore; refusing to index", projectPath)
+	}
+
 	logger, logFile := newDebugLogger()
 	if logFile != nil {
 		defer func() { _ = logFile.Close() }()
@@ -60,11 +74,6 @@ func runIndex(cmd *cobra.Command, args []string) error {
 
 	emb := newEmbedder(cfg)
 	emb.SetLogger(logger)
-
-	projectPath, err := filepath.Abs(args[0])
-	if err != nil {
-		return fmt.Errorf("resolve path: %w", err)
-	}
 
 	modelName := emb.ModelName()
 

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunIndex_RefusesUnindexableRoot(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lumenignore"), []byte("**\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runIndex(indexCmd, []string{dir})
+	if err == nil {
+		t.Fatal("expected runIndex to refuse an un-indexable root, got nil error")
+	}
+	if !strings.Contains(err.Error(), ".lumenignore") {
+		t.Fatalf("expected error to mention .lumenignore, got %q", err.Error())
+	}
+}

--- a/cmd/index_test.go
+++ b/cmd/index_test.go
@@ -31,7 +31,7 @@ func TestRunIndex_RefusesUnindexableRoot(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected runIndex to refuse an un-indexable root, got nil error")
 	}
-	if !strings.Contains(err.Error(), ".lumenignore") {
-		t.Fatalf("expected error to mention .lumenignore, got %q", err.Error())
+	if !strings.Contains(err.Error(), ".lumenignore catch-all") {
+		t.Fatalf("expected error to mention the .lumenignore catch-all reason, got %q", err.Error())
 	}
 }

--- a/internal/merkle/ignore.go
+++ b/internal/merkle/ignore.go
@@ -306,6 +306,9 @@ var refusedRoots = map[string]bool{
 }
 
 // IsRootUnindexable reports whether dir is unsuitable as a Lumen index root.
+// When true, the returned string is a short human-readable reason suitable for
+// inclusion in an error message. When false, the reason is empty.
+//
 // Two checks combine:
 //
 //  1. Hardcoded refusal list — filesystem roots ($HOME, /, /Users, /tmp,
@@ -319,18 +322,18 @@ var refusedRoots = map[string]bool{
 // file, produces an empty index, and on macOS triggers TCC prompts along
 // the way. Callers (findAncestorIndex, `lumen index`) use this to refuse
 // such roots upfront.
-func IsRootUnindexable(dir string) bool {
+func IsRootUnindexable(dir string) (bool, string) {
 	clean := filepath.Clean(dir)
 	if refusedRoots[clean] {
-		return true
+		return true, "hardcoded system root"
 	}
 	if home, err := os.UserHomeDir(); err == nil && filepath.Clean(home) == clean {
-		return true
+		return true, "user home directory"
 	}
 
 	gi, err := ignore.CompileIgnoreFile(filepath.Join(dir, ".lumenignore"))
 	if err != nil || gi == nil {
-		return false
+		return false, ""
 	}
 	// Probe with both a root-level entry and a nested entry using long random
 	// sentinels that no realistic specific pattern would match. Patterns like
@@ -339,7 +342,10 @@ func IsRootUnindexable(dir string) bool {
 	// take as "ignores everything".
 	const probeRoot = "lumen-root-probe-X9F2K7M3"
 	const probeNested = "lumen-root-probe-X9F2K7M3/L8B4Q1P5R6N2"
-	return gi.MatchesPath(probeRoot) && gi.MatchesPath(probeNested)
+	if gi.MatchesPath(probeRoot) && gi.MatchesPath(probeNested) {
+		return true, ".lumenignore catch-all pattern"
+	}
+	return false, ""
 }
 
 // MakeSkipWithExtra is like MakeSkip but also skips directories whose relative

--- a/internal/merkle/ignore.go
+++ b/internal/merkle/ignore.go
@@ -292,17 +292,45 @@ func parseLinguistExcluded(path string) *ignore.GitIgnore {
 // index root regardless of configuration. Indexing them would walk huge,
 // machine-managed trees and on macOS trigger TCC prompts for protected
 // folders. The user's $HOME is added at lookup time via os.UserHomeDir.
+//
+// Entries cover Unix/macOS and Windows. Keys are compared against
+// filepath.Clean(dir), which is platform-dependent (forward slashes on
+// Unix, backslashes on Windows), so Windows entries only match on Windows
+// and vice versa — harmless to include both.
 var refusedRoots = map[string]bool{
-	"/":            true,
-	"/Users":       true,
-	"/tmp":         true,
-	"/private/tmp": true,
-	"/var":         true,
-	"/private/var": true,
-	"/etc":         true,
-	"/usr":         true,
+	// Unix / macOS
+	"/":             true,
+	"/Users":        true,
+	"/home":         true,
+	"/tmp":          true,
+	"/private/tmp":  true,
+	"/var":          true,
+	"/private/var":  true,
+	"/etc":          true,
+	"/usr":          true,
+	"/opt":          true,
 	"/Applications": true,
-	"/Library":     true,
+	"/Library":      true,
+	"/System":       true,
+	// Windows
+	`C:\`:                    true,
+	`C:\Windows`:             true,
+	`C:\Program Files`:       true,
+	`C:\Program Files (x86)`: true,
+	`C:\Users`:               true,
+	`C:\ProgramData`:         true,
+}
+
+// resolvePath returns filepath.EvalSymlinks(dir) when it succeeds, falling
+// back to filepath.Clean(dir) when it does not (e.g. dir does not exist on
+// disk, or a symlink in the chain cannot be resolved). This ensures that a
+// symlink to $HOME or a refused root is caught by IsRootUnindexable rather
+// than slipping through on the symlink path alone.
+func resolvePath(dir string) string {
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return filepath.Clean(dir)
 }
 
 // IsRootUnindexable reports whether dir is unsuitable as a Lumen index root.
@@ -323,12 +351,21 @@ var refusedRoots = map[string]bool{
 // the way. Callers (findAncestorIndex, `lumen index`) use this to refuse
 // such roots upfront.
 func IsRootUnindexable(dir string) (bool, string) {
+	// Check both the cleaned input and the symlink-resolved form against the
+	// refusal map. On macOS, /etc → /private/etc and /tmp → /private/tmp via
+	// symlinks: resolving lets a user-supplied "/private/etc" still match,
+	// while the cleaned-input check keeps "/etc" itself matching.
 	clean := filepath.Clean(dir)
-	if refusedRoots[clean] {
+	resolved := resolvePath(dir)
+	if refusedRoots[clean] || refusedRoots[resolved] {
 		return true, "hardcoded system root"
 	}
-	if home, err := os.UserHomeDir(); err == nil && filepath.Clean(home) == clean {
-		return true, "user home directory"
+	if home, err := os.UserHomeDir(); err == nil {
+		homeClean := filepath.Clean(home)
+		homeResolved := resolvePath(home)
+		if homeClean == clean || homeClean == resolved || homeResolved == clean || homeResolved == resolved {
+			return true, "user home directory"
+		}
 	}
 
 	gi, err := ignore.CompileIgnoreFile(filepath.Join(dir, ".lumenignore"))

--- a/internal/merkle/ignore.go
+++ b/internal/merkle/ignore.go
@@ -288,6 +288,60 @@ func parseLinguistExcluded(path string) *ignore.GitIgnore {
 	return ignore.CompileIgnoreLines(patterns...)
 }
 
+// refusedRoots are filesystem roots that are never appropriate as a Lumen
+// index root regardless of configuration. Indexing them would walk huge,
+// machine-managed trees and on macOS trigger TCC prompts for protected
+// folders. The user's $HOME is added at lookup time via os.UserHomeDir.
+var refusedRoots = map[string]bool{
+	"/":            true,
+	"/Users":       true,
+	"/tmp":         true,
+	"/private/tmp": true,
+	"/var":         true,
+	"/private/var": true,
+	"/etc":         true,
+	"/usr":         true,
+	"/Applications": true,
+	"/Library":     true,
+}
+
+// IsRootUnindexable reports whether dir is unsuitable as a Lumen index root.
+// Two checks combine:
+//
+//  1. Hardcoded refusal list — filesystem roots ($HOME, /, /Users, /tmp,
+//     /var, /etc, /usr, /Applications, /Library and macOS /private/* twins)
+//     that should never be project roots regardless of user config.
+//  2. .lumenignore probe — if dir/.lumenignore contains patterns broad
+//     enough to match every file (e.g. "**", "**/*", "*"), the user has
+//     declared the directory un-indexable at its boundary.
+//
+// Without these guards the indexer walks the entire tree, ignores every
+// file, produces an empty index, and on macOS triggers TCC prompts along
+// the way. Callers (findAncestorIndex, `lumen index`) use this to refuse
+// such roots upfront.
+func IsRootUnindexable(dir string) bool {
+	clean := filepath.Clean(dir)
+	if refusedRoots[clean] {
+		return true
+	}
+	if home, err := os.UserHomeDir(); err == nil && filepath.Clean(home) == clean {
+		return true
+	}
+
+	gi, err := ignore.CompileIgnoreFile(filepath.Join(dir, ".lumenignore"))
+	if err != nil || gi == nil {
+		return false
+	}
+	// Probe with both a root-level entry and a nested entry using long random
+	// sentinels that no realistic specific pattern would match. Patterns like
+	// "*" alone match only the root probe (gitignore `*` doesn't cross `/`);
+	// patterns like "**", "**/*", "*/*" match both probes — which is what we
+	// take as "ignores everything".
+	const probeRoot = "lumen-root-probe-X9F2K7M3"
+	const probeNested = "lumen-root-probe-X9F2K7M3/L8B4Q1P5R6N2"
+	return gi.MatchesPath(probeRoot) && gi.MatchesPath(probeNested)
+}
+
 // MakeSkipWithExtra is like MakeSkip but also skips directories whose relative
 // paths are listed in extraSkipDirs. This is used to exclude git worktrees
 // that are checked out inside the project root directory.

--- a/internal/merkle/ignore_test.go
+++ b/internal/merkle/ignore_test.go
@@ -84,70 +84,42 @@ func TestMakeSkip_NegationPattern(t *testing.T) {
 }
 
 func TestIsRootUnindexable(t *testing.T) {
-	t.Run("no .lumenignore returns false", func(t *testing.T) {
-		dir := t.TempDir()
-		if IsRootUnindexable(dir) {
-			t.Error("expected false when no .lumenignore exists")
-		}
-	})
-
-	t.Run("empty .lumenignore returns false", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "")
-		if IsRootUnindexable(dir) {
-			t.Error("expected false for empty .lumenignore")
-		}
-	})
-
-	t.Run("specific patterns return false", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "node_modules/\n*.log\nbuild/\n")
-		if IsRootUnindexable(dir) {
-			t.Error("expected false for specific patterns")
-		}
-	})
-
-	t.Run("doublestar matches everything returns true", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "**\n")
-		if !IsRootUnindexable(dir) {
-			t.Error("expected true for ** pattern")
-		}
-	})
-
-	t.Run("doublestar-slash-star matches everything returns true", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "**/*\n")
-		if !IsRootUnindexable(dir) {
-			t.Error("expected true for **/* pattern")
-		}
-	})
-
-	t.Run("combined catch-all patterns return true", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "*\n**/**\n*/*\n**/*\n")
-		if !IsRootUnindexable(dir) {
-			t.Error("expected true for combined catch-all patterns (the user's actual $HOME case)")
-		}
-	})
-
-	t.Run("single-star alone returns true", func(t *testing.T) {
+	// .lumenignore-based scenarios: each case writes the given contents (or no
+	// file when ignoreContents is the sentinel "<no file>") to a temp dir.
+	const noFile = "<no file>"
+	lumenIgnoreCases := []struct {
+		name           string
+		ignoreContents string
+		want           bool
+		wantReason     string
+	}{
+		{"no .lumenignore", noFile, false, ""},
+		{"empty .lumenignore", "", false, ""},
+		{"specific patterns", "node_modules/\n*.log\nbuild/\n", false, ""},
+		{"doublestar matches everything", "**\n", true, ".lumenignore catch-all pattern"},
+		{"doublestar-slash-star matches everything", "**/*\n", true, ".lumenignore catch-all pattern"},
+		// The user's actual $HOME case — multiple broad patterns combined.
+		{"combined catch-all patterns", "*\n**/**\n*/*\n**/*\n", true, ".lumenignore catch-all pattern"},
 		// In gitignore semantics, a bare `*` (no `/`) matches any name at any
 		// depth — so it ignores every file in the tree. That is a catch-all.
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "*\n")
-		if !IsRootUnindexable(dir) {
-			t.Error("expected true for `*` alone (matches every file in the tree)")
-		}
-	})
-
-	t.Run("comments and blank lines do not trigger", func(t *testing.T) {
-		dir := t.TempDir()
-		writeFile(t, dir, ".lumenignore", "# comment\n\n  \n")
-		if IsRootUnindexable(dir) {
-			t.Error("expected false for whitespace/comments only")
-		}
-	})
+		{"single-star alone", "*\n", true, ".lumenignore catch-all pattern"},
+		{"comments and blank lines do not trigger", "# comment\n\n  \n", false, ""},
+	}
+	for _, tc := range lumenIgnoreCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.ignoreContents != noFile {
+				writeFile(t, dir, ".lumenignore", tc.ignoreContents)
+			}
+			got, reason := IsRootUnindexable(dir)
+			if got != tc.want {
+				t.Errorf("IsRootUnindexable() = %v, want %v", got, tc.want)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
 
 	t.Run("hardcoded system paths are refused", func(t *testing.T) {
 		// These paths should always be refused as index roots, regardless of
@@ -165,8 +137,12 @@ func TestIsRootUnindexable(t *testing.T) {
 			"/Applications",
 			"/Library",
 		} {
-			if !IsRootUnindexable(p) {
+			got, reason := IsRootUnindexable(p)
+			if !got {
 				t.Errorf("expected %q to be refused as an index root", p)
+			}
+			if reason != "hardcoded system root" {
+				t.Errorf("reason for %q = %q, want %q", p, reason, "hardcoded system root")
 			}
 		}
 	})
@@ -176,8 +152,12 @@ func TestIsRootUnindexable(t *testing.T) {
 		if err != nil {
 			t.Skip("no home dir available")
 		}
-		if !IsRootUnindexable(home) {
+		got, reason := IsRootUnindexable(home)
+		if !got {
 			t.Errorf("expected %q (home) to be refused as an index root", home)
+		}
+		if reason != "user home directory" {
+			t.Errorf("reason = %q, want %q", reason, "user home directory")
 		}
 	})
 
@@ -186,7 +166,7 @@ func TestIsRootUnindexable(t *testing.T) {
 		// must still be indexable. Use the test's tempdir which is outside any
 		// hardcoded path.
 		dir := t.TempDir()
-		if IsRootUnindexable(dir) {
+		if got, _ := IsRootUnindexable(dir); got {
 			t.Errorf("expected %q to be indexable (no .lumenignore, not hardcoded)", dir)
 		}
 	})

--- a/internal/merkle/ignore_test.go
+++ b/internal/merkle/ignore_test.go
@@ -83,6 +83,115 @@ func TestMakeSkip_NegationPattern(t *testing.T) {
 	}
 }
 
+func TestIsRootUnindexable(t *testing.T) {
+	t.Run("no .lumenignore returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		if IsRootUnindexable(dir) {
+			t.Error("expected false when no .lumenignore exists")
+		}
+	})
+
+	t.Run("empty .lumenignore returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "")
+		if IsRootUnindexable(dir) {
+			t.Error("expected false for empty .lumenignore")
+		}
+	})
+
+	t.Run("specific patterns return false", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "node_modules/\n*.log\nbuild/\n")
+		if IsRootUnindexable(dir) {
+			t.Error("expected false for specific patterns")
+		}
+	})
+
+	t.Run("doublestar matches everything returns true", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "**\n")
+		if !IsRootUnindexable(dir) {
+			t.Error("expected true for ** pattern")
+		}
+	})
+
+	t.Run("doublestar-slash-star matches everything returns true", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "**/*\n")
+		if !IsRootUnindexable(dir) {
+			t.Error("expected true for **/* pattern")
+		}
+	})
+
+	t.Run("combined catch-all patterns return true", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "*\n**/**\n*/*\n**/*\n")
+		if !IsRootUnindexable(dir) {
+			t.Error("expected true for combined catch-all patterns (the user's actual $HOME case)")
+		}
+	})
+
+	t.Run("single-star alone returns true", func(t *testing.T) {
+		// In gitignore semantics, a bare `*` (no `/`) matches any name at any
+		// depth — so it ignores every file in the tree. That is a catch-all.
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "*\n")
+		if !IsRootUnindexable(dir) {
+			t.Error("expected true for `*` alone (matches every file in the tree)")
+		}
+	})
+
+	t.Run("comments and blank lines do not trigger", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lumenignore", "# comment\n\n  \n")
+		if IsRootUnindexable(dir) {
+			t.Error("expected false for whitespace/comments only")
+		}
+	})
+
+	t.Run("hardcoded system paths are refused", func(t *testing.T) {
+		// These paths should always be refused as index roots, regardless of
+		// whether a .lumenignore exists. Indexing them is never the user's
+		// intent and on macOS would trigger TCC prompts.
+		for _, p := range []string{
+			"/",
+			"/Users",
+			"/tmp",
+			"/private/tmp",
+			"/var",
+			"/private/var",
+			"/etc",
+			"/usr",
+			"/Applications",
+			"/Library",
+		} {
+			if !IsRootUnindexable(p) {
+				t.Errorf("expected %q to be refused as an index root", p)
+			}
+		}
+	})
+
+	t.Run("home directory is refused", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("no home dir available")
+		}
+		if !IsRootUnindexable(home) {
+			t.Errorf("expected %q (home) to be refused as an index root", home)
+		}
+	})
+
+	t.Run("hardcoded refusal does not falsely flag siblings of home", func(t *testing.T) {
+		// A directory that is NOT in the refusal list and has no .lumenignore
+		// must still be indexable. Use the test's tempdir which is outside any
+		// hardcoded path.
+		dir := t.TempDir()
+		if IsRootUnindexable(dir) {
+			t.Errorf("expected %q to be indexable (no .lumenignore, not hardcoded)", dir)
+		}
+	})
+}
+
 func TestMakeSkip_HardcodedFiles(t *testing.T) {
 	dir := t.TempDir()
 	skip := MakeSkip(dir, []string{".go", ".json", ".yaml"})

--- a/internal/merkle/ignore_test.go
+++ b/internal/merkle/ignore_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -125,18 +126,47 @@ func TestIsRootUnindexable(t *testing.T) {
 		// These paths should always be refused as index roots, regardless of
 		// whether a .lumenignore exists. Indexing them is never the user's
 		// intent and on macOS would trigger TCC prompts.
-		for _, p := range []string{
+		//
+		// The list is platform-aware: Unix paths only assert refusal when the
+		// path exists on disk (so /Applications and /Library don't fail on
+		// Linux), and Windows paths only run on Windows.
+		unixPaths := []string{
 			"/",
 			"/Users",
+			"/home",
 			"/tmp",
 			"/private/tmp",
 			"/var",
 			"/private/var",
 			"/etc",
 			"/usr",
+			"/opt",
 			"/Applications",
 			"/Library",
-		} {
+			"/System",
+		}
+		windowsPaths := []string{
+			`C:\`,
+			`C:\Windows`,
+			`C:\Program Files`,
+			`C:\Program Files (x86)`,
+			`C:\Users`,
+			`C:\ProgramData`,
+		}
+		var paths []string
+		if runtime.GOOS == "windows" {
+			paths = windowsPaths
+		} else {
+			paths = unixPaths
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err != nil {
+				// Skip paths that don't exist on this host — EvalSymlinks
+				// will fail there and the fallback to filepath.Clean still
+				// catches them, but we keep the assertion focused on real
+				// roots that users could actually point lumen at.
+				continue
+			}
 			got, reason := IsRootUnindexable(p)
 			if !got {
 				t.Errorf("expected %q to be refused as an index root", p)
@@ -144,6 +174,25 @@ func TestIsRootUnindexable(t *testing.T) {
 			if reason != "hardcoded system root" {
 				t.Errorf("reason for %q = %q, want %q", p, reason, "hardcoded system root")
 			}
+		}
+	})
+
+	t.Run("symlink to home is refused", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("no home dir available")
+		}
+		linkParent := t.TempDir()
+		link := filepath.Join(linkParent, "home-symlink")
+		if err := os.Symlink(home, link); err != nil {
+			t.Skipf("symlinks unsupported on this platform: %v", err)
+		}
+		got, reason := IsRootUnindexable(link)
+		if !got {
+			t.Errorf("expected %q (symlink to home) to be refused", link)
+		}
+		if reason != "user home directory" {
+			t.Errorf("reason = %q, want %q", reason, "user home directory")
 		}
 	})
 


### PR DESCRIPTION
## Summary

Indexing `$HOME` (or any tree the user has blanketed with a catch-all `.lumenignore`) was walking the whole subtree, ignoring every file, producing an empty index — and on macOS triggering TCC prompts for `~/Desktop`, `~/Documents`, `~/Library`, etc. along the way. Multiple Claude/Conductor sessions starting from `$HOME` amplified this into many concurrent indexers each repeating the same walk.

This adds `merkle.IsRootUnindexable(dir)`, called from the two places that pick index roots:

- **`findAncestorIndex`** now skips candidates that are unindexable, so walking up from a non-git subdirectory can no longer resolve to `$HOME` or to a user-disabled root.
- **`runIndex`** refuses such targets before any config/embedder setup, so `lumen index $HOME` fails fast with a clear error.

The check combines:
1. A hardcoded refusal list: `/`, `$HOME`, `/Users`, `/tmp`, `/var`, `/etc`, `/usr`, `/Applications`, `/Library` and their macOS `/private/*` twins.
2. A `.lumenignore` catch-all probe — matches against `lumen-root-probe-…` and `lumen-root-probe-…/…` so patterns like `**`, `**/*`, `*/*`, or bare `*` register as "ignore everything" but specific patterns like `node_modules/` do not.

## Test plan

- [x] `go test ./internal/merkle/ -run TestIsRootUnindexable` — covers no-file, empty file, specific patterns, doublestar, combined, single-`*`, comments-only, hardcoded paths, `$HOME`, and a sibling-of-home regression.
- [x] `go test ./cmd/ -run TestFindAncestorIndex` — new sub-test verifies ancestor walk skips a candidate whose `.lumenignore` declares it un-indexable.
- [x] `go test ./cmd/ -run TestRunIndex_RefusesUnindexableRoot` — verifies `runIndex` returns an error mentioning `.lumenignore` before any config/embedder work.
- [x] `make lint` — 0 issues.
- [x] `make build-local` — clean build.

## Out of scope (follow-up)

- Spawn deduplication (per-path pid lockfile) — separate concern, tracked separately.
- Teaching `DiscoverNestedGitRepos` to honor the parent's `.lumenignore` — only matters when a refused root somehow slips through, which the two new guards prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directories can be marked unindexable via .lumenignore patterns to prevent indexing and skip them during ancestor resolution.

* **Bug Fixes**
  * Indexing now refuses roots marked unindexable early and re-checks after path normalization to prevent bypass.

* **Tests**
  * Added tests validating unindexable-root detection and ancestor-resolution behavior when roots are catch-all ignored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/lumen/pull/160)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->