### PR TITLE
fix(index): seed nested-worktree indexes from a sibling instead of rebuilding

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -251,6 +251,14 @@ func runIndexer(cmd *cobra.Command, cfg *config.ConfigService, emb *embedder.Fai
 	}
 	defer lock.Release()
 
+	// Reuse a sibling worktree's index for a brand-new database instead of
+	// re-embedding from scratch. Done under the lock just acquired so it is
+	// serialized against any concurrent indexer or MCP-side seed for the same
+	// project. Without this, the SessionStart-spawned `lumen index` always
+	// created an empty DB and rebuilt the whole tree, defeating the donor
+	// seeding that previously only ran in the MCP search handler.
+	seedFromDonorIfNew(dbPath, projectPath, emb.ModelName(), logger)
+
 	// Cancel context on SIGTERM or SIGINT so the indexer stops cleanly and
 	// the deferred lock.Release() runs before exit.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/ory/lumen/internal/config"
+	"github.com/ory/lumen/internal/index"
+)
+
+// findDonorFn and seedFromDonorFn are indirections so tests can exercise
+// seedFromDonorIfNew without real git worktrees or a real donor database.
+var (
+	findDonorFn     = config.FindDonorIndex
+	seedFromDonorFn = index.SeedFromDonor
+)
+
+// seedFromDonorIfNew seeds dbPath from a sibling worktree's index when dbPath
+// does not yet exist, so a fresh git worktree reuses an already-indexed
+// worktree's embeddings instead of re-embedding every file from scratch.
+//
+// The caller must hold the index lock for dbPath: this serializes seeding
+// against other indexers for the same project. Seeding is best-effort — any
+// failure is logged and indexing continues with a from-scratch build — so this
+// never returns an error. When dbPath already exists it is a single stat on the
+// hot path and returns immediately.
+func seedFromDonorIfNew(dbPath, projectPath, model string, logger *slog.Logger) {
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		// Exists already, or stat failed for some other reason — nothing to do.
+		return
+	}
+
+	donorPath := findDonorFn(projectPath, model)
+	if donorPath == "" {
+		return
+	}
+
+	logger.Info("seeding index from donor worktree",
+		"project", projectPath,
+		"donor_path", donorPath,
+	)
+	if _, err := seedFromDonorFn(donorPath, dbPath); err != nil {
+		logger.Warn("seed from donor worktree failed",
+			"project", projectPath,
+			"donor_path", donorPath,
+			"err", err,
+		)
+	}
+}

--- a/cmd/seed_test.go
+++ b/cmd/seed_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Aeneas Rekkas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// withSeedStubs swaps the donor-discovery and seed indirections for the
+// duration of a test and restores them afterward.
+func withSeedStubs(t *testing.T, find func(string, string) string, seed func(string, string) (bool, error)) {
+	t.Helper()
+	origFind, origSeed := findDonorFn, seedFromDonorFn
+	findDonorFn, seedFromDonorFn = find, seed
+	t.Cleanup(func() { findDonorFn, seedFromDonorFn = origFind, origSeed })
+}
+
+func TestSeedFromDonorIfNew_SkipsWhenDBExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+	if err := os.WriteFile(dbPath, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findCalled := false
+	withSeedStubs(t,
+		func(string, string) string { findCalled = true; return "/donor.db" },
+		func(string, string) (bool, error) { t.Fatal("seed must not run when DB exists"); return false, nil },
+	)
+
+	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
+	if findCalled {
+		t.Fatal("donor discovery must not run when the DB already exists")
+	}
+}
+
+func TestSeedFromDonorIfNew_SeedsWhenMissing(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db") // does not exist
+
+	var gotDonor, gotDst string
+	withSeedStubs(t,
+		func(project, model string) string { return "/donor.db" },
+		func(donor, dst string) (bool, error) { gotDonor, gotDst = donor, dst; return true, nil },
+	)
+
+	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
+	if gotDonor != "/donor.db" || gotDst != dbPath {
+		t.Fatalf("seed called with (%q, %q), want (%q, %q)", gotDonor, gotDst, "/donor.db", dbPath)
+	}
+}
+
+func TestSeedFromDonorIfNew_NoDonorFound(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+
+	withSeedStubs(t,
+		func(string, string) string { return "" },
+		func(string, string) (bool, error) { t.Fatal("seed must not run without a donor"); return false, nil },
+	)
+
+	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
+}
+
+func TestSeedFromDonorIfNew_SeedErrorIsSwallowed(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "index.db")
+
+	withSeedStubs(t,
+		func(string, string) string { return "/donor.db" },
+		func(string, string) (bool, error) { return false, errors.New("copy failed") },
+	)
+
+	// Best-effort: a seed failure must not panic or propagate.
+	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
+}

--- a/cmd/seed_test.go
+++ b/cmd/seed_test.go
@@ -36,58 +36,78 @@ func withSeedStubs(t *testing.T, find func(string, string) string, seed func(str
 	t.Cleanup(func() { findDonorFn, seedFromDonorFn = origFind, origSeed })
 }
 
-func TestSeedFromDonorIfNew_SkipsWhenDBExists(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "index.db")
-	if err := os.WriteFile(dbPath, []byte("existing"), 0o644); err != nil {
-		t.Fatal(err)
+func TestSeedFromDonorIfNew(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupDB  bool  // pre-create the destination DB
+		donor    string
+		seedErr  error // error returned by the seed stub
+		wantFind bool  // donor discovery should run
+		wantSeed bool  // seed should run
+	}{
+		{
+			name:     "skips when DB already exists",
+			setupDB:  true,
+			donor:    "/donor.db",
+			wantFind: false,
+			wantSeed: false,
+		},
+		{
+			name:     "seeds when DB missing and donor found",
+			donor:    "/donor.db",
+			wantFind: true,
+			wantSeed: true,
+		},
+		{
+			name:     "no seed when no donor found",
+			donor:    "",
+			wantFind: true,
+			wantSeed: false,
+		},
+		{
+			name:     "seed error is swallowed",
+			donor:    "/donor.db",
+			seedErr:  errors.New("copy failed"),
+			wantFind: true,
+			wantSeed: true,
+		},
 	}
 
-	findCalled := false
-	withSeedStubs(t,
-		func(string, string) string { findCalled = true; return "/donor.db" },
-		func(string, string) (bool, error) { t.Fatal("seed must not run when DB exists"); return false, nil },
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "index.db")
+			if tt.setupDB {
+				if err := os.WriteFile(dbPath, []byte("existing"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
-	if findCalled {
-		t.Fatal("donor discovery must not run when the DB already exists")
+			var findCalled, seedCalled bool
+			var gotDonor, gotDst string
+			withSeedStubs(t,
+				func(_, _ string) string {
+					findCalled = true
+					return tt.donor
+				},
+				func(donor, dst string) (bool, error) {
+					seedCalled = true
+					gotDonor, gotDst = donor, dst
+					return tt.seedErr == nil, tt.seedErr
+				},
+			)
+
+			// Best-effort helper: must never panic or propagate an error.
+			seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
+
+			if findCalled != tt.wantFind {
+				t.Errorf("donor discovery called = %v, want %v", findCalled, tt.wantFind)
+			}
+			if seedCalled != tt.wantSeed {
+				t.Errorf("seed called = %v, want %v", seedCalled, tt.wantSeed)
+			}
+			if tt.wantSeed && (gotDonor != tt.donor || gotDst != dbPath) {
+				t.Errorf("seed called with (%q, %q), want (%q, %q)", gotDonor, gotDst, tt.donor, dbPath)
+			}
+		})
 	}
-}
-
-func TestSeedFromDonorIfNew_SeedsWhenMissing(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "index.db") // does not exist
-
-	var gotDonor, gotDst string
-	withSeedStubs(t,
-		func(project, model string) string { return "/donor.db" },
-		func(donor, dst string) (bool, error) { gotDonor, gotDst = donor, dst; return true, nil },
-	)
-
-	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
-	if gotDonor != "/donor.db" || gotDst != dbPath {
-		t.Fatalf("seed called with (%q, %q), want (%q, %q)", gotDonor, gotDst, "/donor.db", dbPath)
-	}
-}
-
-func TestSeedFromDonorIfNew_NoDonorFound(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "index.db")
-
-	withSeedStubs(t,
-		func(string, string) string { return "" },
-		func(string, string) (bool, error) { t.Fatal("seed must not run without a donor"); return false, nil },
-	)
-
-	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
-}
-
-func TestSeedFromDonorIfNew_SeedErrorIsSwallowed(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "index.db")
-
-	withSeedStubs(t,
-		func(string, string) string { return "/donor.db" },
-		func(string, string) (bool, error) { return false, errors.New("copy failed") },
-	)
-
-	// Best-effort: a seed failure must not panic or propagate.
-	seedFromDonorIfNew(dbPath, "/project", "model", discardLogger())
 }

--- a/internal/config/seed.go
+++ b/internal/config/seed.go
@@ -47,6 +47,18 @@ func FindDonorIndexBase(dataDir, projectPath, model string) string {
 	// Find which worktree contains projectPath and compute the relative suffix.
 	// This handles subdirectory effective roots (e.g., hydra-flake/backoffice)
 	// by searching for the same subdirectory in sibling worktrees.
+	//
+	// Pick the DEEPEST (most specific) containing worktree, not the first match.
+	// `git worktree list` yields the main worktree first, so a first-match scan
+	// selects the main checkout for a worktree nested inside it — e.g. Claude
+	// Code's default repo/.claude/worktrees/<name> layout. That mis-identifies
+	// the current worktree, so relSuffix becomes ".claude/worktrees/<name>", the
+	// donor search then looks for indexes at nonexistent
+	// <sibling>/.claude/worktrees/<name> paths, and the one real donor (the
+	// parent repo's index) is skipped as "self" — leaving every nested worktree
+	// to re-embed from scratch. Every containing worktree is an ancestor of
+	// resolvedProject, so they form a prefix chain and the longest path is
+	// unambiguously the most specific.
 	var myWorktree string
 	for _, wt := range worktrees {
 		resolved := wt
@@ -57,8 +69,9 @@ func FindDonorIndexBase(dataDir, projectPath, model string) string {
 		if err != nil || strings.HasPrefix(rel, "..") {
 			continue
 		}
-		myWorktree = resolved
-		break
+		if len(resolved) > len(myWorktree) {
+			myWorktree = resolved
+		}
 	}
 	if myWorktree == "" {
 		return ""

--- a/internal/config/seed_test.go
+++ b/internal/config/seed_test.go
@@ -65,6 +65,44 @@ func TestFindDonorIndex_WithSibling(t *testing.T) {
 	}
 }
 
+func TestFindDonorIndex_NestedWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// Reproduce Claude Code's layout: a worktree nested INSIDE the main repo at
+	// <main>/.claude/worktrees/<name>. `git worktree list` reports the main
+	// checkout first, so donor discovery must not mistake the main checkout for
+	// the current (nested) worktree.
+	main := t.TempDir()
+	gitRun(t, main, "git", "init")
+	gitRun(t, main, "git", "commit", "--allow-empty", "-m", "init")
+
+	nested := filepath.Join(main, ".claude", "worktrees", "feature")
+	gitRun(t, main, "git", "worktree", "add", nested)
+
+	mainResolved, err := filepath.EvalSymlinks(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The parent repo's index is the only real donor.
+	dataDir := t.TempDir()
+	donorDB := DBPathForProjectBase(dataDir, mainResolved, "test-model")
+	if err := os.MkdirAll(filepath.Dir(donorDB), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(donorDB, []byte("fake-db"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// From the nested worktree we must find the parent repo's index, not "".
+	result := FindDonorIndexBase(dataDir, nested, "test-model")
+	if result != donorDB {
+		t.Fatalf("expected nested worktree to seed from parent index %q, got %q", donorDB, result)
+	}
+}
+
 func TestFindDonorIndex_WrongModel(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")

--- a/internal/index/seed.go
+++ b/internal/index/seed.go
@@ -16,6 +16,7 @@ package index
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,14 @@ import (
 
 // SeedFromDonor copies the donor SQLite database to dstPath if dstPath does
 // not already exist. It checkpoints the WAL first to ensure a self-contained
-// copy, then performs an atomic copy (write to temp file + rename).
+// copy, then atomically publishes the copy via a create-if-absent hard link.
+//
+// Seeding is safe to run concurrently from multiple processes (e.g. the
+// SessionStart background indexer and the first MCP search racing to warm the
+// same fresh worktree): the copy goes to a per-process temp file and dstPath is
+// created with os.Link, which fails if it already exists. The loser of the race
+// therefore no-ops instead of renaming its copy over a database the winner has
+// already opened and begun writing to.
 //
 // Returns (true, nil) if seeded successfully, (false, nil) if dstPath already
 // exists, or (false, error) on failure.
@@ -58,16 +66,31 @@ func SeedFromDonor(donorPath, dstPath string) (bool, error) {
 		return false, fmt.Errorf("create dst directory: %w", err)
 	}
 
-	// Atomic copy: write to temp file then rename.
-	tmp := dstPath + ".seed-tmp"
+	// Copy to a uniquely-named temp file in the destination directory, then
+	// publish it via a create-if-absent hard link. os.CreateTemp guarantees a
+	// unique name even among concurrent callers in the same process, and os.Link
+	// fails with os.ErrExist when dstPath already exists. Together these give
+	// safe concurrent seeding: whoever links first wins, the rest no-op, and no
+	// one ever renames a fresh copy over a database another seeder has already
+	// published and opened for writing.
+	tmpFile, err := os.CreateTemp(filepath.Dir(dstPath), filepath.Base(dstPath)+".seed-*")
+	if err != nil {
+		return false, fmt.Errorf("create seed temp: %w", err)
+	}
+	tmp := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmp) }()
+
 	if err := copyFile(donorPath, tmp); err != nil {
-		_ = os.Remove(tmp)
 		return false, fmt.Errorf("copy donor: %w", err)
 	}
 
-	if err := os.Rename(tmp, dstPath); err != nil {
-		_ = os.Remove(tmp)
-		return false, fmt.Errorf("rename seed: %w", err)
+	if err := os.Link(tmp, dstPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			// Another seeder created dstPath first; its copy is authoritative.
+			return false, nil
+		}
+		return false, fmt.Errorf("link seed: %w", err)
 	}
 
 	return true, nil

--- a/internal/index/seed.go
+++ b/internal/index/seed.go
@@ -66,6 +66,12 @@ func SeedFromDonor(donorPath, dstPath string) (bool, error) {
 		return false, fmt.Errorf("create dst directory: %w", err)
 	}
 
+	in, err := os.Open(donorPath)
+	if err != nil {
+		return false, fmt.Errorf("open donor: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
 	// Copy to a uniquely-named temp file in the destination directory, then
 	// publish it via a create-if-absent hard link. os.CreateTemp guarantees a
 	// unique name even among concurrent callers in the same process, and os.Link
@@ -78,11 +84,19 @@ func SeedFromDonor(donorPath, dstPath string) (bool, error) {
 		return false, fmt.Errorf("create seed temp: %w", err)
 	}
 	tmp := tmpFile.Name()
-	_ = tmpFile.Close()
-	defer func() { _ = os.Remove(tmp) }()
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+	}()
 
-	if err := copyFile(donorPath, tmp); err != nil {
+	// Write into the open descriptor directly rather than closing and
+	// re-opening by name (avoids a Windows sharing violation), and verify the
+	// Close error before publishing so a short write can't be linked into place.
+	if _, err := io.Copy(tmpFile, in); err != nil {
 		return false, fmt.Errorf("copy donor: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return false, fmt.Errorf("close seed temp: %w", err)
 	}
 
 	if err := os.Link(tmp, dstPath); err != nil {
@@ -94,23 +108,4 @@ func SeedFromDonor(donorPath, dstPath string) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = out.Close() }()
-
-	if _, err := io.Copy(out, in); err != nil {
-		return err
-	}
-	return out.Close()
 }

--- a/internal/index/seed_test.go
+++ b/internal/index/seed_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -91,6 +92,86 @@ func TestSeedFromDonor_DstExists(t *testing.T) {
 	content, _ := os.ReadFile(dstPath)
 	if string(content) != "existing" {
 		t.Fatalf("expected dst unchanged, got %q", content)
+	}
+}
+
+func TestSeedFromDonor_ConcurrentSeedersExactlyOneWins(t *testing.T) {
+	// Build a real, complete donor DB.
+	projectDir := t.TempDir()
+	writeGoFile(t, projectDir, "main.go", `package main
+
+func Hello() {}
+`)
+
+	donorPath := filepath.Join(t.TempDir(), "donor.db")
+	emb := &mockEmbedder{dims: 4, model: "test-model"}
+	idx, err := NewIndexer(donorPath, emb, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Index(context.Background(), projectDir, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Many goroutines race to seed the same destination.
+	dstPath := filepath.Join(t.TempDir(), "sub", "seeded.db")
+	const n = 8
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		wins     int
+		firstErr error
+	)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			seeded, err := SeedFromDonor(donorPath, dstPath)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+			if seeded {
+				wins++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		t.Fatalf("concurrent SeedFromDonor returned error: %v", firstErr)
+	}
+	if wins != 1 {
+		t.Fatalf("expected exactly one seeder to win, got %d", wins)
+	}
+
+	// No stray per-process temp files should be left behind.
+	entries, err := os.ReadDir(filepath.Dir(dstPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".db" {
+			t.Fatalf("unexpected leftover file after concurrent seeding: %q", e.Name())
+		}
+	}
+
+	// The published DB must be usable.
+	idx2, err := NewIndexer(dstPath, emb, 0)
+	if err != nil {
+		t.Fatalf("seeded DB is not openable: %v", err)
+	}
+	defer func() { _ = idx2.Close() }()
+	status, err := idx2.Status(projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.IndexedFiles == 0 {
+		t.Fatal("expected seeded DB to have indexed files")
 	}
 }
 


### PR DESCRIPTION
## Problem

Working in a fresh git worktree of an already-indexed repo re-embedded every file from scratch (minutes on a local embedder) instead of reusing a sibling worktree's embeddings. Two independent bugs defeated the existing donor-seeding path, and both bite Claude Code's default `repo/.claude/worktrees/<name>` layout, where worktrees are nested *inside* the repo.

## Fixes

**Bug 1 — donor discovery picked the wrong worktree** (`internal/config/seed.go`)

`FindDonorIndexBase` selected the *first* `git worktree list` entry containing the project. git lists the main checkout first, so for a worktree nested inside the repo it identified the main checkout as "self", searched for donors at nonexistent `<sibling>/.claude/worktrees/<name>` paths, and skipped the one real donor — the parent repo's index. Fix: pick the *deepest* (most specific) containing worktree. That's the longest matching path, since every match is an ancestor of the project and they form a prefix chain.

**Bug 2 — the CLI indexer never seeded** (`cmd/index.go`, new `cmd/seed.go`)

Seeding only ran in the MCP search handler, but the SessionStart hook spawns `lumen index`, which created the DB first; `SeedFromDonor` then no-ops because the DB already exists, so the hook permanently won the race and forced a full rebuild. Fix: seed from a donor in `runIndexer`, under the index lock, before the DB is created.

**Hardening — safe concurrent seeding** (`internal/index/seed.go`)

Because both the CLI indexer and the MCP handler can now seed the same fresh worktree concurrently, `SeedFromDonor` copies to a unique temp file (`os.CreateTemp`) and publishes it via a create-if-absent hard link (`os.Link` fails with `EEXIST`). The loser of the race no-ops instead of renaming a fresh copy over a database the winner has already opened for writing.

## Tests

Adds unit tests for the nested-worktree layout, concurrent seeding, and the `runIndexer` seed helper. `go test` and `go vet` pass for the `config`, `index`, and `cmd` packages.

## Relationship to #170

#170 also makes the CLI indexer seed under the lock (Bug 2), by adding lock coordination to `getOrCreate` in the MCP handler. This PR addresses Bug 2 with a different approach — hardening `SeedFromDonor` for concurrent callers rather than refactoring the handler's locking — and additionally fixes donor discovery for nested worktrees (Bug 1), which #170 does not touch. Happy to rebase, split, or defer to #170 for the overlapping part if that's easier to land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Indexes can now be seeded from an existing sibling worktree to reduce full rebuilds.
  - Seeding is best-effort: if prerequisites aren’t met or seeding fails, indexing continues with a full rebuild.
  - Nested worktrees now choose the most specific applicable donor index.
  - Concurrent seeding is handled safely so only one creator effectively wins without overwriting.

- **Bug Fixes**
  - Fixed donor selection for nested worktree scenarios.
  - Improved reliability when multiple indexing operations run at the same time.

- **Tests**
  - Added coverage for donor seeding logic, nested worktree selection, and concurrent seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
