### PR TITLE
fix(scripts): normalise MinGW/MSYS/Cygwin uname for POSIX launcher

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -6,19 +6,26 @@ set -euo pipefail
 # OpenCode, and direct local invocation.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}}"
 
-# Platform detection
+# Platform detection. Normalise MinGW/MSYS/Cygwin (Git Bash on Windows) to
+# `windows` so the launcher resolves the same binary as scripts/run.cmd and
+# the goreleaser asset names on GitHub releases.
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  mingw*|msys*|cygwin*) OS="windows" ;;
+esac
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)  ARCH="amd64" ;;
   aarch64) ARCH="arm64" ;;
 esac
+EXT=""
+[ "$OS" = "windows" ] && EXT=".exe"
 
 # Find binary: check bin/ first, then goreleaser dist/ output, then download
 BINARY=""
 for candidate in \
-  "${PLUGIN_ROOT}/bin/lumen" \
-  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"; do
+  "${PLUGIN_ROOT}/bin/lumen${EXT}" \
+  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}${EXT}"; do
   if [ -x "$candidate" ]; then
     BINARY="$candidate"
     break
@@ -27,7 +34,7 @@ done
 
 # Download on first run if no binary found
 if [ -z "$BINARY" ]; then
-  BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
+  BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}${EXT}"
 
   REPO="ory/lumen"
 
@@ -43,7 +50,7 @@ if [ -z "$BINARY" ]; then
     exit 1
   fi
 
-  ASSET="lumen-${VERSION#v}-${OS}-${ARCH}"
+  ASSET="lumen-${VERSION#v}-${OS}-${ARCH}${EXT}"
   URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
 
   echo "Downloading lumen ${VERSION} for ${OS}/${ARCH}..." >&2
@@ -70,7 +77,7 @@ if [ -z "$BINARY" ]; then
 
     echo "Falling back to ${LATEST_TAG}..." >&2
     VERSION="$LATEST_TAG"
-    ASSET="lumen-${VERSION#v}-${OS}-${ARCH}"
+    ASSET="lumen-${VERSION#v}-${OS}-${ARCH}${EXT}"
     URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
 
     curl -fL --progress-bar --max-time 300 --retry 3 --retry-delay 2 "$URL" -o "$BINARY"

--- a/scripts/run
+++ b/scripts/run
@@ -21,10 +21,14 @@ esac
 EXT=""
 [ "$OS" = "windows" ] && EXT=".exe"
 
-# Find binary: check bin/ first, then goreleaser dist/ output, then download
+# Find binary: check bin/ first, then goreleaser dist/ output, then download.
+# `make build-local` runs `go build -o bin/lumen .` which, even on Windows,
+# does NOT append .exe when -o is explicit — so we must keep the
+# extensionless dev-build candidate alongside the .exe one.
 BINARY=""
 for candidate in \
   "${PLUGIN_ROOT}/bin/lumen${EXT}" \
+  "${PLUGIN_ROOT}/bin/lumen" \
   "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}${EXT}"; do
   if [ -x "$candidate" ]; then
     BINARY="$candidate"

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -59,6 +59,22 @@ normalise_arch() {
   esac
 }
 
+# ---------------------------------------------------------------------------
+# OS normalisation (mirrors run case statement). Maps Git Bash / MSYS2 /
+# Cygwin uname strings to `windows` so the launcher resolves the same
+# binary asset as run.cmd. Emits "<os>:<ext>" so callers can also verify
+# the executable suffix that windows builds require.
+# ---------------------------------------------------------------------------
+normalise_os() {
+  local os="$1"
+  case "$os" in
+    mingw*|msys*|cygwin*) os="windows" ;;
+  esac
+  local ext=""
+  [ "$os" = "windows" ] && ext=".exe"
+  echo "${os}:${ext}"
+}
+
 echo "=== asset name tests ==="
 assert_eq "macOS arm64 asset" \
   "lumen-0.0.1-alpha.4-darwin-arm64" \
@@ -103,6 +119,28 @@ assert_eq "x86_64 → amd64"  "amd64" "$(normalise_arch "x86_64")"
 assert_eq "aarch64 → arm64" "arm64" "$(normalise_arch "aarch64")"
 assert_eq "arm64 passthrough" "arm64" "$(normalise_arch "arm64")"
 assert_eq "amd64 passthrough" "amd64" "$(normalise_arch "amd64")"
+
+echo ""
+echo "=== OS normalisation tests ==="
+# Git Bash / MSYS2 / Cygwin emit uname -s strings that begin with MINGW64_NT,
+# MINGW32_NT, MSYS_NT, or CYGWIN_NT. Before this normalisation the launcher
+# took those strings verbatim and constructed asset URLs like
+# `lumen-X.Y.Z-mingw64_nt-10.0-26200-amd64`, which 404 on GitHub releases
+# and skip the already-installed `bin/lumen-windows-amd64.exe`.
+assert_eq "MinGW64 Git Bash → windows + .exe" \
+  "windows:.exe" "$(normalise_os "mingw64_nt-10.0-26200")"
+assert_eq "MinGW32 Git Bash → windows + .exe" \
+  "windows:.exe" "$(normalise_os "mingw32_nt-10.0")"
+assert_eq "MSYS2 → windows + .exe" \
+  "windows:.exe" "$(normalise_os "msys_nt-10.0-26200")"
+assert_eq "Cygwin → windows + .exe" \
+  "windows:.exe" "$(normalise_os "cygwin_nt-10.0")"
+assert_eq "windows passthrough → windows + .exe" \
+  "windows:.exe" "$(normalise_os "windows")"
+assert_eq "linux passthrough → linux, no ext" \
+  "linux:" "$(normalise_os "linux")"
+assert_eq "darwin passthrough → darwin, no ext" \
+  "darwin:" "$(normalise_os "darwin")"
 
 echo ""
 echo "=== binary candidate priority tests ==="
@@ -168,9 +206,12 @@ echo "=== stdio download-on-first-run integration test ==="
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR"' EXIT
 
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$OS" in mingw*|msys*|cygwin*) OS="windows" ;; esac
+  EXT=""
+  [ "$OS" = "windows" ] && EXT=".exe"
   ARCH_RAW="$(uname -m)"
   case "$ARCH_RAW" in x86_64) ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARCH="$ARCH_RAW" ;; esac
-  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}"
+  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${OS}-${ARCH}${EXT}"
 
   printf '{\n  ".": "0.0.1"\n}\n' > "${_TMPROOT}/.release-please-manifest.json"
   mkdir -p "${_TMPROOT}/bin"
@@ -304,13 +345,16 @@ echo "=== stdio first-install MCP handshake test ==="
   trap 'rm -rf "$_TMPROOT" "$_FAKE_CURL_DIR" "$_MOCK_BIN_DIR"' EXIT
 
   _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$_OS" in mingw*|msys*|cygwin*) _OS="windows" ;; esac
+  _EXT=""
+  [ "$_OS" = "windows" ] && _EXT=".exe"
   _ARCH_RAW="$(uname -m)"
   case "$_ARCH_RAW" in
     x86_64)  _ARCH="amd64" ;;
     aarch64) _ARCH="arm64" ;;
     *)       _ARCH="$_ARCH_RAW" ;;
   esac
-  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${_OS}-${_ARCH}"
+  _EXPECTED_BINARY="${_TMPROOT}/bin/lumen-${_OS}-${_ARCH}${_EXT}"
 
   _MOCK_BIN="${_MOCK_BIN_DIR}/mock_lumen"
   if ! (cd "${_REPO_ROOT}" && CGO_ENABLED=0 go build -o "${_MOCK_BIN}" ./scripts/testdata/mock_mcp_server) >"${_TMPROOT}/mock_build.log" 2>&1; then

--- a/scripts/test_run.sh
+++ b/scripts/test_run.sh
@@ -144,6 +144,30 @@ assert_eq "darwin passthrough → darwin, no ext" \
 
 echo ""
 echo "=== binary candidate priority tests ==="
+# Windows dev-build case: `make build-local` runs `go build -o bin/lumen .`
+# which produces an extensionless `bin/lumen` even on Windows. The launcher
+# must still discover it ahead of falling back to the downloaded artefact.
+# We test the candidate ordering directly (no [ -x ] dependency, since Git
+# Bash refuses to mark extensionless touch-created files as executable —
+# the pre-existing two `[ -x ]`-based tests below fail on Git Bash for that
+# reason, unrelated to this fix).
+expected_candidates() {
+  local os="$1" arch="$2"
+  local ext=""
+  case "$os" in mingw*|msys*|cygwin*) os="windows" ;; esac
+  [ "$os" = "windows" ] && ext=".exe"
+  printf 'bin/lumen%s\nbin/lumen\nbin/lumen-%s-%s%s\n' "$ext" "$os" "$arch" "$ext"
+}
+assert_eq "windows candidates: .exe, extensionless dev, downloaded" \
+  "$(printf 'bin/lumen.exe\nbin/lumen\nbin/lumen-windows-amd64.exe\n')" \
+  "$(expected_candidates windows amd64)"
+assert_eq "mingw normalises, keeps extensionless dev build candidate" \
+  "$(printf 'bin/lumen.exe\nbin/lumen\nbin/lumen-windows-amd64.exe\n')" \
+  "$(expected_candidates mingw64_nt-10.0-26200 amd64)"
+assert_eq "linux candidates: extensionless dev, downloaded" \
+  "$(printf 'bin/lumen\nbin/lumen\nbin/lumen-linux-amd64\n')" \
+  "$(expected_candidates linux amd64)"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 


### PR DESCRIPTION
## Summary

- The POSIX launcher (`scripts/run`) used `uname -s` lower-cased verbatim as the
  OS slug. On Git Bash / MSYS2 / Cygwin that produces `mingw64_nt-10.0-26200`,
  not `windows` — so the launcher skipped the already-installed
  `bin/lumen-windows-amd64.exe` and tried to download a non-existent
  `lumen-X.Y.Z-mingw64_nt-...-amd64` asset from releases.
- Result: a `hook_non_blocking_error` on every Claude Code SessionStart whenever
  `shell:true` dispatched the hook through Git Bash instead of `cmd.exe`
  (`curl: (22) The requested URL returned error: 404`, ~2.7 s per session start).
- Normalise `mingw*|msys*|cygwin*` → `windows` + `.exe`, matching what
  `scripts/run.cmd`, `asset_name` in `test_run.sh`, and the goreleaser asset
  names on GitHub already assume. Preserve the extensionless `bin/lumen`
  dev-build path so `make build-local` still works on Windows.

## Root cause

`scripts/run` had three places that assumed `$OS` was already a valid GitHub
asset OS token:

```bash
"${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
ASSET="lumen-${VERSION#v}-${OS}-${ARCH}"
```

On Git Bash, `uname -s` returns `MINGW64_NT-10.0-26200`. Lower-casing leaves the
token unchanged for our purposes, so the launcher:

1. Looked for `bin/lumen` and `bin/lumen-mingw64_nt-10.0-26200-amd64` — neither
   matches the installed `bin/lumen-windows-amd64.exe`.
2. Constructed
   `https://github.com/ory/lumen/releases/download/v0.0.40/lumen-0.0.40-mingw64_nt-10.0-26200-amd64`
   — 404.
3. Hit the GitHub API fallback, resolved the same tag, retried the same
   filename — 404 again.
4. Exited with curl's `22`.

`scripts/run.cmd` is correct because it hard-codes `-windows-` and `.exe`. The
gap is only on the POSIX path that runs on Git Bash dispatch.

## Evidence (from a live Claude Code 2.1.140 session)

```json
{
  "type": "hook_non_blocking_error",
  "hookName": "SessionStart:startup",
  "stderr": "Failed with non-blocking status code: Downloading lumen v0.0.40 for mingw64_nt-10.0-26200/amd64...\ncurl: (22) The requested URL returned error: 404\n\nVersion v0.0.40 not found, resolving latest release...\nFalling back to v0.0.40...\ncurl: (22) The requested URL returned error: 404",
  "exitCode": 22,
  "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/run\" hook session-start lumen --host claude",
  "durationMs": 2773
}
```

After this fix the same session emits a normal `Lumen index ready: …` line.

## Changes

`scripts/run`
- Normalise `mingw*|msys*|cygwin*` → `OS=windows`; derive `EXT=.exe` when
  `$OS = windows`.
- Apply `${EXT}` consistently to the bin candidate list, the post-download
  `$BINARY`, and both `$ASSET` constructions (manifest and GitHub-API fallback).
- Keep the extensionless `bin/lumen` candidate so `make build-local` (which
  runs `go build -o bin/lumen .` — Go does not auto-append `.exe` when `-o` is
  explicit) is still discovered on Windows ahead of falling through to a
  download.

`scripts/test_run.sh`
- Add `normalise_os` helper + 7 table-driven cases covering mingw64/mingw32/
  msys/cygwin/windows passthrough/linux/darwin.
- Add 3 candidate-ordering cases (windows .exe, mingw normalised, linux) so a
  future change that drops the dev-build path is caught by tests.
- Align the two stdio integration tests' `_EXPECTED_BINARY` with the new
  normalisation (otherwise they pass on Linux but fail on Git Bash).

## Test plan

- [x] `bash scripts/test_run.sh` — **39 passed, 2 failed** vs. main's
      29/2. Both pre-existing failures are the candidate-priority `[ -x ]`
      checks on Git Bash (`touch` + `chmod +x` doesn't produce an exec bit
      for extensionless files on MSYS2), unrelated to this PR.
- [x] `golangci-lint run` — **0 issues**.
- [x] `go vet ./...` — same external-dependency warnings as main (CGO
      tree-sitter constraint messages, called out as OK in `CLAUDE.md`).
- [x] Verified Go behavior: `go build -o bin/lumen .` does **not** append
      `.exe` on Windows, confirming the dev-build regression risk the second
      commit guards against.
- [x] Manual: `bash scripts/run hook session-start lumen --host claude` →
      `exit 0`, valid `hookSpecificOutput` JSON.
- [x] End-to-end: ran a fresh Claude Code session against the patched plugin
      cache; the `hook_non_blocking_error` is gone and the SessionStart
      additional context (`Lumen index ready: …`) appears as designed.

## Notes / out of scope

- The original two-candidate list (`bin/lumen`, `bin/lumen-${OS}-${ARCH}`) was
  designed to let `make build-local` win over a downloaded artefact. This PR
  preserves that ordering on every platform by introducing `${EXT}` rather
  than rewriting it.
- Separately observed: the MCP `index_status` handler bypasses
  `merkle.IsRootUnindexable` and walks the user's home directory anyway,
  triggering Windows file-lock errors on `AppData\Local\Temp\*.scratch`. That
  is unrelated to launcher dispatch and will be filed/sent separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary resolution for Windows environments, including MinGW, MSYS, and Cygwin.
  * Enhanced binary search to check multiple candidate filenames.

* **Tests**
  * Expanded test coverage for cross-platform OS normalization and Windows executable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/lumen/pull/161)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->