### PR TITLE
fix(run): resolve bundled binary on Windows Git Bash / MSYS2 / Cygwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,14 @@ jobs:
     if: github.actor != 'release-please[bot]'
     services:
       ollama:
-        image: ollama/ollama:latest
+        # Pin the embedding runtime. The lang E2E suite (TestLang_*) asserts on
+        # committed embedding snapshots (testdata/snapshots/), so all-minilm must
+        # return identical vectors run-to-run. The `:latest` tag drifted from
+        # 0.24.0 to a newer build between 2026-05-20 and 2026-06-04, which shifted
+        # the ranked results and broke every snapshot. 0.24.0 is the last runtime
+        # the snapshots were verified green against (== digest
+        # sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4).
+        image: ollama/ollama:0.24.0
         ports:
           - 11434:11434
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
         # return identical vectors run-to-run. The `:latest` tag drifted from
         # 0.24.0 to a newer build between 2026-05-20 and 2026-06-04, which shifted
         # the ranked results and broke every snapshot. 0.24.0 is the last runtime
-        # the snapshots were verified green against (== digest
+        # the snapshots were verified green against (== the multi-arch index
+        # digest that `docker pull` resolves the 0.24.0 tag to:
         # sha256:a6149234667efc71d37766d61c1a16f24c33e4cd7a0bf4125c44a7e47e2419c4).
         image: ollama/ollama:0.24.0
         ports:

--- a/scripts/run
+++ b/scripts/run
@@ -14,11 +14,20 @@ case "$ARCH" in
   aarch64) ARCH="arm64" ;;
 esac
 
+# Normalize Windows-flavored uname. Git Bash/MSYS2/Cygwin report uname -s as
+# mingw*/msys*/cygwin* (and embed the Windows build number), not "windows", and
+# their binaries carry a .exe suffix. Without this the loop below misses the
+# bundled bin/lumen-windows-amd64.exe and falls through to a doomed download.
+EXT=""
+case "$OS" in
+  mingw*|msys*|cygwin*|windows*) OS="windows"; EXT=".exe" ;;
+esac
+
 # Find binary: check bin/ first, then goreleaser dist/ output, then download
 BINARY=""
 for candidate in \
-  "${PLUGIN_ROOT}/bin/lumen" \
-  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"; do
+  "${PLUGIN_ROOT}/bin/lumen${EXT}" \
+  "${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}${EXT}"; do
   if [ -x "$candidate" ]; then
     BINARY="$candidate"
     break
@@ -27,7 +36,7 @@ done
 
 # Download on first run if no binary found
 if [ -z "$BINARY" ]; then
-  BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}"
+  BINARY="${PLUGIN_ROOT}/bin/lumen-${OS}-${ARCH}${EXT}"
 
   REPO="ory/lumen"
 


### PR DESCRIPTION
## Problem

On Windows under Git Bash (and MSYS2 / Cygwin), `scripts/run` never finds the
bundled binary and tries to download a non-existent release asset. Because the
launcher is wired as a `PreToolUse` (`Grep|Bash`) hook, it exits non-zero on
**every tool call**, surfacing as a hook error in the agent.

Root cause is platform detection:

```bash
OS="$(uname -s | tr '[:upper:]' '[:lower:]')"   # Git Bash -> "mingw64_nt-10.0-26200"
```

`uname -s` under Git Bash is `MINGW64_NT-<windows-build>`, not `windows` — and
it even embeds the Windows build number (`10.0-26200`), so it isn't a stable
string. The candidate loop then probes `bin/lumen` and `bin/lumen-${OS}-${ARCH}`
with no `.exe`, never matching the shipped `bin/lumen-windows-amd64.exe`, and
falls through to:

```
Downloading lumen v0.0.41 for mingw64_nt-10.0-26200/amd64...
```

which 404s (`lumen-0.0.41-mingw64_nt-10.0-26200-amd64` is not a release asset).

## Fix

Normalize `mingw*|msys*|cygwin*` (and explicit `windows*`) to `windows`, and
append `.exe` to the binary candidates and the download fallback path. The new
`case` only triggers on those uname strings, so Linux/macOS resolution is
unchanged.

## Testing

Git Bash on Windows 11 (`uname -s` = `MINGW64_NT-10.0-26200`):

- `scripts/run version` -> prints `0.0.41`, no "Downloading..." line
- `echo '{}' | scripts/run hook pre-tool-use lumen` -> exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Windows-like environments (Git Bash, MSYS2, Cygwin) and ensured executables use the correct .exe extension for discovery, installation, and first-run downloads.

* **Chores**
  * Pinned CI runtime image to a verified version to keep end-to-end embedding snapshots deterministic and prevent drift between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->